### PR TITLE
Automated NPM Publishing via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,197 @@
+name: Release and Publish Blend Design System
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+        types: [closed]
+
+jobs:
+    release:
+        if: |
+            (github.event_name == 'push') ||
+            (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: write
+            packages: write
+            pull-requests: write
+            id-token: write
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Get pnpm store directory
+              shell: bash
+              run: |
+                  echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+            - name: Setup pnpm cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ env.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Run linting and build
+              run: |
+                  pnpm --filter @juspay/blend-design-system lint
+                  pnpm --filter @juspay/blend-design-system build
+
+            - name: Determine version bump type
+              id: version-type
+              run: |
+                  # Get the latest commit message
+                  COMMIT_MSG=$(git log -1 --pretty=format:"%s")
+                  echo "Latest commit: $COMMIT_MSG"
+
+                  # Determine version bump based on commit message
+                  if echo "$COMMIT_MSG" | grep -iE "^feat(\(.+\))?!?:" > /dev/null; then
+                    if echo "$COMMIT_MSG" | grep -E "!" > /dev/null; then
+                      echo "version_type=major" >> $GITHUB_OUTPUT
+                      echo "Version bump: MAJOR (breaking change)"
+                    else
+                      echo "version_type=minor" >> $GITHUB_OUTPUT
+                      echo "Version bump: MINOR (new feature)"
+                    fi
+                  elif echo "$COMMIT_MSG" | grep -iE "^fix(\(.+\))?:" > /dev/null; then
+                    echo "version_type=patch" >> $GITHUB_OUTPUT
+                    echo "Version bump: PATCH (bug fix)"
+                  elif echo "$COMMIT_MSG" | grep -iE "^(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?:" > /dev/null; then
+                    echo "version_type=patch" >> $GITHUB_OUTPUT
+                    echo "Version bump: PATCH (maintenance)"
+                  else
+                    echo "version_type=patch" >> $GITHUB_OUTPUT
+                    echo "Version bump: PATCH (default)"
+                  fi
+
+            - name: Configure Git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Bump version
+              id: version-bump
+              working-directory: packages/blend
+              run: |
+                  # Get current version
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+                  echo "Current version: $CURRENT_VERSION"
+
+                  # Bump version based on type
+                  if [ "${{ steps.version-type.outputs.version_type }}" = "major" ]; then
+                    NEW_VERSION=$(pnpm version major --no-git-tag-version)
+                  elif [ "${{ steps.version-type.outputs.version_type }}" = "minor" ]; then
+                    NEW_VERSION=$(pnpm version minor --no-git-tag-version)
+                  else
+                    NEW_VERSION=$(pnpm version patch --no-git-tag-version)
+                  fi
+
+                  # Clean up version string (remove 'v' prefix if present)
+                  NEW_VERSION=$(echo $NEW_VERSION | sed 's/^v//')
+                  echo "New version: $NEW_VERSION"
+                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Create git tag
+              run: |
+                  TAG_NAME="v${{ steps.version-bump.outputs.new_version }}"
+
+                  # Delete tag if it exists locally
+                  if git tag -l | grep -q "^${TAG_NAME}$"; then
+                    git tag -d "$TAG_NAME"
+                  fi
+
+                  # Delete tag if it exists remotely
+                  if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
+                    git push origin ":refs/tags/$TAG_NAME"
+                  fi
+
+                  # Create new tag
+                  git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+
+            - name: Stage and commit changes
+              run: |
+                  # Check if there are any changes to commit
+                  if [ -n "$(git status --porcelain)" ]; then
+                    git add packages/blend/package.json
+                    git commit -m "chore(release): v${{ steps.version-bump.outputs.new_version }}"
+                  else
+                    echo "No changes to commit"
+                  fi
+
+            - name: Push changes and tags
+              run: |
+                  # Push changes first
+                  git push origin main
+
+                  # Then push the tag
+                  git push origin "v${{ steps.version-bump.outputs.new_version }}"
+
+                  echo "Successfully pushed version v${{ steps.version-bump.outputs.new_version }}"
+
+            - name: Publish to NPM
+              working-directory: packages/blend
+              run: |
+                  # Check if this version already exists on NPM
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  NEW_VERSION="${{ steps.version-bump.outputs.new_version }}"
+
+                  if npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null; then
+                    echo "Version $NEW_VERSION already exists on NPM, skipping publish"
+                    exit 0
+                  fi
+
+                  # Publish to NPM with provenance
+                  pnpm publish --provenance --access public --no-git-checks
+                  echo "Successfully published $PACKAGE_NAME@$NEW_VERSION to NPM"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: v${{ steps.version-bump.outputs.new_version }}
+                  name: Release v${{ steps.version-bump.outputs.new_version }}
+                  body: |
+                      ## What's Changed in Blend Design System
+
+                      This release includes updates to the `@juspay/blend-design-system` package.
+
+                      ### Latest Changes
+                      - ${{ github.event.head_commit.message }}
+
+                      **Full Changelog**: https://github.com/juspay/blend-design-system/compare/v${{ steps.version-bump.outputs.previous_version }}...v${{ steps.version-bump.outputs.new_version }}
+
+                      ## Installation
+                      ```bash
+                      npm install @juspay/blend-design-system@${{ steps.version-bump.outputs.new_version }}
+                      ```
+
+                      ## Documentation
+                      Visit [juspay.design](https://juspay.design/) for complete documentation.
+                  draft: false
+                  prerelease: false
+                  files: |
+                      packages/blend/dist/**/*
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/storybook/.storybook/main.mjs
+++ b/apps/storybook/.storybook/main.mjs
@@ -1,7 +1,11 @@
-import type { StorybookConfig } from '@storybook/react-vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
-const config: StorybookConfig = {
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/** @type {import('@storybook/react-vite').StorybookConfig} */
+const config = {
     stories: [
         '../stories/**/*.stories.@(js|jsx|ts|tsx|mdx)',
         '../stories/**/*.mdx',
@@ -23,7 +27,7 @@ const config: StorybookConfig = {
         reactDocgen: 'react-docgen-typescript',
         reactDocgenTypescriptOptions: {
             shouldExtractLiteralValuesFromEnum: true,
-            propFilter: (prop: any) =>
+            propFilter: (prop) =>
                 prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
         },
     },

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
-const path = require('path')
+import path from 'path'
 
 const config: StorybookConfig = {
     stories: [

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,9 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
-import * as path from 'path'
-import { fileURLToPath } from 'url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const path = require('path')
 
 const config: StorybookConfig = {
     stories: [

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -2,6 +2,7 @@
     "name": "storybook",
     "private": true,
     "version": "0.1.0",
+    "type": "module",
     "scripts": {
         "dev": "storybook dev -p 6006",
         "build-storybook": "storybook build",

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -4,6 +4,7 @@
         "baseUrl": ".",
         "module": "ESNext",
         "moduleResolution": "bundler",
+        "target": "ES2022",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "paths": {

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -2,6 +2,10 @@
     "extends": "../../packages/typescript-config/react-app.json",
     "compilerOptions": {
         "baseUrl": ".",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "paths": {
             "@juspay/blend-design-system": ["../../packages/blend/lib/main.ts"],
             "@juspay/blend-design-system/*": ["../../packages/blend/lib/*"]


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow to automatically publish the `blend-design-system` npm package when changes are merged into the `main` branch and a new version tag (`v*.*.*`) is created.


## Affected Scope

<!-- Check all that apply -->

- [x] Design System Component (`@blend/*`)
- [ ] Documentation (`apps/docs`)
- [ ] Tests or Configuration
- [ ] Tools / Scripts
- [ ] Backend / API
- [ ] Refactor / Cleanup
