### PR TITLE
Feat: add new workflows for beta and stable releases

### DIFF
--- a/.github/workflows/create-beta-release.yml
+++ b/.github/workflows/create-beta-release.yml
@@ -1,0 +1,176 @@
+name: Create Beta Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version_type:
+                description: 'Version bump type'
+                required: true
+                default: 'patch'
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+
+concurrency:
+    group: create-beta-release-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    create-beta-release:
+        name: Create Beta Release (No Publish)
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/dev'
+        outputs:
+            version: ${{ steps.bump_version.outputs.new_version }}
+            tag: ${{ steps.bump_version.outputs.tag }}
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js 22 and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Get Current Version and Bump
+              id: bump_version
+              run: |
+                  cd packages/blend
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+                  VERSION_TYPE="${{ inputs.version_type }}"
+
+                  echo "Current version: $CURRENT_VERSION"
+                  echo "Version type: $VERSION_TYPE"
+
+                  # Remove any existing beta suffix to get base version
+                  BASE_VERSION="${CURRENT_VERSION%-beta}"
+
+                  # Create a temporary package.json to bump the base version
+                  echo "{\"version\": \"$BASE_VERSION\"}" > temp_package.json
+                  NEW_BASE_VERSION=$(npm version "$VERSION_TYPE" --no-git-tag-version --package temp_package.json | sed 's/^v//')
+                  rm temp_package.json
+
+                  # Create beta version
+                  NEW_VERSION="${NEW_BASE_VERSION}-beta"
+
+                  # Update package.json with new beta version
+                  npm pkg set version="$NEW_VERSION"
+
+                  echo "New beta version: $NEW_VERSION"
+                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Clean Existing Tags
+              run: |
+                  VERSION=${{ steps.bump_version.outputs.new_version }}
+                  TAG="v$VERSION"
+
+                  # Clean up any existing local tags
+                  git tag -l | xargs -r git tag -d
+                  git fetch --tags
+
+                  # Check if tag exists on remote and delete it
+                  if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
+                    echo "Tag $TAG already exists on remote, deleting it"
+                    git push origin ":refs/tags/$TAG" || echo "Failed to delete remote tag, continuing..."
+                  fi
+
+            - name: Generate Changelog
+              run: |
+                  VERSION=${{ steps.bump_version.outputs.new_version }}
+                  LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+                  # Create docs directory if it doesn't exist
+                  mkdir -p docs
+
+                  echo "# Changelog for v$VERSION (Beta)" > docs/CHANGELOG.md
+                  echo "" >> docs/CHANGELOG.md
+                  echo "This is a beta release. Changes since last tag:" >> docs/CHANGELOG.md
+                  echo "" >> docs/CHANGELOG.md
+                  if [[ -n "$LAST_TAG" ]]; then
+                    git log $LAST_TAG..HEAD --pretty=format:"- %s (%h)" >> docs/CHANGELOG.md
+                  else
+                    git log -n 20 --pretty=format:"- %s (%h)" >> docs/CHANGELOG.md
+                  fi
+
+            - name: Format Generated Files
+              run: |
+                  pnpm format
+
+            - name: Build Package
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Create Release Tag
+              run: |
+                  VERSION=${{ steps.bump_version.outputs.new_version }}
+                  TAG="v$VERSION"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Create and push the tag
+                  git tag "$TAG" -m "Beta Release $TAG"
+                  git push origin "$TAG"
+                  echo "Successfully created and pushed tag $TAG"
+
+            - name: Create GitHub Beta Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ steps.bump_version.outputs.tag }}
+                  name: Beta Release ${{ steps.bump_version.outputs.tag }}
+                  body_path: docs/CHANGELOG.md
+                  draft: false
+                  prerelease: true
+
+            - name: Create Version Update PR to Dev
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: release/update-beta-version-${{ steps.bump_version.outputs.new_version }}
+                  title: 'chore(release): ${{ steps.bump_version.outputs.tag }} [BETA]'
+                  body: |
+                      Beta Release ${{ steps.bump_version.outputs.tag }}
+
+                      - Bump version to ${{ steps.bump_version.outputs.new_version }}
+                      - Update changelog
+                      - **This is a BETA release - ready for NPM publishing**
+
+                      This PR was automatically created by the beta release workflow.
+
+                      **Next Steps:**
+                      1. Review and merge this PR
+                      2. Trigger "Publish Beta to NPM" workflow to publish to npm with beta tag
+                      3. After testing, create PR from dev → main for stable release
+
+                      **Changes included:**
+                      - Updated package.json version to beta
+                      - Generated changelog
+                      - Created GitHub release with prerelease flag
+                  labels: |
+                      automated
+                      release
+                      beta
+                  assignees: ${{ github.actor }}
+                  commit-message: |
+                      chore(release): ${{ steps.bump_version.outputs.tag }} [BETA]
+
+                      - Bump version to ${{ steps.bump_version.outputs.new_version }}
+                      - Update changelog
+                      - Create beta release
+
+                      [skip ci]
+                  add-paths: |
+                      packages/blend/package.json
+                      docs/CHANGELOG.md
+                      .

--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -1,0 +1,242 @@
+name: Create Stable Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm_stable:
+                description: 'Type "STABLE" to confirm creating stable release'
+                required: true
+                type: string
+
+concurrency:
+    group: create-stable-release-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    create-stable-release:
+        name: Create Stable Release (No Publish)
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/main' && github.event.inputs.confirm_stable == 'STABLE'
+        outputs:
+            version: ${{ steps.convert_version.outputs.stable_version }}
+            tag: ${{ steps.convert_version.outputs.tag }}
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js 22 and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Convert Beta to Stable Version
+              id: convert_version
+              run: |
+                  cd packages/blend
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+                  echo "Current version: $CURRENT_VERSION"
+
+                  if [[ "$CURRENT_VERSION" == *"-beta" ]]; then
+                    # Remove -beta suffix to get stable version
+                    STABLE_VERSION="${CURRENT_VERSION%-beta}"
+                    echo "Converting beta to stable: $CURRENT_VERSION → $STABLE_VERSION"
+                  else
+                    # Already stable, keep as is
+                    STABLE_VERSION="$CURRENT_VERSION"
+                    echo "Already stable version: $STABLE_VERSION"
+                  fi
+
+                  # Update package.json with stable version
+                  npm pkg set version="$STABLE_VERSION"
+
+                  echo "stable_version=$STABLE_VERSION" >> $GITHUB_OUTPUT
+                  echo "tag=v$STABLE_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Clean Existing Tags
+              run: |
+                  VERSION=${{ steps.convert_version.outputs.stable_version }}
+                  TAG="v$VERSION"
+
+                  # Clean up any existing local tags
+                  git tag -l | xargs -r git tag -d
+                  git fetch --tags
+
+                  # Check if tag exists on remote and delete it
+                  if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
+                    echo "Tag $TAG already exists on remote, deleting it"
+                    git push origin ":refs/tags/$TAG" || echo "Failed to delete remote tag, continuing..."
+                  fi
+
+            - name: Generate Stable Changelog
+              run: |
+                  VERSION=${{ steps.convert_version.outputs.stable_version }}
+                  LAST_STABLE_TAG=$(git tag -l | grep -v beta | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || echo "")
+
+                  # Create docs directory if it doesn't exist
+                  mkdir -p docs
+
+                  echo "# Changelog for v$VERSION (Stable)" > docs/CHANGELOG.md
+                  echo "" >> docs/CHANGELOG.md
+                  echo "This is a stable release. Changes since last stable release:" >> docs/CHANGELOG.md
+                  echo "" >> docs/CHANGELOG.md
+                  if [[ -n "$LAST_STABLE_TAG" ]]; then
+                    git log $LAST_STABLE_TAG..HEAD --pretty=format:"- %s (%h)" >> docs/CHANGELOG.md
+                  else
+                    git log -n 20 --pretty=format:"- %s (%h)" >> docs/CHANGELOG.md
+                  fi
+
+            - name: Format Generated Files
+              run: |
+                  pnpm format
+
+            - name: Build Package
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Create Stable Release Tag
+              run: |
+                  VERSION=${{ steps.convert_version.outputs.stable_version }}
+                  TAG="v$VERSION"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Create and push the tag
+                  git tag "$TAG" -m "Stable Release $TAG"
+                  git push origin "$TAG"
+                  echo "Successfully created and pushed tag $TAG"
+
+            - name: Create GitHub Stable Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ steps.convert_version.outputs.tag }}
+                  name: Release ${{ steps.convert_version.outputs.tag }}
+                  body_path: docs/CHANGELOG.md
+                  draft: false
+                  prerelease: false
+
+            - name: Create Version Update PR to Main
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: release/update-stable-version-${{ steps.convert_version.outputs.stable_version }}
+                  title: 'chore(release): ${{ steps.convert_version.outputs.tag }} [STABLE]'
+                  body: |
+                      Stable Release ${{ steps.convert_version.outputs.tag }}
+
+                      - Convert beta to stable version: ${{ steps.convert_version.outputs.stable_version }}
+                      - Update changelog for stable release
+                      - **This is a STABLE release - ready for NPM publishing**
+
+                      This PR was automatically created by the stable release workflow.
+
+                      **Next Steps:**
+                      1. Review and merge this PR
+                      2. Trigger "Publish Stable to NPM" workflow to publish to npm with latest tag
+                      3. Auto-backmerge to dev will be created
+
+                      **Changes included:**
+                      - Updated package.json version to stable (removed -beta)
+                      - Generated stable changelog
+                      - Created GitHub release (not prerelease)
+                  labels: |
+                      automated
+                      release
+                      stable
+                  assignees: ${{ github.actor }}
+                  commit-message: |
+                      chore(release): ${{ steps.convert_version.outputs.tag }} [STABLE]
+
+                      - Convert to stable version ${{ steps.convert_version.outputs.stable_version }}
+                      - Update changelog
+                      - Create stable release
+
+                      [skip ci]
+                  add-paths: |
+                      packages/blend/package.json
+                      docs/CHANGELOG.md
+                      .
+
+    create-backmerge-pr:
+        name: Create Backmerge PR (Main → Dev)
+        needs: create-stable-release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Create Beta Version for Dev Branch
+              id: create_beta_version
+              run: |
+                  cd packages/blend
+                  STABLE_VERSION="${{ needs.create-stable-release.outputs.version }}"
+                  NEXT_BETA_VERSION="${STABLE_VERSION}-beta"
+
+                  echo "Creating next beta version: $NEXT_BETA_VERSION"
+                  npm pkg set version="$NEXT_BETA_VERSION"
+
+                  echo "next_beta_version=$NEXT_BETA_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Create Main to Dev Backmerge PR
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  head: main
+                  base: dev
+                  branch: backmerge/main-to-dev-${{ needs.create-stable-release.outputs.version }}
+                  title: 'chore: backmerge stable ${{ needs.create-stable-release.outputs.version }} to dev'
+                  body: |
+                      **Backmerge Stable Release to Dev**
+
+                      Backmerging stable release `${{ needs.create-stable-release.outputs.version }}` from `main` into `dev` branch.
+
+                      **Changes:**
+                      - Stable version: `${{ needs.create-stable-release.outputs.version }}`
+                      - Updated changelog
+                      - Prepare dev for next development cycle with beta version: `${{ steps.create_beta_version.outputs.next_beta_version }}`
+
+                      **Status:**
+                      - ✅ Stable release created on main
+                      - ✅ GitHub stable release published
+                      - 🔄 Ready for NPM stable publish
+                      - 🔄 Dev branch ready for next development cycle
+
+                      ---
+                      *This PR was automatically created after stable release creation*
+                  labels: |
+                      automated
+                      release
+                      backmerge
+                  assignees: ${{ github.actor }}
+                  commit-message: |
+                      chore: backmerge stable ${{ needs.create-stable-release.outputs.version }} to dev
+
+                      Sync stable release from main to dev and prepare for next dev cycle
+
+                      [skip ci]
+                  add-paths: |
+                      packages/blend/package.json
+                      docs/CHANGELOG.md
+                      .

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -1,0 +1,142 @@
+name: Publish Beta to NPM
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm_publish:
+                description: 'Type "PUBLISH" to confirm publishing to NPM'
+                required: true
+                type: string
+
+concurrency:
+    group: publish-beta-npm-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-beta:
+        name: Publish Beta Version to NPM
+        runs-on: ubuntu-latest
+        environment: npm
+        if: github.ref == 'refs/heads/dev' && github.event.inputs.confirm_publish == 'PUBLISH'
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js 22 and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Verify Beta Version
+              id: verify_version
+              run: |
+                  cd packages/blend
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+                  if [[ "$CURRENT_VERSION" != *"-beta" ]]; then
+                    echo "ERROR: Current version ($CURRENT_VERSION) is not a beta version!"
+                    echo "This workflow should only be used to publish beta versions."
+                    exit 1
+                  fi
+
+                  echo "Verified beta version: $CURRENT_VERSION"
+                  echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Build Package
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Verify NPM Token
+              run: |
+                  if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+                    echo "NPM_TOKEN secret is not set!"
+                    exit 1
+                  else
+                    echo "NPM_TOKEN secret is configured"
+                  fi
+
+                  echo "Testing NPM authentication..."
+                  npm whoami || echo "NPM authentication test failed, but continuing..."
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Check if Version Already Published
+              id: check_published
+              run: |
+                  cd packages/blend
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  VERSION="${{ steps.verify_version.outputs.version }}"
+
+                  echo "Checking if $PACKAGE_NAME@$VERSION is already published..."
+
+                  if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+                    echo "already_published=true" >> $GITHUB_OUTPUT
+                    echo "Version $VERSION already exists on NPM"
+                  else
+                    echo "already_published=false" >> $GITHUB_OUTPUT
+                    echo "Version $VERSION is not yet published"
+                  fi
+
+            - name: Publish Beta to NPM
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  cd packages/blend
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  VERSION="${{ steps.verify_version.outputs.version }}"
+
+                  echo "Publishing $PACKAGE_NAME@$VERSION to NPM with beta tag"
+                  npm publish --access public --tag beta
+                  echo "Successfully published $PACKAGE_NAME@$VERSION to NPM with beta tag"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Create Dev to Main PR
+              if: steps.check_published.outputs.already_published != 'true'
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  head: dev
+                  base: main
+                  title: 'feat: promote beta ${{ steps.verify_version.outputs.version }} to stable'
+                  body: |
+                      **Promote Beta to Stable Release**
+
+                      Beta version `${{ steps.verify_version.outputs.version }}` has been published to NPM and is ready for promotion to stable.
+
+                      **Current Status:**
+                      - ✅ Beta version published to NPM with `beta` tag
+                      - ✅ GitHub beta release created
+                      - 🔄 Ready for stable release process
+
+                      **Next Steps After Merging:**
+                      1. This will trigger creation of stable version (removing `-beta` suffix)
+                      2. Trigger "Create Stable Release" workflow to create stable GitHub release
+                      3. Trigger "Publish Stable to NPM" workflow to publish with `latest` tag
+                      4. Auto-backmerge to dev will be created
+
+                      **Version Info:**
+                      - Beta: `${{ steps.verify_version.outputs.version }}`
+                      - Stable: `${{ steps.verify_version.outputs.version | replace('-beta', '') }}`
+
+                      ---
+                      *This PR was automatically created after successful beta NPM publish*
+                  labels: |
+                      automated
+                      release
+                      stable-promotion
+                  assignees: ${{ github.actor }}
+
+            - name: Skip Publishing (Already Published)
+              if: steps.check_published.outputs.already_published == 'true'
+              run: |
+                  echo "Version ${{ steps.verify_version.outputs.version }} is already published on NPM"
+                  echo "Skipping publish step"

--- a/.github/workflows/publish-stable-npm.yml
+++ b/.github/workflows/publish-stable-npm.yml
@@ -1,0 +1,176 @@
+name: Publish Stable to NPM
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm_publish:
+                description: 'Type "PUBLISH" to confirm publishing stable to NPM'
+                required: true
+                type: string
+
+concurrency:
+    group: publish-stable-npm-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-stable:
+        name: Publish Stable Version to NPM
+        runs-on: ubuntu-latest
+        environment: npm
+        if: github.ref == 'refs/heads/main' && github.event.inputs.confirm_publish == 'PUBLISH'
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js 22 and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Verify Stable Version
+              id: verify_version
+              run: |
+                  cd packages/blend
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+                  if [[ "$CURRENT_VERSION" == *"-beta" ]]; then
+                    echo "ERROR: Current version ($CURRENT_VERSION) is a beta version!"
+                    echo "This workflow should only be used to publish stable versions."
+                    echo "Please run the 'Create Stable Release' workflow first to convert beta to stable."
+                    exit 1
+                  fi
+
+                  echo "Verified stable version: $CURRENT_VERSION"
+                  echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Build Package
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Verify NPM Token
+              run: |
+                  if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+                    echo "NPM_TOKEN secret is not set!"
+                    exit 1
+                  else
+                    echo "NPM_TOKEN secret is configured"
+                  fi
+
+                  echo "Testing NPM authentication..."
+                  npm whoami || echo "NPM authentication test failed, but continuing..."
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Check if Version Already Published
+              id: check_published
+              run: |
+                  cd packages/blend
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  VERSION="${{ steps.verify_version.outputs.version }}"
+
+                  echo "Checking if $PACKAGE_NAME@$VERSION is already published..."
+
+                  if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+                    echo "already_published=true" >> $GITHUB_OUTPUT
+                    echo "Version $VERSION already exists on NPM"
+                  else
+                    echo "already_published=false" >> $GITHUB_OUTPUT
+                    echo "Version $VERSION is not yet published"
+                  fi
+
+            - name: Publish Stable to NPM
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  cd packages/blend
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  VERSION="${{ steps.verify_version.outputs.version }}"
+
+                  echo "Publishing $PACKAGE_NAME@$VERSION to NPM with latest tag"
+                  npm publish --access public --tag latest
+                  echo "Successfully published $PACKAGE_NAME@$VERSION to NPM with latest tag"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Verify NPM Package
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  cd packages/blend
+                  PACKAGE_NAME=$(node -p "require('./package.json').name")
+                  VERSION="${{ steps.verify_version.outputs.version }}"
+
+                  echo "Verifying published package..."
+                  sleep 10  # Wait for NPM to propagate
+
+                  PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@latest" version 2>/dev/null || echo "")
+                  if [[ "$PUBLISHED_VERSION" == "$VERSION" ]]; then
+                    echo "✅ Successfully verified: $PACKAGE_NAME@$VERSION is live on NPM with latest tag"
+                  else
+                    echo "⚠️  Warning: Expected $VERSION but NPM shows $PUBLISHED_VERSION for latest tag"
+                  fi
+
+            - name: Update Release Notes
+              if: steps.check_published.outputs.already_published != 'true'
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: v${{ steps.verify_version.outputs.version }}
+                  name: Release v${{ steps.verify_version.outputs.version }}
+                  body: |
+                      # Release v${{ steps.verify_version.outputs.version }}
+
+                      🎉 **Stable release published to NPM!**
+
+                      ## Installation
+                      ```bash
+                      npm install @juspay/blend-design-system@latest
+                      # or
+                      npm install @juspay/blend-design-system@${{ steps.verify_version.outputs.version }}
+                      ```
+
+                      ## NPM Package Info
+                      - **Package**: `@juspay/blend-design-system`
+                      - **Version**: `${{ steps.verify_version.outputs.version }}`
+                      - **Tag**: `latest`
+                      - **Published**: $(date -u)
+
+                      ## What's Changed
+                      This stable release includes all changes from the corresponding beta version.
+
+                      ---
+
+                      **Full Changelog**: https://github.com/juspay/blend-design-system/releases
+                  draft: false
+                  prerelease: false
+
+            - name: Skip Publishing (Already Published)
+              if: steps.check_published.outputs.already_published == 'true'
+              run: |
+                  echo "Version ${{ steps.verify_version.outputs.version }} is already published on NPM"
+                  echo "Skipping publish step"
+
+            - name: Create Success Summary
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  echo "## 🎉 Stable Release Published Successfully!" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Package**: \`@juspay/blend-design-system\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Version**: \`${{ steps.verify_version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**NPM Tag**: \`latest\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### Installation" >> $GITHUB_STEP_SUMMARY
+                  echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+                  echo "npm install @juspay/blend-design-system@latest" >> $GITHUB_STEP_SUMMARY
+                  echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ Stable version is now live on NPM" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ GitHub release updated with NPM info" >> $GITHUB_STEP_SUMMARY
+                  echo "- 🔄 Merge the auto-created backmerge PR to sync main → dev" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,19 @@
-name: Release
+name: Legacy Release (DEPRECATED)
+
+# This workflow is deprecated. Use the new manual workflows instead:
+# - create-beta-release.yml: Create beta releases from dev branch
+# - publish-beta-npm.yml: Publish beta to NPM
+# - create-stable-release.yml: Create stable releases on main branch
+# - publish-stable-npm.yml: Publish stable to NPM
 
 on:
-    push:
-        branches:
-            - main
-            - dev
-        paths-ignore:
-            - 'docs/CHANGELOG.md'
+    # Disabled automatic triggers - only manual for emergency use
     workflow_dispatch:
         inputs:
+            emergency_release:
+                description: 'Type "EMERGENCY" to confirm this legacy workflow usage'
+                required: true
+                type: string
             version_type:
                 description: 'Version bump type'
                 required: true
@@ -21,7 +26,7 @@ on:
             dry_run:
                 description: 'Dry run (skip publishing)'
                 required: false
-                default: false
+                default: true
                 type: boolean
 
 concurrency:
@@ -30,9 +35,10 @@ concurrency:
 
 jobs:
     release:
-        name: Publish Release
+        name: Legacy Release (Emergency Only)
         runs-on: ubuntu-latest
         environment: npm
+        if: github.event.inputs.emergency_release == 'EMERGENCY'
         outputs:
             version: ${{ steps.bump_version.outputs.new_version }}
             tag: ${{ steps.bump_version.outputs.tag }}


### PR DESCRIPTION
# Release Workflow Guide

This document explains the new manual release workflow for the Blend Design System. The workflow is designed to provide better control over releases and separate the creation of releases from publishing to NPM.

## Overview

The release process is split into multiple manual workflows that must be triggered in sequence:

1. **Create Beta Release** - Creates a beta version, GitHub release, and PR
2. **Publish Beta to NPM** - Publishes the beta version to NPM with `beta` tag
3. **Create Stable Release** - Converts beta to stable, creates GitHub release and PR
4. **Publish Stable to NPM** - Publishes the stable version to NPM with `latest` tag

## Workflows

### 1. Create Beta Release (`create-beta-release.yml`)

**Purpose**: Create a beta release from the `dev` branch without publishing to NPM.

**Triggers**: Manual workflow dispatch from `dev` branch only

**What it does**:
- Bumps version according to chosen type (patch/minor/major)
- Always creates a `-beta` version (e.g., `0.0.9` → `0.0.10-beta`)
- Handles version conflicts by cleaning existing tags
- Creates GitHub beta release (marked as prerelease)
- Generates changelog
- Creates a PR to merge version changes back to `dev`

**Usage**:
1. Navigate to Actions tab in GitHub
2. Select "Create Beta Release" workflow
3. Click "Run workflow"
4. Choose version bump type (patch/minor/major)
5. Confirm you're on the `dev` branch
6. Click "Run workflow"

### 2. Publish Beta to NPM (`publish-beta-npm.yml`)

**Purpose**: Publish the beta version to NPM after the beta release PR is merged.

**Triggers**: Manual workflow dispatch from `dev` branch only

**Prerequisites**: 
- Beta release PR must be merged to `dev`
- Version in `package.json` must end with `-beta`

**What it does**:
- Verifies current version is a beta version
- Builds the package
- Publishes to NPM with `beta` tag
- Creates a PR from `dev` → `main` for stable promotion
- Skips publishing if version already exists on NPM

**Usage**:
1. Merge the beta release PR created in step 1
2. Navigate to Actions tab in GitHub
3. Select "Publish Beta to NPM" workflow
4. Click "Run workflow"
5. Type "PUBLISH" in the confirmation field
6. Confirm you're on the `dev` branch
7. Click "Run workflow"

### 3. Create Stable Release (`create-stable-release.yml`)

**Purpose**: Create a stable release from the `main` branch after dev→main PR is merged.

**Triggers**: Manual workflow dispatch from `main` branch only

**Prerequisites**:
- Dev→main PR (created in step 2) must be merged
- Main branch should have a beta version to convert

**What it does**:
- Converts beta version to stable (removes `-beta` suffix)
- Creates GitHub stable release (not marked as prerelease)
- Generates stable changelog
- Creates PR to merge stable version back to `main`
- Creates automatic backmerge PR from `main` → `dev`

**Usage**:
1. Merge the dev→main promotion PR created in step 2
2. Navigate to Actions tab in GitHub
3. Select "Create Stable Release" workflow
4. Click "Run workflow"
5. Type "STABLE" in the confirmation field
6. Confirm you're on the `main` branch
7. Click "Run workflow"

### 4. Publish Stable to NPM (`publish-stable-npm.yml`)

**Purpose**: Publish the stable version to NPM with `latest` tag.

**Triggers**: Manual workflow dispatch from `main` branch only

**Prerequisites**:
- Stable release PR (created in step 3) must be merged
- Version in `package.json` must NOT end with `-beta`

**What it does**:
- Verifies current version is stable (no `-beta` suffix)
- Builds the package
- Publishes to NPM with `latest` tag
- Updates GitHub release with NPM installation info
- Provides success summary

**Usage**:
1. Merge the stable release PR created in step 3
2. Navigate to Actions tab in GitHub
3. Select "Publish Stable to NPM" workflow
4. Click "Run workflow"
5. Type "PUBLISH" in the confirmation field
6. Confirm you're on the `main` branch
7. Click "Run workflow"

## Complete Release Process Example

Let's say your current version is `0.0.9-beta` on `dev` branch and you want to create version `0.0.10`:

### Phase 1: Beta Release
1. **Trigger**: "Create Beta Release" workflow from `dev` branch with "patch"
   - Result: Version becomes `0.0.10-beta`
   - Creates GitHub beta release
   - Creates PR to update `dev` with new version

2. **Merge**: Beta release PR to `dev` branch

3. **Trigger**: "Publish Beta to NPM" workflow from `dev` branch
   - Result: `0.0.10-beta` published to NPM with `beta` tag
   - Creates PR from `dev` → `main`

### Phase 2: Stable Release
4. **Merge**: Dev→main promotion PR

5. **Trigger**: "Create Stable Release" workflow from `main` branch
   - Result: Version becomes `0.0.10` (removes `-beta`)
   - Creates GitHub stable release
   - Creates PR to update `main` with stable version
   - Creates backmerge PR from `main` → `dev`

6. **Merge**: Stable release PR to `main` branch

7. **Trigger**: "Publish Stable to NPM" workflow from `main` branch
   - Result: `0.0.10` published to NPM with `latest` tag
   - Updates GitHub release with installation info

8. **Merge**: Backmerge PR to sync `main` → `dev`

## Version Management

### Beta Versions
- Always end with `-beta` suffix
- Example: `0.0.10-beta`, `0.1.0-beta`, `1.0.0-beta`
- Published to NPM with `beta` tag
- GitHub releases are marked as "prerelease"

### Stable Versions
- Never have `-beta` suffix
- Example: `0.0.10`, `0.1.0`, `1.0.0`
- Published to NPM with `latest` tag
- GitHub releases are not marked as prerelease

### Version Bump Logic
- The workflow always bumps from the base version (removes `-beta` first)
- Example: `0.0.9-beta` + patch → `0.0.10-beta`
- Conflicts are resolved by deleting existing tags

## Safety Features

1. **Manual Triggers Only**: All workflows require manual dispatch
2. **Confirmation Fields**: Publishing workflows require typing confirmation
3. **Branch Restrictions**: Workflows only run from appropriate branches
4. **Version Validation**: Checks ensure correct version types for each workflow
5. **Duplicate Prevention**: Skips publishing if version already exists on NPM
6. **Build Validation**: All packages are built and tested before publishing

## Troubleshooting

### Common Issues

**"Version X already exists on NPM"**
- The workflow will skip publishing and continue
- This is safe and expected if you re-run workflows

**"Current version is not a beta version"**
- Make sure you've merged the appropriate release PR
- Check that `package.json` has the expected version format

**"Emergency releases"**
- The legacy `release.yml` workflow is available for emergencies
- Requires typing "EMERGENCY" to confirm usage
- Should only be used when the new workflow is broken

### Manual Recovery

If you need to manually fix version issues:

1. Create a branch from the appropriate base (`dev` or `main`)
2. Manually update `packages/blend/package.json`
3. Create a PR with the title format: `chore(release): fix version to X.X.X`
4. Merge the PR
5. Continue with the normal workflow from the appropriate step

## Migration from Old Workflow

The previous automatic release workflow has been deprecated. Key differences:

- **Old**: Automatic triggers on push to `main`/`dev`
- **New**: Manual triggers only
- **Old**: Single workflow handling everything
- **New**: Separate workflows for each step
- **Old**: Combined release creation + NPM publishing
- **New**: Separated release creation from NPM publishing

The old workflow (`release.yml`) is still available for emergencies but requires typing "EMERGENCY" to run. 