### PR TITLE
232 need to add the intermediate state for the sidebar which will be triggered on hover in the collapsed state

### DIFF
--- a/apps/site/src/demos/ChartsDemo.tsx
+++ b/apps/site/src/demos/ChartsDemo.tsx
@@ -344,21 +344,6 @@ const ChartDemo = () => {
         }
     }
 
-    const getMetrics = () => {
-        if (!showLimitedMetrics) return undefined
-
-        switch (selectedDataset) {
-            case 'financial':
-                return ['revenue', 'profit']
-            case 'performance':
-                return ['sales', 'leads']
-            case 'analytics':
-                return ['users']
-            default:
-                return undefined
-        }
-    }
-
     const getColors = () => {
         switch (selectedChartType) {
             case ChartType.LINE:
@@ -394,7 +379,6 @@ const ChartDemo = () => {
                     chartType={selectedChartType}
                     legendPosition={selectedLegendPosition}
                     colors={getColors()}
-                    metrics={getMetrics()}
                     xAxisLabel={
                         selectedDataset === 'analytics'
                             ? 'Device Type'
@@ -670,7 +654,6 @@ const ChartDemo = () => {
                     <Charts
                         data={financialData}
                         chartType={ChartType.LINE}
-                        metrics={['revenue', 'profit']}
                         xAxisLabel="Month"
                         yAxisLabel="Amount ($)"
                         chartHeaderSlot={

--- a/packages/blend/lib/components/Charts/types.tsx
+++ b/packages/blend/lib/components/Charts/types.tsx
@@ -62,10 +62,9 @@ export type RenderChartProps = {
 export type ChartsProps = {
     chartType?: ChartType
     data: NewNestedDataPoint[]
+    colors?: string[]
     xAxisLabel?: string
     yAxisLabel?: string
-    colors?: string[]
-    metrics?: string[]
     slot1?: ReactNode
     slot2?: ReactNode
     slot3?: ReactNode

--- a/packages/blend/lib/components/Sidebar/types.ts
+++ b/packages/blend/lib/components/Sidebar/types.ts
@@ -20,4 +20,5 @@ export type SidebarProps = {
     topbar: ReactNode
     footer?: ReactNode
     sidebarTopSlot?: ReactNode
+    sidebarCollapseKey?: string
 }


### PR DESCRIPTION
## Summary

sidebar intermediate state with key to expand and collapse

---

## Affected Scope

<!-- Check all that apply -->

- [ ] Design System Component (`@blend/*`)
- [ ] Documentation (`apps/docs`)
- [ ] Tests or Configuration
- [ ] Tools / Scripts
- [ ] Backend / API
- [ ] Refactor / Cleanup

---

## Changes Made

- ...
- ...
- ...

---

## How to Test

<!-- Instructions for reviewers to test changes -->

---

## Screenshots (if applicable)

| Before | After |
| ------ | ----- |
|        |       |

---

## Related Issues

Closes #[issue_number] or Related to #232 #233 
