### PR TITLE
feat(avatar-group): separate triggers for white and dark theme

### DIFF
--- a/packages/blend/lib/components/AvatarGroup/DarkStyledAvatarGroup.tsx
+++ b/packages/blend/lib/components/AvatarGroup/DarkStyledAvatarGroup.tsx
@@ -1,0 +1,123 @@
+import styled from 'styled-components'
+import { foundationToken } from '../../foundationToken'
+import type {
+    StyledAvatarGroupContainerProps,
+    StyledAvatarWrapperProps,
+    StyledOverflowCounterProps,
+} from './types'
+import avatarGroupTokens from './avatarGroup.tokens'
+
+/* Container */
+/* Dark Theme Styled Components */
+export const DarkStyledAvatarGroupContainer = styled.div<StyledAvatarGroupContainerProps>`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+`
+
+export const DarkStyledAvatarWrapper = styled.div<StyledAvatarWrapperProps>`
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    margin-left: -${(props) => avatarGroupTokens.container.spacing[props.$size]};
+    z-index: ${(props) =>
+        avatarGroupTokens.darkThemeavatar.stacking.zIndex +
+        (props.$total - props.$index)};
+
+    /* First avatar doesn't need negative margin */
+    ${(props) => props.$index === 0 && `margin-left: 0;`}
+
+    /* Border ring around avatar: dark border for dark theme */
+  & > div {
+        border: 2px solid ${foundationToken.colors.gray[700]};
+    }
+
+    /* Selected avatar ring */
+    ${(props) =>
+        props.$isSelected &&
+        `
+    & > div {
+      box-shadow: 0 0 0 2px ${foundationToken.colors.primary[500]};
+      outline: 2px solid ${foundationToken.colors.gray[900]};
+    }
+  `}
+
+    &:focus-visible {
+        outline: 2px solid ${foundationToken.colors.primary[500]};
+        outline-offset: 2px;
+    }
+`
+
+export const DarkStyledOverflowCounter = styled.button<StyledOverflowCounterProps>`
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    margin-left: -${(props) => avatarGroupTokens.container.spacing[props.$size]};
+
+    width: ${(props) =>
+        avatarGroupTokens.overflowCounter.sizes[props.$size].width};
+    height: ${(props) =>
+        avatarGroupTokens.overflowCounter.sizes[props.$size].height};
+    font-size: ${(props) =>
+        avatarGroupTokens.overflowCounter.sizes[props.$size].fontSize};
+    font-weight: ${foundationToken.fontWeight[500]};
+
+    color: ${avatarGroupTokens.overflowCounter.text.color};
+    background-color: ${(props) =>
+        props.$isOpen
+            ? avatarGroupTokens.overflowCounter.background.active
+            : avatarGroupTokens.overflowCounter.background.default};
+
+    border-radius: ${(props) =>
+        avatarGroupTokens.overflowCounter.shapes[props.$shape].borderRadius};
+    border: 2px solid ${foundationToken.colors.gray[700]}; /* DARK border */
+
+    transition:
+        background-color 0.2s ease,
+        box-shadow 0.2s ease;
+    z-index: ${avatarGroupTokens.darkThemeavatar.stacking.zIndex};
+
+    &:hover {
+        background-color: ${avatarGroupTokens.overflowCounter.background.hover};
+    }
+
+    &:focus-visible {
+        outline: 2px solid ${foundationToken.colors.primary[500]};
+        outline-offset: 2px;
+    }
+
+    ${(props) =>
+        props.$isOpen &&
+        `
+    box-shadow: 0 0 0 2px ${foundationToken.colors.primary[500]};
+    outline: 2px solid ${foundationToken.colors.gray[900]};
+  `}
+`
+
+export const DarkStyledMenuContainer = styled.div`
+    position: fixed;
+    z-index: ${avatarGroupTokens.menu.zIndex};
+    margin-top: ${avatarGroupTokens.menu.spacing};
+    background-color: ${foundationToken.colors.gray[900]};
+    color: ${foundationToken.colors.gray[50]};
+    border-radius: 4px;
+    box-shadow:
+        0 4px 6px -1px rgba(0, 0, 0, 0.3),
+        0 2px 4px -1px rgba(0, 0, 0, 0.2);
+`
+
+export const DarkVisuallyHidden = styled.span`
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+`

--- a/packages/blend/lib/components/AvatarGroup/avatarGroup.tokens.ts
+++ b/packages/blend/lib/components/AvatarGroup/avatarGroup.tokens.ts
@@ -26,6 +26,21 @@ const avatarGroupTokens = {
             color: foundationToken.colors.gray[0],
         },
     },
+    darkThemeavatar: {
+        // added for DarkTheme , Using the existing Avatar tokens for styling the avatars themselves
+        stacking: {
+            zIndex: 1, // Base z-index for stacking
+        },
+        selected: {
+            ringColor: foundationToken.colors.primary[500],
+            ringWidth: '2px',
+            ringOffset: '2px',
+        },
+        border: {
+            width: '2px',
+            color: foundationToken.colors.gray[0],
+        },
+    },
     overflowCounter: {
         background: {
             default: foundationToken.colors.gray[900],


### PR DESCRIPTION
# Summary  
Separated the **menu and search logic** between **Light AvatarGroup** and **Dark AvatarGroup** so that opening/searching in one does not affect the other.  

---

# Affected Scope  
- **Design System Component (@blend/\*)**: Yes  
- **Documentation (apps/docs)**: Yes (via storybook update)  
- **Tests or Configuration**: No  
- **Tools / Scripts**: No  
- **Backend / API**: No  
- **Refactor / Cleanup**: Partial (split state handling)  

---

# Changes Made  
- Introduced **separate state variables** for:  
  - Light AvatarGroup: `isLightMenuOpen`, `lightSearchTerm`  
  - Dark AvatarGroup: `isDarkMenuOpen`, `darkSearchTerm`  
- Updated **menu toggle logic** so clicking on the dark overflow counter no longer triggers the light menu, and vice versa.  
- Updated **search input logic** so filtering is independent per theme.  
- Kept the **Avatar selection logic** shared (selection state is still consistent across both themes).  
- Updated **Styled wrappers** (`DarkStyledAvatarWrapper`, `DarkStyledOverflowCounter`, etc.) to reflect new props where necessary.  

---

# How to Test  
1. Run Storybook.  
2. Navigate to **AvatarGroup stories**.  
3. Check both **White Theme** and **Black Theme** stories.  
   - Clicking the **white overflow counter** should only open the white menu.  
   - Clicking the **dark overflow counter** should only open the dark menu.  
   - Searching inside one menu should not affect the other.  
4. Avatar selection (click/tap on avatar) should still highlight correctly in both themes.  

---

# Screenshots (if applicable)  
-before : 
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/1f8d3454-9c0a-4566-a20e-1c9c849cfebe" />

-after :
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/24245d50-87e8-46dc-b600-beae88d07220" />

**Before**  
- Clicking on the dark overflow counter also opened the white menu (shared trigger).  
- Search input was shared between themes.  

**After**  
- White and Dark AvatarGroups have **independent menus** and **separate search inputs**.  

---

# Related Issues  
Closes #110 (avatar-group-theming)  

---

# Files Likely to Change  
- `packages/blend/lib/components/AvatarGroup/StyledAvatarGroup.tsx`  
- `packages/blend/lib/components/AvatarGroup/AvatarGroup.tsx`  
- `packages/blend/lib/components/AvatarGroup/avatarGroupUtils.tsx`  
- `packages/blend/lib/components/AvatarGroup/avatarGroup.tokens.ts`  

---

# Storybook Demonstration  
We duplicated existing stories for:  
- **Avatar**  
- **AvatarGroup**  

Show two versions:  
- White theme  
- Black theme  

---

# Why Duplication?  
- There’s no global theme toggle in docs currently.  
- Duplication makes theme differences visible immediately.  
- Even with a theme toggle later, these stories remain useful.  
- Adding a toggle button only for Avatar would feel inconsistent with the rest of the system.  

---

# My Approach  
- Added extra visible padding and borders to Avatars for clarity.  
- Applied **two themes (White + Black)** to demonstrate how tokens affect the component.  

---

# Next Steps  
- Confirm if this aligns with maintainers’ expectations.  
- Open to feedback on whether to pursue **duplication** or a **shared toggle system** later.  
