### PR TITLE
chore: fixed the type of switch label

### DIFF
--- a/packages/blend/__tests__/components/Switch/Switch.accessibility.test.tsx
+++ b/packages/blend/__tests__/components/Switch/Switch.accessibility.test.tsx
@@ -569,11 +569,8 @@ describe('Switch Accessibility', () => {
         it('handles complex label content accessibly', async () => {
             const { container } = render(
                 <Switch
-                    label={
-                        <span>
-                            Enable <strong>advanced</strong> notifications
-                        </span>
-                    }
+                    label="Enable advanced notifications"
+                    subtext="Configure notification settings with enhanced options"
                 />
             )
 

--- a/packages/blend/lib/components/Switch/Switch.tsx
+++ b/packages/blend/lib/components/Switch/Switch.tsx
@@ -111,7 +111,7 @@ const SwitchContent: React.FC<{
     error: boolean
     required: boolean
     size: SwitchSize
-    label?: React.ReactNode
+    label?: string
     tokens: SwitchTokensType
 }> = ({ uniqueId, disabled, error, required, size, label, tokens }) => {
     if (!label) return null

--- a/packages/blend/lib/components/Switch/types.ts
+++ b/packages/blend/lib/components/Switch/types.ts
@@ -14,7 +14,7 @@ export type SwitchProps = {
     required?: boolean
     error?: boolean
     size?: SwitchSize
-    label?: ReactNode
+    label?: string
     subtext?: ReactNode
     slot?: ReactNode
     name?: string


### PR DESCRIPTION
### Summary

fixed the type definition of the label prop which was react node earlier and made it of string type

### Issue Ticket

Closes #89 
