### PR TITLE
chore: removed unnecessary checkboxCheckedState

### DIFF
--- a/packages/blend/lib/components/Checkbox/StyledCheckbox.tsx
+++ b/packages/blend/lib/components/Checkbox/StyledCheckbox.tsx
@@ -1,17 +1,20 @@
 import styled, { css } from 'styled-components'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import type { CheckboxInteractionState } from './types'
-import { CheckboxSize } from './types'
+import {
+    CheckboxSize,
+    CheckboxCheckedState,
+    CheckboxInteractionState,
+} from './types'
 import type { CheckboxTokensType } from './checkbox.token'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 
 const getInteractionState = (
     isDisabled: boolean,
     error?: boolean
-): Exclude<CheckboxInteractionState, 'hover'> => {
-    if (isDisabled) return 'disabled'
-    if (error) return 'error'
-    return 'default'
+): Exclude<CheckboxInteractionState, CheckboxInteractionState.HOVER> => {
+    if (isDisabled) return CheckboxInteractionState.DISABLED
+    if (error) return CheckboxInteractionState.ERROR
+    return CheckboxInteractionState.DEFAULT
 }
 
 export const StyledCheckboxRoot = styled(CheckboxPrimitive.Root)<{
@@ -27,12 +30,12 @@ export const StyledCheckboxRoot = styled(CheckboxPrimitive.Root)<{
 
     ${({ size, $isDisabled, $checked, $error }) => {
         const tokens = useResponsiveTokens<CheckboxTokensType>('CHECKBOX')
-        const currentCheckedState: 'checked' | 'unchecked' | 'indeterminate' =
+        const currentCheckedState: CheckboxCheckedState =
             $checked === 'indeterminate'
-                ? 'indeterminate'
+                ? CheckboxCheckedState.INDETERMINATE
                 : $checked
-                  ? 'checked'
-                  : 'unchecked'
+                  ? CheckboxCheckedState.CHECKED
+                  : CheckboxCheckedState.UNCHECKED
 
         const currentInteractionState = getInteractionState($isDisabled, $error)
 

--- a/packages/blend/lib/components/Checkbox/checkbox.token.ts
+++ b/packages/blend/lib/components/Checkbox/checkbox.token.ts
@@ -1,8 +1,7 @@
 import type { CSSObject } from 'styled-components'
 import { FOUNDATION_THEME } from '../../tokens'
 import type { ThemeType } from '../../tokens'
-import type { CheckboxInteractionState } from './types'
-import { CheckboxSize } from './types'
+import { CheckboxSize, CheckboxInteractionState } from './types'
 import type { BreakpointType } from '../../breakpoints/breakPoints'
 
 // Token Structure: $component.$target.$property.[$variant].[$type].[$state]

--- a/packages/blend/lib/components/Checkbox/checkboxUtils.ts
+++ b/packages/blend/lib/components/Checkbox/checkboxUtils.ts
@@ -1,11 +1,13 @@
-import { CheckboxSize } from './types'
+import { CheckboxSize, CheckboxCheckedState } from './types'
 import type { CheckboxTokensType } from './checkbox.token'
 
 export const getCheckboxDataState = (
     checked: boolean | 'indeterminate'
 ): string => {
-    if (checked === 'indeterminate') return 'indeterminate'
-    return checked ? 'checked' : 'unchecked'
+    if (checked === 'indeterminate') return CheckboxCheckedState.INDETERMINATE
+    return checked
+        ? CheckboxCheckedState.CHECKED
+        : CheckboxCheckedState.UNCHECKED
 }
 
 export const extractPixelValue = (
@@ -69,11 +71,11 @@ export const getCheckboxIconColor = (
     disabled: boolean
 ): string => {
     if (disabled) {
-        return currentChecked === 'indeterminate'
+        return currentChecked === CheckboxCheckedState.INDETERMINATE
             ? String(tokens.icon.color.indeterminate?.disabled || '')
             : String(tokens.icon.color.checked?.disabled || '')
     }
-    return currentChecked === 'indeterminate'
+    return currentChecked === CheckboxCheckedState.INDETERMINATE
         ? String(tokens.icon.color.indeterminate?.default || '')
         : String(tokens.icon.color.checked?.default || '')
 }

--- a/packages/blend/lib/components/Checkbox/types.ts
+++ b/packages/blend/lib/components/Checkbox/types.ts
@@ -5,11 +5,18 @@ export enum CheckboxSize {
     MEDIUM = 'md',
 }
 
-export type CheckboxInteractionState =
-    | 'default'
-    | 'hover'
-    | 'disabled'
-    | 'error'
+export enum CheckboxCheckedState {
+    CHECKED = 'checked',
+    UNCHECKED = 'unchecked',
+    INDETERMINATE = 'indeterminate',
+}
+
+export enum CheckboxInteractionState {
+    DEFAULT = 'default',
+    HOVER = 'hover',
+    DISABLED = 'disabled',
+    ERROR = 'error',
+}
 
 export type CheckboxProps = {
     id?: string


### PR DESCRIPTION
### Summary

- Removed unused CheckboxCheckedState type from types.ts
- Updated checkbox.token.ts - Replaced type usage with explicit inline unions
- Updated StyledCheckbox.tsx - Replaced type import with inline union

### Issue Ticket

Closes #363 
