### PR TITLE
fixed the side bar issue - to prevent the tokens being forwarded to DOM

### DIFF
--- a/packages/blend/lib/components/Sidebar/SidebarHeader.tsx
+++ b/packages/blend/lib/components/Sidebar/SidebarHeader.tsx
@@ -11,7 +11,9 @@ import type { SidebarMerchantInfo } from './types'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import type { SidebarTokenType } from './sidebar.tokens'
 
-const ToggleButton = styled.button<{ tokens: SidebarTokenType }>`
+const ToggleButton = styled.button.withConfig({
+    shouldForwardProp: (prop) => prop !== 'tokens',
+})<{ tokens: SidebarTokenType }>`
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Sidebar is throwing style related error and warnings in the console Fixes #228

# Prevent `tokens` Prop from Being Forwarded to the DOM in Sidebar Toggle Button

Styled-components was forwarding the `tokens` prop into the rendered `<button>`, causing React "unknown DOM prop" warnings and noisy console output. This change filters the prop so it is used only for styling and not forwarded to DOM nodes.

## What I changed
- Updated: `SidebarHeader.tsx`
  - Used `styled.button.withConfig({ shouldForwardProp: (prop) => prop !== 'tokens' })` for `ToggleButton` to prevent forwarding the `tokens` prop to the DOM.

**Commit:** 8372f6835572c27c14a28510043757660d78dfa6  
**Branch:** `fix/sidebar-style-warnings`

## Motivation
React logs warnings when non-standard props (like an object `tokens`) are passed to DOM nodes. These warnings appear in the browser console and can hide real issues. Filtering these transient props keeps the DOM clean and avoids React warnings.

## How to test (local)
1. Install dependencies and build the workspace:
   ```bash
   pnpm install
   pnpm -w build
   ```
2. Run dev server:
   ```bash
   pnpm dev
   # or for a specific app:
   pnpm --filter apps/ascent dev
   ```
3. In DevTools console, interact with the Sidebar:
   - No React "unknown DOM prop" warnings referencing `tokens`
   - Sidebar toggle behavior remains unchanged

## Quality checks
```bash
pnpm -w lint
pnpm -w test
```

## Notes & follow-ups
- This PR fixes the most visible warning in the Sidebar (`tokens` forwarded to `<button>`).
- Follow-ups recommended:
  - Search for similar cases where object props are forwarded to DOM nodes
  - Use `shouldForwardProp` or transient props (like `$tokens`) consistently
  - Add a CI test to fail on unknown-prop warnings

## Related
- Issue/Discussion: (add link if any)
- Follows project development workflow in `README.md`
