### PR TITLE
fix: update error message display in ErrorState of upload

### DIFF
--- a/packages/blend/lib/components/Upload/components/ErrorState.tsx
+++ b/packages/blend/lib/components/Upload/components/ErrorState.tsx
@@ -75,7 +75,7 @@ const ErrorState: React.FC<ErrorStateProps> = ({
             >
                 {multiple
                     ? `${errorFiles.length} files failed`
-                    : errorFiles[0]?.error ||
+                    : errorFiles[0]?.file?.name ||
                       'Upload failed. Please try again.'}
             </Text>
         </Block>


### PR DESCRIPTION
### Summary

fix the error state message in upload to show the file name

### Issue Ticket

 #807

<img width="363" height="341" alt="Screenshot 2025-12-17 at 5 45 56 PM" src="https://github.com/user-attachments/assets/7ea279e9-25e0-4578-99f4-6fc2adf0662d" />

