### PR TITLE
Change DataTable overflow property from 'visible' to 'auto'

### DIFF
--- a/packages/blend/lib/components/DataTable/DataTable.tsx
+++ b/packages/blend/lib/components/DataTable/DataTable.tsx
@@ -1233,7 +1233,7 @@ const DataTable = forwardRef(
                         display: 'flex',
                         flexDirection: 'column',
                         position: 'relative',
-                        overflow: 'visible',
+                        overflow: 'auto',
                     }}
                 >
                     <BulkActionBar


### PR DESCRIPTION
### Summary

fix overflowing issue when we scroll horizontally

### Issue Ticket

Closes #885 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved DataTable scrolling behavior by enabling vertical scrolling when content exceeds the container height.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->