### PR TITLE
fix: add export in component index for tokens and accodion visibilitty fix

### DIFF
--- a/packages/blend/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/blend/lib/components/Accordion/AccordionItem.tsx
@@ -28,8 +28,7 @@ const StyledAccordionItem = styled(RadixAccordion.Item)<{
     border: props.$accordionToken.trigger.border[props.$accordionType].default,
 
     borderRadius: props.$accordionToken.borderRadius[props.$accordionType],
-    overflow:
-        props.$accordionType === AccordionType.BORDER ? 'hidden' : 'visible',
+    overflow: 'visible',
     ...(props.$isDisabled &&
         props.$accordionType === AccordionType.BORDER && {
             backgroundColor:
@@ -159,7 +158,7 @@ const StyledAccordionContent = styled(RadixAccordion.Content)<{
     $accordionType: AccordionType
     $accordionToken: AccordionTokenType
 }>((props) => ({
-    overflow: 'hidden',
+    overflow: 'visible',
     transition: 'all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
 
     '&[data-state="open"]': {

--- a/packages/blend/lib/components/Accordion/index.ts
+++ b/packages/blend/lib/components/Accordion/index.ts
@@ -1,3 +1,4 @@
 export { default as Accordion } from './Accordion'
 export { default as AccordionItem } from './AccordionItem'
+export * from './accordion.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Alert/index.ts
+++ b/packages/blend/lib/components/Alert/index.ts
@@ -1,2 +1,3 @@
 export { default as Alert } from './Alert'
+export * from './alert.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Avatar/index.ts
+++ b/packages/blend/lib/components/Avatar/index.ts
@@ -1,2 +1,3 @@
 export { default as Avatar } from './Avatar'
+export * from './avatar.tokens'
 export * from './types'

--- a/packages/blend/lib/components/AvatarGroup/index.ts
+++ b/packages/blend/lib/components/AvatarGroup/index.ts
@@ -1,2 +1,3 @@
 export { default as AvatarGroup } from './AvatarGroup'
+export * from './avatarGroup.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Breadcrumb/index.ts
+++ b/packages/blend/lib/components/Breadcrumb/index.ts
@@ -1,2 +1,3 @@
 export { default as Breadcrumb } from './Breadcrumb'
+export * from './breadcrumb.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Button/index.ts
+++ b/packages/blend/lib/components/Button/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button'
+export * from './button.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Card/index.ts
+++ b/packages/blend/lib/components/Card/index.ts
@@ -1,2 +1,3 @@
 export { default as Card } from './Card'
+export * from './card.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Charts/index.ts
+++ b/packages/blend/lib/components/Charts/index.ts
@@ -7,4 +7,5 @@ export { default as ChartLegends } from './ChartLegend'
 export { default as SankeyNode } from './SankeyNode'
 export { default as SankeyLink } from './SankeyLink'
 
+export * from './chart.tokens'
 export * from './types'

--- a/packages/blend/lib/components/ChatInput/index.tsx
+++ b/packages/blend/lib/components/ChatInput/index.tsx
@@ -1,2 +1,3 @@
 export { default as ChatInput } from './ChatInput'
+export * from './chatInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/DataTable/index.ts
+++ b/packages/blend/lib/components/DataTable/index.ts
@@ -5,7 +5,7 @@ export * from './TableBody/types'
 export * from './TableCell/types'
 export * from './TableFooter/types'
 export * from './DataTableHeader/types'
-export type { TableTokenType } from './dataTable.tokens'
+export * from './dataTable.tokens'
 
 export { validateColumnData, getColumnTypeConfig } from './columnTypes'
 

--- a/packages/blend/lib/components/DateRangePicker/index.ts
+++ b/packages/blend/lib/components/DateRangePicker/index.ts
@@ -1,3 +1,4 @@
 export { default as DateRangePicker } from './DateRangePicker'
 export { default as MobileDrawerPresets } from './MobileDrawerPresets'
+export * from './dateRangePicker.tokens'
 export * from './types'

--- a/packages/blend/lib/components/DateRangePicker/utils.ts
+++ b/packages/blend/lib/components/DateRangePicker/utils.ts
@@ -1446,8 +1446,8 @@ export const getDateCellStates = (
 
     const isDisabled = Boolean(
         (disableFutureDates && date > today) ||
-        (disablePastDates && date < today) ||
-        (customDisableDates && customDisableDates(date))
+            (disablePastDates && date < today) ||
+            (customDisableDates && customDisableDates(date))
     )
 
     return {

--- a/packages/blend/lib/components/Directory/index.ts
+++ b/packages/blend/lib/components/Directory/index.ts
@@ -1,2 +1,3 @@
 export { default as Directory } from './Directory'
+export * from './directory.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/DropdownInput/index.ts
+++ b/packages/blend/lib/components/Inputs/DropdownInput/index.ts
@@ -1,2 +1,3 @@
 export { default as DropdownInput } from './DropdownInput'
+export * from './dropdownInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/MultiValueInput/index.ts
+++ b/packages/blend/lib/components/Inputs/MultiValueInput/index.ts
@@ -1,2 +1,3 @@
 export { default as MultiValueInput } from './MultiValueInput'
+export * from './multiValueInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/NumberInput/index.ts
+++ b/packages/blend/lib/components/Inputs/NumberInput/index.ts
@@ -1,2 +1,3 @@
 export { default as NumberInput } from './NumberInput'
+export * from './numberInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/OTPInput/index.ts
+++ b/packages/blend/lib/components/Inputs/OTPInput/index.ts
@@ -1,2 +1,3 @@
 export { default as OTPInput } from './OTPInput'
+export * from './otpInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/SearchInput/index.ts
+++ b/packages/blend/lib/components/Inputs/SearchInput/index.ts
@@ -1,2 +1,3 @@
 export { default as SearchInput } from './SearchInput'
+export * from './searchInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/TextInput/index.ts
+++ b/packages/blend/lib/components/Inputs/TextInput/index.ts
@@ -1,2 +1,3 @@
 export { default as TextInput } from './TextInput'
+export * from './textInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Inputs/UnitInput/index.ts
+++ b/packages/blend/lib/components/Inputs/UnitInput/index.ts
@@ -1,2 +1,3 @@
 export { default as UnitInput } from './UnitInput'
+export * from './unitInput.tokens'
 export * from './types'

--- a/packages/blend/lib/components/KeyValuePair/index.ts
+++ b/packages/blend/lib/components/KeyValuePair/index.ts
@@ -1,2 +1,3 @@
 export { default as KeyValuePair } from './KeyValuePair'
+export * from './KeyValuePair.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Menu/index.ts
+++ b/packages/blend/lib/components/Menu/index.ts
@@ -1,2 +1,3 @@
 export { default as Menu } from './Menu'
+export * from './menu.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Modal/index.ts
+++ b/packages/blend/lib/components/Modal/index.ts
@@ -1,2 +1,3 @@
 export { default as Modal } from './Modal'
+export * from './modal.tokens'
 export * from './types'

--- a/packages/blend/lib/components/MultiSelect/index.ts
+++ b/packages/blend/lib/components/MultiSelect/index.ts
@@ -1,3 +1,4 @@
 export { default as MultiSelect } from './MultiSelect'
 export { default as MultiSelectTrigger } from './MultiSelectTrigger'
+export * from './multiSelect.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Popover/index.ts
+++ b/packages/blend/lib/components/Popover/index.ts
@@ -1,2 +1,3 @@
 export { default as Popover } from './Popover'
+export * from './popover.tokens'
 export * from './types'

--- a/packages/blend/lib/components/ProgressBar/index.ts
+++ b/packages/blend/lib/components/ProgressBar/index.ts
@@ -1,2 +1,3 @@
 export { default as ProgressBar } from './ProgressBar'
+export * from './progressbar.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Sidebar/index.ts
+++ b/packages/blend/lib/components/Sidebar/index.ts
@@ -1,2 +1,3 @@
 export { default as Sidebar } from './Sidebar'
+export * from './sidebar.tokens'
 export * from './types'

--- a/packages/blend/lib/components/SingleSelect/index.ts
+++ b/packages/blend/lib/components/SingleSelect/index.ts
@@ -1,2 +1,3 @@
 export { default as SingleSelect } from './SingleSelect'
+export * from './singleSelect.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Snackbar/index.ts
+++ b/packages/blend/lib/components/Snackbar/index.ts
@@ -1,3 +1,4 @@
 export { default as Snackbar } from './Snackbar'
 export { addSnackbar } from './Snackbar'
+export * from './snackbar.tokens'
 export * from './types'

--- a/packages/blend/lib/components/StatCard/index.ts
+++ b/packages/blend/lib/components/StatCard/index.ts
@@ -1,2 +1,3 @@
 export { default as StatCard } from './StatCard'
+export * from './statcard.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Stepper/index.ts
+++ b/packages/blend/lib/components/Stepper/index.ts
@@ -1,2 +1,3 @@
 export { default as Stepper } from './Stepper'
+export * from './stepper.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Tags/index.ts
+++ b/packages/blend/lib/components/Tags/index.ts
@@ -1,2 +1,3 @@
 export { default as Tag } from './Tag'
+export * from './tag.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Tooltip/index.ts
+++ b/packages/blend/lib/components/Tooltip/index.ts
@@ -1,2 +1,3 @@
 export { default as Tooltip } from './Tooltip'
+export * from './tooltip.tokens'
 export * from './types'

--- a/packages/blend/lib/components/Topbar/index.ts
+++ b/packages/blend/lib/components/Topbar/index.ts
@@ -1,2 +1,3 @@
 export { default as Topbar } from './Topbar'
+export * from './topbar.tokens'
 export type { TopbarProps, MerchantInfo } from './types'

--- a/packages/blend/lib/components/Upload/index.ts
+++ b/packages/blend/lib/components/Upload/index.ts
@@ -1,2 +1,4 @@
 export { default as Upload } from './Upload'
+export type { UploadTokenType, ResponsiveUploadTokens } from './upload.tokens'
+export { getUploadTokens } from './upload.tokens'
 export * from './types'


### PR DESCRIPTION
### Summary

1. Fix for The overflow hidden class is making our floating components to hide
2. adding exports in component index for tokens

### Issue Ticket

Closes #910 
Closes #911 

Screenshot for accordion fix:

<img width="1579" height="673" alt="Screenshot 2025-12-29 at 1 17 38 PM" src="https://github.com/user-attachments/assets/e8b6ef23-1664-4bfe-b4af-14f42d2cf37d" />


