### PR TITLE
feat: Add showBorder prop to StatCard

### DIFF
--- a/apps/ascent/app/docs/content/components/stat-card.mdx
+++ b/apps/ascent/app/docs/content/components/stat-card.mdx
@@ -247,6 +247,15 @@ function MyComponent() {
         ],
         [
             {
+                content: 'StatCard.showBorder',
+                hintText:
+                    'Optional boolean to control whether the stat card displays a border. When set to false, the card appears without a border. Defaults to true, maintaining backward compatibility with existing implementations.',
+            },
+            { content: 'boolean', hintText: 'boolean' },
+            { content: 'true (default), false' },
+        ],
+        [
+            {
                 content: 'StatCardChange.value',
                 hintText: 'The percentage change value',
             },

--- a/apps/site/src/demos/StatCardDemo.tsx
+++ b/apps/site/src/demos/StatCardDemo.tsx
@@ -52,6 +52,7 @@ const StatCardDemo = () => {
     const [showSkeleton, setShowSkeleton] = useState(false)
 
     const [dataDisplay, setDataDisplay] = useState(true)
+    const [showBorder, setShowBorder] = useState(true)
     // Sample chart data
     const sampleLineData = [
         { value: 100, name: 'JAN' },
@@ -269,8 +270,13 @@ const StatCardDemo = () => {
                             checked={dataDisplay}
                             onChange={() => setDataDisplay(!dataDisplay)}
                         />
+                        <Switch
+                            label="Show Border"
+                            checked={showBorder}
+                            onChange={() => setShowBorder(!showBorder)}
+                        />
                     </div>
-                    <div className="w-[350px]">
+                    <div className="w-87.5">
                         <StatCard
                             skeleton={{
                                 show: showSkeleton,
@@ -332,6 +338,7 @@ const StatCardDemo = () => {
                                       : undefined
                             }
                             dataDisplay={dataDisplay}
+                            showBorder={showBorder}
                             progressValue={
                                 playgroundVariant ===
                                 StatCardVariant.PROGRESS_BAR

--- a/apps/storybook/stories/components/StatCard/StatCard.stories.tsx
+++ b/apps/storybook/stories/components/StatCard/StatCard.stories.tsx
@@ -131,6 +131,11 @@ import { StatCard, StatCardVariant, ChangeType } from '@juspay/blend-design-syst
             control: 'text',
             description: 'Tooltip text for the help icon',
         },
+        showBorder: {
+            control: 'boolean',
+            description: 'Control whether the stat card displays a border',
+            defaultValue: true,
+        },
     },
     tags: ['autodocs'],
 }

--- a/packages/blend/lib/components/StatCard/StatCard.tsx
+++ b/packages/blend/lib/components/StatCard/StatCard.tsx
@@ -68,6 +68,7 @@ const StatCard = ({
     direction = StatCardDirection.VERTICAL,
     skeleton,
     dataDisplay = true,
+    showBorder = true,
     ...props
 }: StatCardProps) => {
     const statCardToken = useResponsiveTokens<StatCardTokenType>('STAT_CARD')
@@ -328,11 +329,11 @@ const StatCard = ({
                 height={
                     height && !isSmallScreen ? height : statCardToken.height
                 }
-                border={statCardToken.border}
+                border={showBorder ? statCardToken.border : undefined}
                 borderRadius={statCardToken.borderRadius}
                 overflow="hidden"
                 backgroundColor={statCardToken.backgroundColor}
-                boxShadow={statCardToken.boxShadow}
+                boxShadow={showBorder ? statCardToken.boxShadow : undefined}
                 padding={`${statCardToken.padding.y} ${statCardToken.padding.x}`}
                 display="flex"
                 flexDirection="column"
@@ -534,11 +535,11 @@ const StatCard = ({
     return (
         <Block
             height={height && !isSmallScreen ? height : statCardToken.height}
-            border={statCardToken.border}
+            border={showBorder ? statCardToken.border : undefined}
             borderRadius={statCardToken.borderRadius}
             overflow="hidden"
             backgroundColor={statCardToken.backgroundColor}
-            boxShadow={statCardToken.boxShadow}
+            boxShadow={showBorder ? statCardToken.boxShadow : undefined}
             padding={`${statCardToken.padding.y} ${statCardToken.padding.x}`}
             display="flex"
             flexDirection="column"

--- a/packages/blend/lib/components/StatCard/types.ts
+++ b/packages/blend/lib/components/StatCard/types.ts
@@ -78,4 +78,5 @@ export type StatCardProps = {
     direction?: StatCardDirection
     skeleton?: StatCardSkeletonProps
     dataDisplay?: boolean
+    showBorder?: boolean
 }


### PR DESCRIPTION

### Summary

- Add props to show hide the border in statcard

### Issue Ticket

Closes #940 


<img width="702" height="433" alt="Screenshot 2026-01-05 at 6 36 41 PM" src="https://github.com/user-attachments/assets/314c6374-e9a2-43d4-8787-9d0cab3b33a2" />
