### PR TITLE
fix: data table column msnager selection removed on close

### DIFF
--- a/apps/ascent/app/docs/content/components/multi-select.mdx
+++ b/apps/ascent/app/docs/content/components/multi-select.mdx
@@ -801,6 +801,19 @@ function MyComponent() {
         ],
         [
             {
+                content: 'MultiSelect.onOpenChange',
+                hintText:
+                    'Optional callback function invoked when the dropdown menu or mobile drawer opens or closes. Receives a boolean indicating the new open state. Useful for resetting internal state when the menu is dismissed without applying changes.',
+            },
+            {
+                content: '(open: boolean) => void',
+                hintText:
+                    'Function called with boolean open state when menu visibility changes',
+            },
+            { content: '' },
+        ],
+        [
+            {
                 content: 'MultiSelectMenuGroupType.groupLabel',
                 hintText:
                     'Optional string label displayed above the menu items in this group. Provides a heading or category name for organizing related items (e.g., "Frontend", "Backend", "Tools"). The label is styled distinctly from menu items.',

--- a/apps/storybook/stories/components/MultiSelect.stories.tsx
+++ b/apps/storybook/stories/components/MultiSelect.stories.tsx
@@ -412,6 +412,15 @@ const [selectedValues, setSelectedValues] = useState<string[]>([]);
                 category: 'Behavior',
             },
         },
+        onOpenChange: {
+            action: 'open-change',
+            description:
+                'Callback function invoked when the dropdown menu or mobile drawer opens or closes. Receives a boolean indicating the new open state.',
+            table: {
+                type: { summary: '(open: boolean) => void' },
+                category: 'Behavior',
+            },
+        },
     },
     tags: ['autodocs'],
 }

--- a/packages/blend/lib/components/DataTable/ColumnManager.tsx
+++ b/packages/blend/lib/components/DataTable/ColumnManager.tsx
@@ -178,6 +178,15 @@ export const ColumnManager = <T extends Record<string, unknown>>({
         }, 100)
     }
 
+    const handleOpenChange = (open: boolean) => {
+        if (!open && hasPrimaryAction) {
+            // Reset pending state to match actual visible columns when modal closes
+            setPendingSelectedColumns(
+                visibleColumns.map((col) => String(col.field))
+            )
+        }
+    }
+
     const customTrigger = (
         <PrimitiveButton
             ref={(el) => {
@@ -248,6 +257,7 @@ export const ColumnManager = <T extends Record<string, unknown>>({
         secondaryAction: columnManagerSecondaryAction,
         disabled,
         onBlur: handleMenuClose,
+        onOpenChange: handleOpenChange,
     }
 
     return (

--- a/packages/blend/lib/components/MultiSelect/MobileMultiSelect.tsx
+++ b/packages/blend/lib/components/MultiSelect/MobileMultiSelect.tsx
@@ -335,6 +335,7 @@ const MobileMultiSelect: React.FC<MobileMultiSelectProps> = ({
     minTriggerWidth,
     allowCustomValue = false,
     customValueLabel = 'Specify',
+    onOpenChange,
 }) => {
     const { breakPointLabel } = useBreakpoints(BREAKPOINTS)
     const isSmallScreen = breakPointLabel === 'sm'
@@ -420,6 +421,7 @@ const MobileMultiSelect: React.FC<MobileMultiSelectProps> = ({
                             setSearchText('')
                         }
                     }
+                    onOpenChange?.(isOpen)
                 }}
             >
                 <DrawerTrigger>

--- a/packages/blend/lib/components/MultiSelect/MultiSelect.tsx
+++ b/packages/blend/lib/components/MultiSelect/MultiSelect.tsx
@@ -94,6 +94,7 @@ const MultiSelect = ({
     customValueLabel = 'Specify',
     showClearButton,
     onClearAllClick,
+    onOpenChange,
 }: MultiSelectProps) => {
     const { breakPointLabel } = useBreakpoints(BREAKPOINTS)
     const isSmallScreen = breakPointLabel === 'sm'
@@ -218,6 +219,7 @@ const MultiSelect = ({
                 skeleton={skeleton}
                 allowCustomValue={allowCustomValue}
                 customValueLabel={customValueLabel}
+                onOpenChange={onOpenChange}
             />
         )
     }
@@ -311,6 +313,7 @@ const MultiSelect = ({
                                 } else {
                                     onBlur?.()
                                 }
+                                onOpenChange?.(isOpen)
                             }}
                             showActionButtons={shouldShowActionButtons}
                             primaryAction={

--- a/packages/blend/lib/components/MultiSelect/types.ts
+++ b/packages/blend/lib/components/MultiSelect/types.ts
@@ -117,6 +117,7 @@ export type MultiSelectProps = {
     inline?: boolean
     onBlur?: () => void
     onFocus?: () => void
+    onOpenChange?: (open: boolean) => void
 
     // error
     error?: boolean


### PR DESCRIPTION
### Summary
This PR fixes a state persistence bug in the DataTable's Column Manager where temporary column selections were retained even if the modal was closed without clicking "Apply".
<!-- Write a brief summary of your changes -->
The ColumnManager  relies on the onOpenChange callback from the MultiSelect component to reset its internal "staged" selections back to the actual visible columns when the dropdown/drawer is closed. However, the MultiSelect
 component was not propagating this prop to its internal UI elements (desktop menu and mobile drawer), causing a communication gap that prevented the reset logic from triggering.

### Issue Ticket
Added onOpenChange support to MultiSelectProps and the main MultiSelect component. Implemented propagation of the onOpenChange event in both MultiSelect.tsx (desktop flow) and MobileMultiSelect.tsx (mobile drawer flow).
This ensures that when a user dismisses the column manager (via outside click, Escape key, or mobile close actions), the component correctly reverts to the last applied state.
Closes #[issue_number] or Related to #[issue_number]

https://github.com/juspay/blend-design-system/issues/952