### PR TITLE
fix: added gap between arrow and value in delta value in stat card

### DIFF
--- a/packages/blend/lib/components/StatCard/StatCard.tsx
+++ b/packages/blend/lib/components/StatCard/StatCard.tsx
@@ -209,6 +209,7 @@ const StatCard = ({
                       <Block
                           display="flex"
                           alignItems="center"
+                          gap={3}
                           color={
                               effectiveChange.valueType === ChangeType.INCREASE
                                   ? statCardToken.textContainer.stats.title


### PR DESCRIPTION
### Summary

added gap between arrow and value in delta value in stat card

### Issue Ticket

Closes #1090 
<img width="361" height="178" alt="Screenshot 2026-02-05 at 1 27 04 PM" src="https://github.com/user-attachments/assets/16be65ed-aa7e-4319-92ff-80c128c3dd32" />

