### PR TITLE
fix: modal zindex wrt drawer

### DIFF
--- a/apps/site/src/demos/DrawerDemo.tsx
+++ b/apps/site/src/demos/DrawerDemo.tsx
@@ -40,7 +40,7 @@ import {
 } from '../../../../packages/blend/lib/components/SingleSelect'
 import { addSnackbar } from '../../../../packages/blend/lib/components/Snackbar'
 import { Code, Database, Search, Server, User, X } from 'lucide-react'
-import { SearchInput } from '../../../../packages/blend/lib/main'
+import { Modal, SearchInput } from '../../../../packages/blend/lib/main'
 const simpleItems: SelectMenuGroupType[] = [
     {
         items: [
@@ -337,7 +337,7 @@ export const NestedDrawerExample = () => {
 export const SideDrawerExample = () => {
     const [basicIconSelected, setBasicIconSelected] = useState('')
     const [basicSimpleSelected, setBasicSimpleSelected] = useState<string[]>([])
-
+    const [isModalOpen, setIsModalOpen] = useState(false)
     // Helper function to handle multi-select changes
     const handleMultiSelectChange =
         (
@@ -357,7 +357,7 @@ export const SideDrawerExample = () => {
         }
 
     return (
-        <Drawer direction="right">
+        <Drawer direction="right" dismissible={isModalOpen ? false : true}>
             <DrawerTrigger>
                 <button
                     style={{
@@ -401,6 +401,44 @@ export const SideDrawerExample = () => {
                                 gap: '16px',
                             }}
                         >
+                            <Button
+                                text="Open Modal"
+                                onClick={() => {
+                                    setIsModalOpen(!isModalOpen)
+                                }}
+                            />
+                            <Modal
+                                isOpen={isModalOpen}
+                                onClose={() => {
+                                    setIsModalOpen(false)
+                                }}
+                                title="Modal Title"
+                                subtitle="Modal Subtitle"
+                            >
+                                <div>
+                                    <h1
+                                        onClick={(e) => {
+                                            console.log('hello------->>>')
+                                            e.stopPropagation()
+                                        }}
+                                    >
+                                        Modal Content
+                                    </h1>
+                                    <SingleSelect
+                                        items={simpleItems}
+                                        selected={basicIconSelected}
+                                        onSelect={(value) => {
+                                            setBasicIconSelected(value)
+                                            addSnackbar({
+                                                header: `Icon Selected: ${value}`,
+                                            })
+                                        }}
+                                        placeholder="Select user"
+                                        slot={<User size={16} />}
+                                    />
+                                </div>
+                            </Modal>
+
                             <SingleSelect
                                 label="User Selection"
                                 items={simpleItems}

--- a/packages/blend/lib/components/Modal/Modal.tsx
+++ b/packages/blend/lib/components/Modal/Modal.tsx
@@ -301,15 +301,13 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
                 >
                     <AnimatedBackdrop
                         onClick={handleBackdropClick}
-                        display="flex"
-                        alignItems="center"
-                        justifyContent="center"
-                        position="fixed"
+                        position="absolute"
                         inset={0}
                         backgroundColor={FOUNDATION_THEME.colors.gray[700]}
                         pointerEvents="auto"
                         role="presentation"
                         aria-hidden="true"
+                        zIndex={0}
                         $isAnimatingIn={isAnimatingIn}
                     />
 
@@ -331,6 +329,8 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
                         aria-labelledby={titleId}
                         aria-label={title || 'Modal dialog'}
                         aria-describedby={ariaDescribedBy}
+                        zIndex={1}
+                        pointerEvents="auto"
                         $isAnimatingIn={isAnimatingIn}
                     >
                         <ModalHeader

--- a/packages/blend/lib/components/Modal/modal.utils.ts
+++ b/packages/blend/lib/components/Modal/modal.utils.ts
@@ -7,7 +7,8 @@ export const getPortalContainer = (): HTMLElement => {
         portalContainer = document.createElement('div')
         portalContainer.id = PORTAL_ID
         portalContainer.style.position = 'relative'
-        portalContainer.style.zIndex = '99'
+        portalContainer.style.zIndex = '101'
+        portalContainer.style.pointerEvents = 'auto'
         document.body.appendChild(portalContainer)
     }
 


### PR DESCRIPTION
### Summary

fixed modal zIndex wrt to drawer


Misc: If the drawer closes on clicking outside the modal 
 `<Drawer direction="right" dismissible={isModalOpen ? false : true}>`
 use the above snippet to handle it

Tests: 
tested mulitple modal component occurance wrt to drawer and without drawer also tested the single/mulit select inside modal 

### Issue Ticket

Closes  #1118 

https://github.com/user-attachments/assets/a46df48f-73a3-4fb8-989c-47f58521234d

