### PR TITLE
feat: enable SPA navigation while preserving native anchor behavior

### DIFF
--- a/apps/site/src/demos/SidebarDemo.tsx
+++ b/apps/site/src/demos/SidebarDemo.tsx
@@ -678,6 +678,7 @@ const SidebarDemo = () => {
                             setTopbarVisible(true)
                         }
                     },
+                    href: '/icons/?search=copy',
                     showOnMobile: true,
                 },
                 {

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -75,3 +75,39 @@ export const handleKeyDown = (
         onNavigate('up', index)
     }
 }
+
+export const handleClientSideNavigation = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    href: string,
+    onNavigate?: (href: string) => void
+): boolean => {
+    if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
+        event.currentTarget.target === '_blank'
+    ) {
+        return false
+    }
+
+    // Check if it's an external URL (starts with http://, https://, or //)
+    const isExternalUrl = /^https?:\/\//.test(href) || href.startsWith('//')
+
+    if (isExternalUrl) {
+        // For external URLs, let the browser handle the navigation normally
+        // Don't call event.preventDefault() - allow default anchor behavior
+        return false
+    }
+
+    event.preventDefault()
+    window.history.pushState({}, '', href)
+
+    if (onNavigate) {
+        onNavigate(href)
+    }
+
+    return true
+}


### PR DESCRIPTION
Summary
Applied anchor tag for sidebar directory to achieve
. right-click → Open in new tab
. Cmd/Ctrl + Click → Open in new tab
. Normal click -> mimics router.push
. Supports external link 


https://github.com/user-attachments/assets/04735b1e-72c6-4774-8d90-4a01e9661114


https://github.com/user-attachments/assets/80a7beff-b8e2-4dd0-957d-7170dd51f3b6

Issue Ticket
Closes https://github.com/juspay/blend-design-system/issues/1164