### PR TITLE
feat: add showBulkActionBar prop to DataTable and update documentation

### DIFF
--- a/apps/ascent/app/docs/content/components/data-table.mdx
+++ b/apps/ascent/app/docs/content/components/data-table.mdx
@@ -1031,7 +1031,7 @@ function CompactTable() {
             {
                 content: 'enableRowSelection',
                 hintText:
-                    'When true, enables row selection with checkboxes in the first column. Users can select individual rows or use "select all" functionality. Selected rows can trigger bulk actions. Requires bulkActions to be provided for actions to appear. Defaults to false.',
+                    'When true, enables row selection with checkboxes in the first column. Users can select individual rows or use "select all" functionality. Selected rows can trigger bulk actions when showBulkActionBar is true. Defaults to false.',
             },
             {
                 content: 'boolean',
@@ -1039,6 +1039,19 @@ function CompactTable() {
                     'true enables row selection, false disables selection checkboxes',
             },
             { content: '' },
+        ],
+        [
+            {
+                content: 'showBulkActionBar',
+                hintText:
+                    'When true (default), the bulk action bar is shown when rows are selected, with Export, Deselect all, and custom actions. When false, the bulk action bar is hidden while checkbox selection remains available. Use when you need selection state (e.g. via onRowSelectionChange) but do not want to show the bulk actions UI.',
+            },
+            {
+                content: 'boolean',
+                hintText:
+                    'true shows bulk action bar when rows are selected (default), false hides it',
+            },
+            { content: 'true' },
         ],
         [
             {

--- a/apps/site/src/demos/dataTableDemo.tsx
+++ b/apps/site/src/demos/dataTableDemo.tsx
@@ -3425,9 +3425,11 @@ const DataTableDemo = () => {
                         <code>tableBodyHeight</code> property. This creates a
                         fixed-height table with scrollable content, perfect for
                         dashboard layouts or when you need consistent table
-                        dimensions. The table below has a fixed height of{' '}
-                        <strong>400px</strong> - try scrolling within the table
-                        body!
+                        dimensions. The table below has a fixed height with
+                        scrollable content. It uses{' '}
+                        <code>showBulkActionBar={'{false}'}</code> so checkbox
+                        selection is available without the bulk action bar
+                        (download, deselect all).
                     </p>
                 </div>
 
@@ -3447,6 +3449,7 @@ const DataTableDemo = () => {
                     enableInlineEdit={false}
                     enableRowExpansion={false}
                     enableRowSelection={true}
+                    showBulkActionBar={false}
                     enableColumnManager={false}
                     showSettings={false}
                     columnFreeze={0}
@@ -3458,11 +3461,6 @@ const DataTableDemo = () => {
                         pageSizeOptions: [20, 50, 100],
                     }}
                     onRowSelectionChange={handleRowSelectionChange}
-                    bulkActions={{
-                        // showExport defaults to true - Export button will be shown
-                        // Set to false to hide it and only show customActions
-                        showExport: true,
-                    }}
                     headerSlot1={
                         <Button
                             text="Settings"

--- a/packages/blend/lib/components/DataTable/DataTable.tsx
+++ b/packages/blend/lib/components/DataTable/DataTable.tsx
@@ -116,6 +116,7 @@ const DataTable = forwardRef(
             enableInlineEdit = false,
             enableRowExpansion = false,
             enableRowSelection = false,
+            showBulkActionBar = true,
             onRowSelectionChange,
             renderExpandedRow,
             isRowExpandable,
@@ -1372,13 +1373,15 @@ const DataTable = forwardRef(
                         overflow: 'auto',
                     }}
                 >
-                    <BulkActionBar
-                        selectedCount={selectedCount}
-                        onExport={exportToCSV}
-                        onDeselectAll={handleDeselectAll}
-                        customActions={renderBulkActions()}
-                        showExport={bulkActions?.showExport}
-                    />
+                    {showBulkActionBar && (
+                        <BulkActionBar
+                            selectedCount={selectedCount}
+                            onExport={exportToCSV}
+                            onDeselectAll={handleDeselectAll}
+                            customActions={renderBulkActions()}
+                            showExport={bulkActions?.showExport}
+                        />
+                    )}
                     <Block
                         id={statusRegionId}
                         role="status"

--- a/packages/blend/lib/components/DataTable/types.ts
+++ b/packages/blend/lib/components/DataTable/types.ts
@@ -413,6 +413,7 @@ export type DataTableProps<T extends Record<string, unknown>> = {
     ) => void
 
     enableRowSelection?: boolean
+    showBulkActionBar?: boolean
     onRowSelectionChange?: (
         selectedRowIds: string[],
         isSelected: boolean,


### PR DESCRIPTION
### Summary

Add a prop to show and hide the bulk action bar

### Issue Ticket

Closes #1240

<img width="1725" height="1082" alt="Screenshot 2026-03-10 at 5 10 28 PM" src="https://github.com/user-attachments/assets/565892a1-e2df-4b23-a514-f74791314f3e" />
