### PR TITLE
fix: drawer overlay is same as modal overlay

### DIFF
--- a/apps/site/src/demos/SidebarDemo.tsx
+++ b/apps/site/src/demos/SidebarDemo.tsx
@@ -224,7 +224,7 @@ const SidebarDemo = () => {
         | 'tooltipV2'
         | 'singleSelectV2'
         | 'popoverV2'
-    >('statCardV2')
+    >('drawer')
 
     const [activeTenant, setActiveTenant] = useState<string>('Juspay')
     const [activeMerchant, setActiveMerchant] =

--- a/packages/blend/lib/components/Drawer/components/DrawerBase.tsx
+++ b/packages/blend/lib/components/Drawer/components/DrawerBase.tsx
@@ -44,8 +44,16 @@ const DrawerOpenChangeContext =
 const StyledOverlay = styled(VaulDrawer.Overlay)<{ tokens: DrawerTokensType }>`
     position: fixed;
     inset: 0;
-    background-color: ${({ tokens }) => tokens.overlay.backgroundColor};
     z-index: 99;
+    background: transparent;
+
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: ${({ tokens }) => tokens.overlay.backgroundColor};
+        opacity: ${({ tokens }) => tokens.overlay.opacity};
+    }
 `
 
 const StyledContent = styled(VaulDrawer.Content)<{

--- a/packages/blend/lib/components/Drawer/drawer.tokens.ts
+++ b/packages/blend/lib/components/Drawer/drawer.tokens.ts
@@ -38,6 +38,7 @@ export type DrawerTokensType = {
     // Overlay section
     overlay: {
         backgroundColor: CSSObject['backgroundColor']
+        opacity: CSSObject['opacity']
     }
 
     offset: {
@@ -82,7 +83,8 @@ export const getDrawerComponentTokens = (
             // border: `1px solid ${foundationToken.colors.gray[200]}`,
 
             overlay: {
-                backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                backgroundColor: foundationToken.colors.gray[700],
+                opacity: foundationToken.opacity[50],
             },
             offset: {
                 top: '74px',
@@ -115,7 +117,8 @@ export const getDrawerComponentTokens = (
             // border: `1px solid ${foundationToken.colors.gray[200]}`,
 
             overlay: {
-                backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                backgroundColor: foundationToken.colors.gray[700],
+                opacity: foundationToken.opacity[50],
             },
             offset: {
                 top: '74px',


### PR DESCRIPTION
### Summary
<img width="1728" height="1117" alt="Screenshot 2026-03-25 at 1 53 55 PM" src="https://github.com/user-attachments/assets/875c755d-6e93-44d5-adf2-023555499c99" />
<img width="1728" height="1117" alt="Screenshot 2026-03-25 at 1 54 13 PM" src="https://github.com/user-attachments/assets/6a0cd229-8781-463d-aff5-ce557dcaf647" />

drawer overlay is same as modal overlay

### Issue Ticket

Closes #1287 
