### PR TITLE
fix: Directory token wiring, Text fontSize, select group label margin

### DIFF
--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -64,6 +64,22 @@ const StyledElement = styled(Block)<{
     }
 `
 
+const IconWrapper = styled.div<{ $tokens: DirectoryTokenType }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: ${({ $tokens }) => $tokens.section.itemList.item.icon.width};
+    height: ${({ $tokens }) => $tokens.section.itemList.item.icon.width};
+
+    & > svg {
+        width: ${({ $tokens }) =>
+            $tokens.section.itemList.item.icon.width} !important;
+        height: ${({ $tokens }) =>
+            $tokens.section.itemList.item.icon.width} !important;
+    }
+`
+
 const ChevronWrapper = styled(Block)<{
     $isExpanded: boolean
     $tokens: DirectoryTokenType
@@ -74,8 +90,10 @@ const ChevronWrapper = styled(Block)<{
     margin-left: auto;
 
     & > svg {
-        width: ${({ $tokens }) => $tokens.section.itemList.item.chevron.width};
-        height: ${({ $tokens }) => $tokens.section.itemList.item.chevron.width};
+        width: ${({ $tokens }) =>
+            $tokens.section.itemList.item.chevron.width} !important;
+        height: ${({ $tokens }) =>
+            $tokens.section.itemList.item.chevron.width} !important;
         transition: transform 150ms;
         transform: ${({ $isExpanded }) =>
             $isExpanded ? 'rotate(180deg)' : 'rotate(0)'};
@@ -267,17 +285,22 @@ const NavItem = ({
                 )
             }
             if (React.isValidElement(item.leftSlot)) {
-                return React.cloneElement(
-                    item.leftSlot as React.ReactElement<
-                        React.SVGProps<SVGSVGElement>
-                    >,
-                    {
-                        color: isActive
-                            ? tokens.section.itemList.item.color.active
-                            : tokens.section.itemList.item.color.default,
-                        width: 20,
-                        height: 20,
-                    }
+                return (
+                    <IconWrapper $tokens={tokens}>
+                        {React.cloneElement(
+                            item.leftSlot as React.ReactElement<
+                                React.SVGProps<SVGSVGElement> & {
+                                    size?: number
+                                }
+                            >,
+                            {
+                                color: isActive
+                                    ? tokens.section.itemList.item.color.active
+                                    : tokens.section.itemList.item.color
+                                          .default,
+                            }
+                        )}
+                    </IconWrapper>
                 )
             }
             return null
@@ -289,13 +312,15 @@ const NavItem = ({
                     display="flex"
                     alignItems="center"
                     justifyContent="flex-start"
-                    gap="8px"
+                    gap={tokens.section.itemList.item.gap}
                 >
                     {item.leftSlot && React.isValidElement(item.leftSlot) && (
-                        <Block aria-hidden="true">
+                        <IconWrapper aria-hidden="true" $tokens={tokens}>
                             {React.cloneElement(
                                 item.leftSlot as React.ReactElement<
-                                    React.SVGProps<SVGSVGElement>
+                                    React.SVGProps<SVGSVGElement> & {
+                                        size?: number
+                                    }
                                 >,
                                 {
                                     color: isActive
@@ -305,11 +330,13 @@ const NavItem = ({
                                               .default,
                                 }
                             )}
-                        </Block>
+                        </IconWrapper>
                     )}
                     <Text
                         as="span"
                         variant="body.md"
+                        fontWeight={tokens.section.itemList.item.fontWeight}
+                        fontSize={tokens.section.itemList.item.fontSize}
                         color={
                             isActive
                                 ? tokens.section.itemList.item.color.active

--- a/packages/blend/lib/components/Directory/Section.tsx
+++ b/packages/blend/lib/components/Directory/Section.tsx
@@ -22,15 +22,20 @@ const useSectionState = () => {
 
 export { SectionStateContext }
 
-const ChevronWrapper = styled(Block)<{ $isOpen: boolean }>`
+const ChevronWrapper = styled(Block)<{
+    $isOpen: boolean
+    $tokens: DirectoryTokenType
+}>`
     display: flex;
     align-items: center;
     justify-content: center;
     margin-left: auto;
 
     & > svg {
-        width: 16px;
-        height: 16px;
+        width: ${({ $tokens }) =>
+            $tokens.section.header.chevron.width} !important;
+        height: ${({ $tokens }) =>
+            $tokens.section.header.chevron.width} !important;
         transition: transform 150ms;
         transform: ${({ $isOpen }) =>
             $isOpen ? 'rotate(180deg)' : 'rotate(0)'};
@@ -184,14 +189,18 @@ const Section = ({
                         variant="body.sm"
                         color={tokens.section.header.label.color}
                         fontWeight={tokens.section.header.label.fontWeight}
+                        fontSize={tokens.section.header.label.fontSize}
                     >
                         {section.label.toUpperCase()}
                     </Text>
                     {isCollapsible && (
-                        <ChevronWrapper $isOpen={isOpen} aria-hidden="true">
+                        <ChevronWrapper
+                            $isOpen={isOpen}
+                            $tokens={tokens}
+                            aria-hidden="true"
+                        >
                             <ChevronDown
                                 color={tokens.section.header.chevron.color}
-                                size={tokens.section.header.chevron.width}
                             />
                         </ChevronWrapper>
                     )}

--- a/packages/blend/lib/components/Directory/directory.tokens.ts
+++ b/packages/blend/lib/components/Directory/directory.tokens.ts
@@ -204,7 +204,7 @@ export const getDirectoryTokens = (
                     label: {
                         fontSize: foundationToken.font.size.body.sm.fontSize,
                         color: foundationToken.colors.gray[400],
-                        fontWeight: 500,
+                        fontWeight: 600,
                     },
                     chevron: {
                         width: foundationToken.unit[16],
@@ -220,7 +220,7 @@ export const getDirectoryTokens = (
                             x: foundationToken.unit[12],
                             y: foundationToken.unit[6],
                         },
-                        gap: foundationToken.unit[12],
+                        gap: foundationToken.unit[10],
                         borderRadius: foundationToken.border.radius[4],
                         fontWeight: 500,
                         fontSize: foundationToken.font.size.body.md.fontSize,
@@ -239,7 +239,7 @@ export const getDirectoryTokens = (
                         },
 
                         icon: {
-                            width: foundationToken.unit[20],
+                            width: foundationToken.unit[14],
                         },
 
                         chevron: {

--- a/packages/blend/lib/components/SingleSelect/SingleSelectMenu.tsx
+++ b/packages/blend/lib/components/SingleSelect/SingleSelectMenu.tsx
@@ -305,7 +305,7 @@ const Item = ({
 }
 
 const Label = styled(RadixMenu.Label)(() => ({
-    margin: '0px 8px',
+    margin: '0',
     padding: '8px 6px',
     userSelect: 'none',
     textTransform: 'uppercase',

--- a/packages/blend/lib/components/SingleSelectV2/singleSelectV2.dark.tokens.ts
+++ b/packages/blend/lib/components/SingleSelectV2/singleSelectV2.dark.tokens.ts
@@ -239,7 +239,7 @@ export const getSingleSelectV2DarkTokens = (
                 },
             },
             groupLabel: {
-                margin: `0 ${foundationToken.unit[8]}`,
+                margin: '0',
                 paddingTop: foundationToken.unit[8],
                 paddingRight: foundationToken.unit[6],
                 paddingBottom: foundationToken.unit[8],

--- a/packages/blend/lib/components/SingleSelectV2/singleSelectV2.light.tokens.ts
+++ b/packages/blend/lib/components/SingleSelectV2/singleSelectV2.light.tokens.ts
@@ -239,7 +239,7 @@ export const getSingleSelectV2LightTokens = (
                 },
             },
             groupLabel: {
-                margin: `0 ${foundationToken.unit[8]}`,
+                margin: '0',
                 paddingTop: foundationToken.unit[8],
                 paddingRight: foundationToken.unit[6],
                 paddingBottom: foundationToken.unit[8],

--- a/packages/blend/lib/components/Text/Text.tsx
+++ b/packages/blend/lib/components/Text/Text.tsx
@@ -131,7 +131,7 @@ const Text = ({
     return (
         <PrimitiveText
             as={Tag}
-            fontSize={fontGroup?.fontSize}
+            fontSize={fontSize ?? fontGroup?.fontSize}
             lineHeight={formatLineHeight(fontGroup?.lineHeight)}
             fontWeight={fontWeight}
             color={color ?? 'inherit'}


### PR DESCRIPTION
### Summary

Fixes **Directory** so `directory.tokens` actually controls typography, spacing, and icon sizes, and fixes **Text** so explicit `fontSize` is not overridden by `variant`. Lucide icons apply size via **inline `style`**, which was beating normal CSS; we override that with `!important` on wrapper rules so token-driven dimensions win.

Removes horizontal **8px margin** on SingleSelect / SingleSelectV2 menu **group labels** so labels align with menu content padding.

## Changes

### `packages/blend/lib/components/Text/Text.tsx`

- When both `variant` and `fontSize` are set, **`fontSize` now takes precedence** (`fontSize ?? fontGroup?.fontSize` on `PrimitiveText`). This lets consumers and Directory pass token-based sizes without the variant silently overriding them.

### `packages/blend/lib/components/Directory/NavItem.tsx`

- **`IconWrapper`**: Wraps `leftSlot` icons with a flex box sized from `section.itemList.item.icon.width`; targets direct child `svg` with the same width/height from tokens.
- **Lucide / inline styles**: Adds **`!important`** on `IconWrapper > svg` width/height so design-token CSS overrides Lucide’s inline `width`/`height` (otherwise the SVG stayed at e.g. 16px while the wrapper grew).
- **Item label**: Passes **`fontWeight`** and **`fontSize`** from `section.itemList.item` into `Text` (not only on the row container).
- **Spacing**: Inner row **`gap`** uses `tokens.section.itemList.item.gap` instead of a hardcoded value.
- **Item chevron**: `ChevronWrapper > svg` uses token **`section.itemList.item.chevron.width`** with **`!important`** for the same Lucide inline-style reason.
- **Icon-only mode**: Uses `IconWrapper` around the cloned icon for consistent sizing with the labeled row.

### `packages/blend/lib/components/Directory/Section.tsx`

- **Section label**: Passes **`fontSize={tokens.section.header.label.fontSize}`** to `Text` instead of relying only on `variant` for size.
- **Header chevron**: `ChevronWrapper` receives **`$tokens`**; chevron SVG size comes from **`section.header.chevron.width`** (no fixed 16px). **`!important`** on `> svg` width/height so Lucide inline styles do not override tokens.

### `packages/blend/lib/components/Directory/directory.tokens.ts`

- Token tweaks as part of this work (e.g. section label weight, item list gap, item icon width)—adjust in PR if further design review changes values.

### `packages/blend/lib/components/SingleSelect/SingleSelectMenu.tsx`

- **Group label** (`Label` styled `RadixMenu.Label`): horizontal margin removed — **`margin: '0'`** (was `'0px 8px'`). Padding unchanged (`8px 6px`).

### `packages/blend/lib/components/SingleSelectV2/singleSelectV2.light.tokens.ts` & `singleSelectV2.dark.tokens.ts`

- **`menu.groupLabel.margin`**: set to **`'0'`** (was `0 ${foundationToken.unit[8]}`).

## Technical note (for reviewers)

**Why `!important`?** `lucide-react` sets SVG dimensions via the `style` attribute. Inline styles outrank class-based rules, so token-based `& > svg { width; height }` was struck through in DevTools until we used `!important`. This is scoped to Directory icon/chevron wrappers, not global.

**MultiSelect V1/V2:** Group labels there did not use the same horizontal margin pattern; only SingleSelect / SingleSelectV2 were updated for the 8px margin removal.

## Testing

- **Directory / Storybook or app**: Lucide `leftSlot` icons — change **`section.itemList.item.icon.width`** in tokens and confirm the **SVG** (not only the wrapper) resizes.
- **Section headers**: Chevron size follows **`section.header.chevron.width`**.
- **Nav rows with children**: Item chevron follows **`section.itemList.item.chevron.width`**.
- **Labels**: Item and section labels respect **`fontSize`** (and item **`fontWeight`**) from tokens when used with a `variant`.
- **SingleSelect / SingleSelectV2**: Open a menu with grouped options; group labels should have **no extra horizontal margin** beyond menu padding.


### Issue Ticket

Closes #1292 #1294 