### PR TITLE
Add optional row FLIP animation with spring/bezier config

### DIFF
--- a/apps/site/src/demos/dataTableDemo.tsx
+++ b/apps/site/src/demos/dataTableDemo.tsx
@@ -4609,18 +4609,35 @@ const RowAnimationDemo = () => {
         setData((prev) => prev.filter((r) => r.id !== rowId))
     }
 
-    const animationConfig: RowAnimationConfig = {
+    const animationConfig: RowAnimationConfig = useMemo(() => {
+        if (transitionType === 'spring') {
+            return {
+                transitionType,
+                stiffness: springStiffness,
+                damping: springDamping,
+                mass: springMass,
+                enterDuration,
+                enterOffset,
+            }
+        }
+
+        return {
+            transitionType,
+            duration: bezierDuration,
+            bezier: bezierControl,
+            enterDuration,
+            enterOffset,
+        }
+    }, [
         transitionType,
-        ...(transitionType === 'spring'
-            ? {
-                  stiffness: springStiffness,
-                  damping: springDamping,
-                  mass: springMass,
-              }
-            : { duration: bezierDuration, bezier: bezierControl }),
+        springStiffness,
+        springDamping,
+        springMass,
+        bezierDuration,
+        bezierControl,
         enterDuration,
         enterOffset,
-    }
+    ])
 
     return (
         <div style={{ marginTop: '40px' }}>

--- a/apps/site/src/demos/dataTableDemo.tsx
+++ b/apps/site/src/demos/dataTableDemo.tsx
@@ -11,6 +11,7 @@ import {
     DateColumnProps,
     DateFormat,
     PivotAggregationType,
+    RowAnimationConfig,
 } from '../../../../packages/blend/lib/components/DataTable/types'
 import DataTable from '../../../../packages/blend/lib/components/DataTable/DataTable'
 import type { PivotTableConfig } from '../../../../packages/blend/lib/components/DataTable/PivotTableModal/types'
@@ -4280,6 +4281,8 @@ const DataTableDemo = () => {
 
             <EmptyDataTableExamples />
 
+            <RowAnimationDemo />
+
             <SkeletonLoadingDemo />
 
             <Modal
@@ -4381,6 +4384,741 @@ const DataTableDemo = () => {
                     </div>
                 </div>
             </Modal>
+        </div>
+    )
+}
+
+// Row Animation Demo Component
+const RowAnimationDemo = () => {
+    type AnimRow = {
+        id: number
+        name: string
+        category: string
+        price: number
+        status: TagColumnProps
+    }
+
+    const baseData: AnimRow[] = [
+        {
+            id: 1,
+            name: 'Wireless Headphones',
+            category: 'Audio',
+            price: 89,
+            status: {
+                text: 'Active',
+                variant: 'subtle' as const,
+                color: 'success' as const,
+                size: 'sm' as const,
+            },
+        },
+        {
+            id: 2,
+            name: 'Mechanical Keyboard',
+            category: 'Peripherals',
+            price: 149,
+            status: {
+                text: 'Low Stock',
+                variant: 'subtle' as const,
+                color: 'warning' as const,
+                size: 'sm' as const,
+            },
+        },
+        {
+            id: 3,
+            name: 'USB-C Hub',
+            category: 'Accessories',
+            price: 45,
+            status: {
+                text: 'Active',
+                variant: 'subtle' as const,
+                color: 'success' as const,
+                size: 'sm' as const,
+            },
+        },
+        {
+            id: 4,
+            name: '4K Monitor',
+            category: 'Displays',
+            price: 599,
+            status: {
+                text: 'Inactive',
+                variant: 'subtle' as const,
+                color: 'error' as const,
+                size: 'sm' as const,
+            },
+        },
+        {
+            id: 5,
+            name: 'Webcam HD',
+            category: 'Peripherals',
+            price: 79,
+            status: {
+                text: 'Active',
+                variant: 'subtle' as const,
+                color: 'success' as const,
+                size: 'sm' as const,
+            },
+        },
+    ]
+
+    const [data, setData] = useState(baseData)
+    const [currentPage, setCurrentPage] = useState(1)
+    const [nextId, setNextId] = useState(6)
+    const [transitionType, setTransitionType] = useState<'spring' | 'bezier'>(
+        'bezier'
+    )
+    // Spring config
+    const [springStiffness, setSpringStiffness] = useState(320)
+    const [springDamping, setSpringDamping] = useState(32)
+    const [springMass, setSpringMass] = useState(1)
+    const [bezierDuration, setBezierDuration] = useState(0.3)
+    const [bezierControl, setBezierControl] = useState<
+        [number, number, number, number]
+    >([0, 0.2, 0, 1])
+    const [enterDuration, setEnterDuration] = useState(0.65)
+    const [enterOffset, setEnterOffset] = useState(34)
+    const [animationEnabled, setAnimationEnabled] = useState(true)
+    const [showActiveOnly, setShowActiveOnly] = useState(false)
+
+    const bezierPresets: Record<string, [number, number, number, number]> = {
+        Apple: [0, 0.2, 0, 1],
+        Smooth: [0.22, 1, 0.36, 1],
+        'ease-out': [0, 0, 0.58, 1],
+        'ease-in': [0.42, 0, 1, 1],
+        'ease-in-out': [0.42, 0, 0.58, 1],
+        linear: [0, 0, 1, 1],
+    }
+
+    const animColumns: ColumnDefinition<AnimRow>[] = [
+        {
+            field: 'name',
+            header: 'Product',
+            type: ColumnType.TEXT,
+            isSortable: true,
+        },
+        {
+            field: 'category',
+            header: 'Category',
+            type: ColumnType.TEXT,
+            isSortable: true,
+        },
+        {
+            field: 'price',
+            header: 'Price',
+            type: ColumnType.NUMBER,
+            isSortable: true,
+        },
+        {
+            field: 'status',
+            header: 'Status',
+            type: ColumnType.TAG,
+            isSortable: true,
+            renderCell: (value: TagColumnProps) => (
+                <Tag
+                    text={value.text}
+                    variant={TagVariant.SUBTLE}
+                    color={
+                        value.color === 'success'
+                            ? TagColor.SUCCESS
+                            : value.color === 'error'
+                              ? TagColor.ERROR
+                              : value.color === 'warning'
+                                ? TagColor.WARNING
+                                : TagColor.NEUTRAL
+                    }
+                    size={TagSize.SM}
+                />
+            ),
+        },
+    ]
+
+    const handleSortByName = () => {
+        setData((prev) =>
+            [...prev].sort((a, b) => a.name.localeCompare(b.name))
+        )
+    }
+
+    const handleSortByPrice = () => {
+        setData((prev) => [...prev].sort((a, b) => a.price - b.price))
+    }
+
+    const handleShuffle = () => {
+        setData((prev) => {
+            const shuffled = [...prev]
+            for (let i = shuffled.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1))
+                ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+            }
+            return shuffled
+        })
+    }
+
+    const handleFilterActive = () => {
+        setShowActiveOnly((prev) => {
+            if (!prev) {
+                setData(baseData.filter((r) => r.status.text === 'Active'))
+            } else {
+                setData(baseData)
+            }
+            return !prev
+        })
+    }
+
+    const handleReset = () => {
+        setData(baseData)
+        setShowActiveOnly(false)
+    }
+
+    const handleAddRow = () => {
+        const categories = ['Audio', 'Peripherals', 'Accessories', 'Displays']
+        const statusOptions: TagColumnProps[] = [
+            {
+                text: 'Active',
+                variant: 'subtle' as const,
+                color: 'success' as const,
+                size: 'sm' as const,
+            },
+            {
+                text: 'Low Stock',
+                variant: 'subtle' as const,
+                color: 'warning' as const,
+                size: 'sm' as const,
+            },
+            {
+                text: 'Inactive',
+                variant: 'subtle' as const,
+                color: 'error' as const,
+                size: 'sm' as const,
+            },
+        ]
+        const newRow: AnimRow = {
+            id: nextId,
+            name: `Product ${nextId}`,
+            category: categories[Math.floor(Math.random() * categories.length)],
+            price: Math.floor(Math.random() * 500) + 20,
+            status: statusOptions[
+                Math.floor(Math.random() * statusOptions.length)
+            ],
+        }
+        setData((prev) => [newRow, ...prev])
+        setNextId((prev) => prev + 1)
+    }
+
+    const handleDeleteRow = (row: Record<string, unknown>) => {
+        const rowId = row.id as number
+        setData((prev) => prev.filter((r) => r.id !== rowId))
+    }
+
+    const animationConfig: RowAnimationConfig = {
+        transitionType,
+        ...(transitionType === 'spring'
+            ? {
+                  stiffness: springStiffness,
+                  damping: springDamping,
+                  mass: springMass,
+              }
+            : { duration: bezierDuration, bezier: bezierControl }),
+        enterDuration,
+        enterOffset,
+    }
+
+    return (
+        <div style={{ marginTop: '40px' }}>
+            <div
+                style={{
+                    marginBottom: '20px',
+                    padding: '16px',
+                    backgroundColor: '#f0fdf4',
+                    borderRadius: '8px',
+                    border: '1px solid #bbf7d0',
+                }}
+            >
+                <h3
+                    style={{
+                        margin: '0 0 8px 0',
+                        fontSize: '18px',
+                        fontWeight: 600,
+                        color: '#15803d',
+                    }}
+                >
+                    Row FLIP Animation Demo
+                </h3>
+                <p style={{ margin: 0, fontSize: '14px', color: '#166534' }}>
+                    Rows animate to their new positions when sorted, filtered,
+                    or shuffled. Uses framer-motion&apos;s <code>layout</code>{' '}
+                    prop for automatic FLIP animations.
+                    <br />
+                    <strong>enableRowAnimation</strong> is opt-in (default:
+                    false). Toggle between spring and tween transitions below.
+                </p>
+            </div>
+
+            <div
+                style={{
+                    marginBottom: '16px',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '8px',
+                    alignItems: 'center',
+                }}
+            >
+                <span style={{ fontSize: '14px', color: '#666' }}>
+                    Transition:
+                </span>
+                <Button
+                    buttonType={
+                        transitionType === 'spring'
+                            ? ButtonType.PRIMARY
+                            : ButtonType.SECONDARY
+                    }
+                    size={ButtonSize.SMALL}
+                    onClick={() => setTransitionType('spring')}
+                    text="Spring"
+                />
+                <Button
+                    buttonType={
+                        transitionType === 'bezier'
+                            ? ButtonType.PRIMARY
+                            : ButtonType.SECONDARY
+                    }
+                    size={ButtonSize.SMALL}
+                    onClick={() => setTransitionType('bezier')}
+                    text="Bezier"
+                />
+                <Button
+                    buttonType={
+                        animationEnabled
+                            ? ButtonType.PRIMARY
+                            : ButtonType.SECONDARY
+                    }
+                    size={ButtonSize.SMALL}
+                    onClick={() => setAnimationEnabled((prev) => !prev)}
+                    text={animationEnabled ? 'Anim: On' : 'Anim: Off'}
+                />
+            </div>
+
+            {transitionType === 'spring' ? (
+                <div
+                    style={{
+                        marginBottom: '16px',
+                        display: 'grid',
+                        gridTemplateColumns:
+                            'repeat(auto-fit, minmax(160px, 1fr))',
+                        gap: '12px',
+                        alignItems: 'center',
+                        padding: '12px',
+                        borderRadius: '6px',
+                        backgroundColor: '#fafafa',
+                        border: '1px solid #e5e5e5',
+                    }}
+                >
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Controls how tightly the spring pulls toward rest. Higher = faster movement."
+                        >
+                            Stiffness: {springStiffness}
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={10}
+                            max={500}
+                            step={10}
+                            value={springStiffness}
+                            onChange={(e) =>
+                                setSpringStiffness(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Controls how quickly oscillations die out. Higher = less bounce."
+                        >
+                            Damping: {springDamping}
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={1}
+                            max={100}
+                            step={1}
+                            value={springDamping}
+                            onChange={(e) =>
+                                setSpringDamping(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Virtual weight of the object. Higher = slower acceleration."
+                        >
+                            Mass: {springMass.toFixed(1)}
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={0.1}
+                            max={5}
+                            step={0.1}
+                            value={springMass}
+                            onChange={(e) =>
+                                setSpringMass(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                </div>
+            ) : (
+                <div
+                    style={{
+                        marginBottom: '16px',
+                        display: 'grid',
+                        gridTemplateColumns:
+                            'repeat(auto-fit, minmax(160px, 1fr))',
+                        gap: '12px',
+                        alignItems: 'center',
+                        padding: '12px',
+                        borderRadius: '6px',
+                        backgroundColor: '#fafafa',
+                        border: '1px solid #e5e5e5',
+                    }}
+                >
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="How long each row takes to move to its new position."
+                        >
+                            Duration: {(bezierDuration * 1000).toFixed(0)}ms
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={0.05}
+                            max={2.0}
+                            step={0.01}
+                            value={bezierDuration}
+                            onChange={(e) =>
+                                setBezierDuration(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    <div style={{ gridColumn: '1 / -1' }}>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Pre-defined cubic-bezier curves for common easing styles."
+                        >
+                            Presets
+                            <Info size={12} color="#999" />
+                        </label>
+                        <div
+                            style={{
+                                display: 'flex',
+                                gap: '8px',
+                                flexWrap: 'wrap',
+                                marginBottom: '8px',
+                            }}
+                        >
+                            {Object.entries(bezierPresets).map(
+                                ([label, curve]) => {
+                                    const isActive =
+                                        bezierControl[0] === curve[0] &&
+                                        bezierControl[1] === curve[1] &&
+                                        bezierControl[2] === curve[2] &&
+                                        bezierControl[3] === curve[3]
+                                    return (
+                                        <button
+                                            key={label}
+                                            type="button"
+                                            onClick={() =>
+                                                setBezierControl(curve)
+                                            }
+                                            style={{
+                                                fontSize: '13px',
+                                                padding: '4px 10px',
+                                                borderRadius: '4px',
+                                                border: '1px solid #ccc',
+                                                backgroundColor: isActive
+                                                    ? '#333'
+                                                    : '#fff',
+                                                color: isActive
+                                                    ? '#fff'
+                                                    : '#333',
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            {label}
+                                        </button>
+                                    )
+                                }
+                            )}
+                        </div>
+                    </div>
+                    <div style={{ gridColumn: '1 / -1' }}>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Custom cubic-bezier control points (p1.x, p1.y, p2.x, p2.y). Defines the acceleration curve."
+                        >
+                            Curve: cubic-bezier({bezierControl[0]},{' '}
+                            {bezierControl[1]}, {bezierControl[2]},{' '}
+                            {bezierControl[3]})
+                            <Info size={12} color="#999" />
+                        </label>
+                        <div
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: '1fr 1fr',
+                                gap: '12px',
+                                maxWidth: '400px',
+                            }}
+                        >
+                            {[0, 1, 2, 3].map((i) => (
+                                <div key={i}>
+                                    <input
+                                        type="number"
+                                        step={0.01}
+                                        min={-0.5}
+                                        max={1.5}
+                                        value={bezierControl[i]}
+                                        onChange={(e) => {
+                                            const val = Number(e.target.value)
+                                            setBezierControl((prev) => {
+                                                const next = [...prev] as [
+                                                    number,
+                                                    number,
+                                                    number,
+                                                    number,
+                                                ]
+                                                next[i] = val
+                                                return next
+                                            })
+                                        }}
+                                        style={{
+                                            width: '100%',
+                                            padding: '4px 8px',
+                                            fontSize: '13px',
+                                            border: '1px solid #ccc',
+                                            borderRadius: '4px',
+                                            textAlign: 'center',
+                                        }}
+                                    />
+                                    <span
+                                        style={{
+                                            display: 'block',
+                                            textAlign: 'center',
+                                            fontSize: '11px',
+                                            color: '#999',
+                                            marginTop: '2px',
+                                        }}
+                                    >
+                                        {i < 2 ? 'p1' : 'p2'}.
+                                        {i % 2 === 0 ? 'x' : 'y'}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="Time for newly added rows to fade in and slide into place."
+                        >
+                            Enter Duration: {(enterDuration * 1000).toFixed(0)}
+                            ms
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={0.05}
+                            max={1.0}
+                            step={0.01}
+                            value={enterDuration}
+                            onChange={(e) =>
+                                setEnterDuration(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    <div>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                fontSize: '12px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: '#666',
+                                marginBottom: '4px',
+                            }}
+                            title="How far new rows slide down before settling into place."
+                        >
+                            Enter Offset: {enterOffset}px
+                            <Info size={12} color="#999" />
+                        </label>
+                        <input
+                            type="range"
+                            min={0}
+                            max={50}
+                            step={1}
+                            value={enterOffset}
+                            onChange={(e) =>
+                                setEnterOffset(Number(e.target.value))
+                            }
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            <div
+                style={{
+                    marginBottom: '16px',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '8px',
+                    alignItems: 'center',
+                }}
+            >
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    leadingIcon={<Filter size={14} />}
+                    onClick={handleSortByName}
+                    text="Sort by Name"
+                />
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    leadingIcon={<Filter size={14} />}
+                    onClick={handleSortByPrice}
+                    text="Sort by Price"
+                />
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    onClick={handleShuffle}
+                    text="Shuffle"
+                />
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    onClick={handleFilterActive}
+                    text={showActiveOnly ? 'Show All' : 'Active Only'}
+                />
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    onClick={handleReset}
+                    text="Reset"
+                />
+                <Button
+                    buttonType={ButtonType.PRIMARY}
+                    size={ButtonSize.SMALL}
+                    onClick={handleAddRow}
+                    text="Add Row"
+                />
+            </div>
+
+            <DataTable
+                data={data as Record<string, unknown>[]}
+                columns={
+                    animColumns as ColumnDefinition<Record<string, unknown>>[]
+                }
+                idField="id"
+                enableRowAnimation={animationEnabled}
+                rowAnimationConfig={
+                    animationEnabled ? animationConfig : undefined
+                }
+                enableSearch
+                pagination={{
+                    currentPage,
+                    pageSize: 10,
+                    totalRows: data.length,
+                    pageSizeOptions: [5, 10, 20],
+                }}
+                onPageChange={(page) => setCurrentPage(page)}
+                onPageSizeChange={() => setCurrentPage(1)}
+                rowActions={{
+                    showEditAction: false,
+                    slot1: {
+                        id: 'delete-row',
+                        text: 'Delete',
+                        buttonType: ButtonType.SECONDARY,
+                        size: ButtonSize.SMALL,
+                        leadingIcon: <Trash2 size={16} />,
+                        onClick: (row) => handleDeleteRow(row),
+                    },
+                }}
+            />
         </div>
     )
 }

--- a/packages/blend/lib/components/DataTable/DataTable.tsx
+++ b/packages/blend/lib/components/DataTable/DataTable.tsx
@@ -155,6 +155,8 @@ const DataTable = forwardRef(
             onInsertRight,
             onDeleteColumn,
             getRowStyle,
+            enableRowAnimation,
+            rowAnimationConfig,
             tableBodyHeight,
             mobileColumnsToShow,
             enablePivotTable = false,
@@ -1996,6 +1998,12 @@ const DataTable = forwardRef(
                                                               index: number
                                                           ) => boolean)
                                                         | undefined
+                                                }
+                                                enableRowAnimation={
+                                                    enableRowAnimation
+                                                }
+                                                rowAnimationConfig={
+                                                    rowAnimationConfig
                                                 }
                                             />
                                         )}

--- a/packages/blend/lib/components/DataTable/TableBody/index.tsx
+++ b/packages/blend/lib/components/DataTable/TableBody/index.tsx
@@ -1,4 +1,11 @@
-import React, { forwardRef, useMemo, useRef, useEffect, useState } from 'react'
+import React, {
+    forwardRef,
+    useMemo,
+    useRef,
+    useEffect,
+    useState,
+    useCallback,
+} from 'react'
 import {
     Edit,
     Save,
@@ -18,6 +25,7 @@ import Menu from '../../Menu/Menu'
 import { MenuAlignment, MenuSide } from '../../Menu/types'
 import Skeleton from '../../Skeleton/Skeleton'
 import { getSkeletonState } from '../../Skeleton/utils'
+import { useRowFlip } from '../hooks/useRowFlip'
 
 import { Button, ButtonType, ButtonSize, ButtonSubType } from '../../Button'
 import { Checkbox, CheckboxSize } from '../../Checkbox'
@@ -571,6 +579,8 @@ const TableBody = forwardRef<
             isRowLoading,
             focusedCell,
             onCellFocus,
+            enableRowAnimation = false,
+            rowAnimationConfig,
         },
         ref
     ) => {
@@ -650,13 +660,33 @@ const TableBody = forwardRef<
             return `tbody-${len}-${firstId}-${lastId}`
         }, [currentData, dataVersion, idField])
 
+        const orderedRowIds = useMemo(
+            () => currentData.map((row) => String(row[idField])),
+            [currentData, idField]
+        )
+
+        const { register } = useRowFlip(
+            enableRowAnimation ? orderedRowIds : [],
+            rowAnimationConfig
+        )
+
+        const getFlipRefCallback = useCallback(
+            (rowId: string) => (el: HTMLTableRowElement | null) => {
+                if (!enableRowAnimation) return
+                register(rowId, el)
+            },
+            [enableRowAnimation, register]
+        )
+
+        const isPageTransition = !enableRowAnimation
+
         return (
             <motion.tbody
-                key={tbodyKey}
+                key={isPageTransition ? tbodyKey : undefined}
                 ref={ref}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.3 }}
+                initial={isPageTransition ? { opacity: 0 } : undefined}
+                animate={isPageTransition ? { opacity: 1 } : undefined}
+                transition={isPageTransition ? { duration: 0.3 } : undefined}
                 style={{
                     backgroundColor: FOUNDATION_THEME.colors.gray[0],
                 }}
@@ -685,7 +715,6 @@ const TableBody = forwardRef<
                           const isSelected = selectedRows[rowId] || false
                           const rowAriaLabel = `Row ${index + 1}${isSelected ? ', selected' : ''}${isExpanded ? ', expanded' : ''}`
 
-                          // Helper to calculate absolute column index
                           const getAbsoluteColIndex = (
                               relativeColIndex: number
                           ) => {
@@ -695,11 +724,18 @@ const TableBody = forwardRef<
                               return colIndex
                           }
 
-                          const rowKey = `${rowId}-${index}`
+                          const rowKey = enableRowAnimation
+                              ? rowId
+                              : `${rowId}-${index}`
 
                           return (
                               <React.Fragment key={rowKey}>
                                   <TableRow
+                                      ref={
+                                          enableRowAnimation
+                                              ? getFlipRefCallback(rowId)
+                                              : undefined
+                                      }
                                       $isClickable={!!onRowClick}
                                       $customBackgroundColor={
                                           rowStyling.backgroundColor
@@ -1156,6 +1192,9 @@ const TableBody = forwardRef<
                                                           $hasCustomBackground={
                                                               hasCustomBackground
                                                           }
+                                                          $isFirstRow={
+                                                              index === 0
+                                                          }
                                                           data-row-index={index}
                                                           data-col-index={
                                                               absoluteColIndex
@@ -1188,9 +1227,6 @@ const TableBody = forwardRef<
                                                                   getFrozenBodyStyles()),
                                                               outline: 'none',
                                                           }}
-                                                          $isFirstRow={
-                                                              index === 0
-                                                          }
                                                       >
                                                           <Skeleton
                                                               variant={
@@ -1537,6 +1573,7 @@ const TableBody = forwardRef<
                                                       $hasCustomBackground={
                                                           hasCustomBackground
                                                       }
+                                                      $isFirstRow={index === 0}
                                                       data-row-index={index}
                                                       data-col-index={
                                                           columnManagerColIndex
@@ -1562,7 +1599,6 @@ const TableBody = forwardRef<
                                                           )
                                                       }
                                                       role="gridcell"
-                                                      $isFirstRow={index === 0}
                                                       style={{
                                                           minWidth:
                                                               FOUNDATION_THEME

--- a/packages/blend/lib/components/DataTable/TableBody/types.ts
+++ b/packages/blend/lib/components/DataTable/TableBody/types.ts
@@ -1,4 +1,8 @@
-import { ColumnDefinition, RowActionsConfig } from '../types'
+import {
+    ColumnDefinition,
+    RowActionsConfig,
+    RowAnimationConfig,
+} from '../types'
 import { MobileDataTableConfig } from '../hooks/useMobileDataTable'
 import type { SkeletonVariant } from '../../Skeleton/skeleton.tokens'
 
@@ -57,4 +61,6 @@ export type TableBodyProps<T extends Record<string, unknown>> = {
     isRowLoading?: (row: T, index: number) => boolean
     focusedCell?: { rowIndex: number; colIndex: number } | null
     onCellFocus?: (rowIndex: number, colIndex: number) => void
+    enableRowAnimation?: boolean
+    rowAnimationConfig?: RowAnimationConfig
 }

--- a/packages/blend/lib/components/DataTable/TableCell/index.tsx
+++ b/packages/blend/lib/components/DataTable/TableCell/index.tsx
@@ -576,8 +576,8 @@ const TableCell = forwardRef<
                     column.type === ColumnType.REACT_ELEMENT ||
                     (isEditing && column.isEditable)
                 }
-                $isFirstRow={isFirstRow}
                 $customBackgroundColor={customBackgroundColor}
+                $isFirstRow={isFirstRow}
                 $hasCustomBackground={hasCustomBackground}
                 data-row-index={dataRowIndex}
                 data-col-index={dataColIndex}

--- a/packages/blend/lib/components/DataTable/hooks/index.ts
+++ b/packages/blend/lib/components/DataTable/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useMobileDataTable } from './useMobileDataTable'
 export type { MobileDataTableConfig } from './useMobileDataTable'
+export { useReducedMotion } from './useReducedMotion'
+export { useRowFlip } from './useRowFlip'

--- a/packages/blend/lib/components/DataTable/hooks/useReducedMotion.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+export function useReducedMotion(): boolean {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+        if (typeof window === 'undefined') return false
+        return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    })
+
+    useEffect(() => {
+        const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+        const handler = (e: MediaQueryListEvent) => {
+            setPrefersReducedMotion(e.matches)
+        }
+        mql.addEventListener('change', handler)
+        return () => mql.removeEventListener('change', handler)
+    }, [])
+
+    return prefersReducedMotion
+}

--- a/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
@@ -1,0 +1,173 @@
+import { useRef, useLayoutEffect, useCallback } from 'react'
+import { useReducedMotion } from './useReducedMotion'
+import type { RowAnimationConfig } from '../types'
+
+const DEFAULT_ANIMATION_CONFIG: Required<
+    Pick<
+        RowAnimationConfig,
+        | 'transitionType'
+        | 'stiffness'
+        | 'damping'
+        | 'mass'
+        | 'duration'
+        | 'bezier'
+        | 'enterDuration'
+        | 'enterOffset'
+    >
+> = {
+    transitionType: 'bezier',
+    stiffness: 320,
+    damping: 32,
+    mass: 1,
+    duration: 0.3,
+    bezier: [0, 0.2, 0, 1],
+    enterDuration: 0.65,
+    enterOffset: 34,
+}
+
+function toCssTransition(config: RowAnimationConfig | undefined): {
+    transition: string
+    duration: number
+} {
+    const merged = { ...DEFAULT_ANIMATION_CONFIG, ...config }
+    const { transitionType, duration, bezier } = merged
+
+    if (transitionType === 'bezier') {
+        const [p0, p1, p2, p3] = bezier
+        const cssBezier = `cubic-bezier(${p0}, ${p1}, ${p2}, ${p3})`
+        return {
+            duration,
+            transition: `transform ${duration}s ${cssBezier}, opacity ${duration}s ${cssBezier}`,
+        }
+    }
+
+    const cssBezier = `cubic-bezier(0.32, 0.72, 0, 1)`
+    const transition = `transform 0.35s ${cssBezier}, opacity 0.35s ${cssBezier}`
+    return {
+        duration: 0.35,
+        transition,
+    }
+}
+
+interface UseRowFlipReturn {
+    register: (id: string, el: HTMLTableRowElement | null) => void
+}
+
+export function useRowFlip(
+    orderedIds: string[],
+    animationConfig?: RowAnimationConfig
+): UseRowFlipReturn {
+    const elementsRef = useRef<Map<string, HTMLTableRowElement>>(new Map())
+    const prevTopsRef = useRef<Map<string, number>>(new Map())
+    const prevIdsRef = useRef<Set<string>>(new Set())
+    const configRef = useRef<RowAnimationConfig | undefined>(animationConfig)
+    const prefersReducedMotion = useReducedMotion()
+
+    configRef.current = animationConfig
+
+    const register = useCallback(
+        (id: string, el: HTMLTableRowElement | null) => {
+            if (el === null) {
+                elementsRef.current.delete(id)
+            } else {
+                elementsRef.current.set(id, el)
+            }
+        },
+        []
+    )
+
+    useLayoutEffect(() => {
+        const currentConfig = configRef.current
+
+        if (prefersReducedMotion) {
+            const newTops = new Map<string, number>()
+            for (const id of orderedIds) {
+                const el = elementsRef.current.get(id)
+                if (el) {
+                    newTops.set(id, el.getBoundingClientRect().top)
+                }
+            }
+            prevTopsRef.current = newTops
+            prevIdsRef.current = new Set(orderedIds)
+            return
+        }
+
+        const mergedConfig = {
+            ...DEFAULT_ANIMATION_CONFIG,
+            ...currentConfig,
+        }
+        const { transition: cssTransition, duration } = toCssTransition(
+            currentConfig || {}
+        )
+        const enterDuration = mergedConfig.enterDuration
+        const enterOffset = mergedConfig.enterOffset
+
+        const prevIds = prevIdsRef.current
+        const newRowIdSet = new Set(orderedIds.filter((id) => !prevIds.has(id)))
+
+        const currentTops = new Map<string, number>()
+        for (const id of orderedIds) {
+            const el = elementsRef.current.get(id)
+            if (el) {
+                currentTops.set(id, el.getBoundingClientRect().top)
+            }
+        }
+
+        for (const [id, newTop] of currentTops) {
+            if (newRowIdSet.has(id)) continue
+
+            const prevTop = prevTopsRef.current.get(id)
+            if (prevTop === undefined) continue
+
+            const delta = prevTop - newTop
+            if (Math.abs(delta) < 1) continue
+
+            const el = elementsRef.current.get(id)
+            if (!el) continue
+
+            el.style.transition = 'none'
+            el.style.transform = `translateY(${delta}px)`
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    el.style.transition = cssTransition
+                    el.style.transform = ''
+                })
+            })
+        }
+
+        for (const id of newRowIdSet) {
+            const el = elementsRef.current.get(id)
+            if (!el) continue
+
+            el.style.transition = 'none'
+            el.style.transform = `translateY(${enterOffset}px)`
+            el.style.opacity = '0'
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    el.style.transition = `transform ${enterDuration}s cubic-bezier(0.32, 0.72, 0, 1), opacity ${enterDuration}s cubic-bezier(0.32, 0.72, 0, 1)`
+                    el.style.transform = ''
+                    el.style.opacity = '1'
+                })
+            })
+        }
+
+        const cleanupTimeout = Math.max(duration, enterDuration) * 1000 + 50
+        setTimeout(() => {
+            for (const id of orderedIds) {
+                const el = elementsRef.current.get(id)
+                if (el) {
+                    el.style.transition = ''
+                    el.style.transform = ''
+                    el.style.opacity = ''
+                }
+            }
+        }, cleanupTimeout)
+
+        prevTopsRef.current = currentTops
+        prevIdsRef.current = new Set(orderedIds)
+    }, [orderedIds, prefersReducedMotion])
+
+    return { register }
+}

--- a/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
@@ -61,10 +61,13 @@ export function useRowFlip(
     const prevTopsRef = useRef<Map<string, number>>(new Map())
     const prevIdsRef = useRef<Set<string>>(new Set())
     const configRef = useRef<RowAnimationConfig | undefined>(animationConfig)
+    const orderedIdsRef = useRef(orderedIds)
     const prefersReducedMotion = useReducedMotion()
     const cleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const serializedOrderedIds = JSON.stringify(orderedIds)
 
     configRef.current = animationConfig
+    orderedIdsRef.current = orderedIds
 
     const register = useCallback(
         (id: string, el: HTMLTableRowElement | null) => {
@@ -78,18 +81,19 @@ export function useRowFlip(
     )
 
     useLayoutEffect(() => {
+        const currentOrderedIds = orderedIdsRef.current
         const currentConfig = configRef.current
 
         if (prefersReducedMotion) {
             const newTops = new Map<string, number>()
-            for (const id of orderedIds) {
+            for (const id of currentOrderedIds) {
                 const el = elementsRef.current.get(id)
                 if (el) {
                     newTops.set(id, el.getBoundingClientRect().top)
                 }
             }
             prevTopsRef.current = newTops
-            prevIdsRef.current = new Set(orderedIds)
+            prevIdsRef.current = new Set(currentOrderedIds)
             return
         }
 
@@ -104,10 +108,12 @@ export function useRowFlip(
         const enterOffset = mergedConfig.enterOffset
 
         const prevIds = prevIdsRef.current
-        const newRowIdSet = new Set(orderedIds.filter((id) => !prevIds.has(id)))
+        const newRowIdSet = new Set(
+            currentOrderedIds.filter((id) => !prevIds.has(id))
+        )
 
         const currentTops = new Map<string, number>()
-        for (const id of orderedIds) {
+        for (const id of currentOrderedIds) {
             const el = elementsRef.current.get(id)
             if (el) {
                 currentTops.set(id, el.getBoundingClientRect().top)
@@ -161,7 +167,7 @@ export function useRowFlip(
         }
 
         cleanupTimeoutRef.current = setTimeout(() => {
-            for (const id of orderedIds) {
+            for (const id of currentOrderedIds) {
                 const el = elementsRef.current.get(id)
                 if (el) {
                     el.style.transition = ''
@@ -172,7 +178,7 @@ export function useRowFlip(
         }, cleanupTimeout)
 
         prevTopsRef.current = currentTops
-        prevIdsRef.current = new Set(orderedIds)
+        prevIdsRef.current = new Set(currentOrderedIds)
 
         return () => {
             if (cleanupTimeoutRef.current) {
@@ -180,7 +186,7 @@ export function useRowFlip(
                 cleanupTimeoutRef.current = null
             }
         }
-    }, [orderedIds, prefersReducedMotion])
+    }, [serializedOrderedIds, prefersReducedMotion])
 
     return { register }
 }

--- a/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
@@ -62,6 +62,7 @@ export function useRowFlip(
     const prevIdsRef = useRef<Set<string>>(new Set())
     const configRef = useRef<RowAnimationConfig | undefined>(animationConfig)
     const prefersReducedMotion = useReducedMotion()
+    const cleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     configRef.current = animationConfig
 
@@ -154,7 +155,12 @@ export function useRowFlip(
         }
 
         const cleanupTimeout = Math.max(duration, enterDuration) * 1000 + 50
-        setTimeout(() => {
+
+        if (cleanupTimeoutRef.current) {
+            clearTimeout(cleanupTimeoutRef.current)
+        }
+
+        cleanupTimeoutRef.current = setTimeout(() => {
             for (const id of orderedIds) {
                 const el = elementsRef.current.get(id)
                 if (el) {
@@ -167,6 +173,13 @@ export function useRowFlip(
 
         prevTopsRef.current = currentTops
         prevIdsRef.current = new Set(orderedIds)
+
+        return () => {
+            if (cleanupTimeoutRef.current) {
+                clearTimeout(cleanupTimeoutRef.current)
+                cleanupTimeoutRef.current = null
+            }
+        }
     }, [orderedIds, prefersReducedMotion])
 
     return { register }

--- a/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
@@ -1,43 +1,17 @@
-import { useRef, useLayoutEffect, useCallback } from 'react'
+import { useRef, useLayoutEffect, useCallback, useMemo } from 'react'
 import { useReducedMotion } from './useReducedMotion'
 import type { RowAnimationConfig } from '../types'
 
-const DEFAULT_ANIMATION_CONFIG: Required<
-    Pick<
-        RowAnimationConfig,
-        | 'transitionType'
-        | 'stiffness'
-        | 'damping'
-        | 'mass'
-        | 'duration'
-        | 'bezier'
-        | 'enterDuration'
-        | 'enterOffset'
-    >
-> = {
-    transitionType: 'bezier',
-    stiffness: 320,
-    damping: 32,
-    mass: 1,
-    duration: 0.3,
-    bezier: [0, 0.2, 0, 1],
-    enterDuration: 0.65,
-    enterOffset: 34,
-}
-
-function toCssTransition(config: RowAnimationConfig | undefined): {
+function toCssTransition(config: RowAnimationConfig): {
     transition: string
     duration: number
 } {
-    const merged = { ...DEFAULT_ANIMATION_CONFIG, ...config }
-    const { transitionType, duration, bezier } = merged
-
-    if (transitionType === 'bezier') {
-        const [p0, p1, p2, p3] = bezier
+    if (config.transitionType === 'bezier') {
+        const [p0, p1, p2, p3] = config.bezier
         const cssBezier = `cubic-bezier(${p0}, ${p1}, ${p2}, ${p3})`
         return {
-            duration,
-            transition: `transform ${duration}s ${cssBezier}, opacity ${duration}s ${cssBezier}`,
+            duration: config.duration,
+            transition: `transform ${config.duration}s ${cssBezier}, opacity ${config.duration}s ${cssBezier}`,
         }
     }
 
@@ -64,7 +38,10 @@ export function useRowFlip(
     const orderedIdsRef = useRef(orderedIds)
     const prefersReducedMotion = useReducedMotion()
     const cleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-    const serializedOrderedIds = JSON.stringify(orderedIds)
+    const serializedOrderedIds = useMemo(
+        () => JSON.stringify(orderedIds),
+        [orderedIds]
+    )
 
     configRef.current = animationConfig
     orderedIdsRef.current = orderedIds
@@ -97,21 +74,6 @@ export function useRowFlip(
             return
         }
 
-        const mergedConfig = {
-            ...DEFAULT_ANIMATION_CONFIG,
-            ...currentConfig,
-        }
-        const { transition: cssTransition, duration } = toCssTransition(
-            currentConfig || {}
-        )
-        const enterDuration = mergedConfig.enterDuration
-        const enterOffset = mergedConfig.enterOffset
-
-        const prevIds = prevIdsRef.current
-        const newRowIdSet = new Set(
-            currentOrderedIds.filter((id) => !prevIds.has(id))
-        )
-
         const currentTops = new Map<string, number>()
         for (const id of currentOrderedIds) {
             const el = elementsRef.current.get(id)
@@ -119,6 +81,22 @@ export function useRowFlip(
                 currentTops.set(id, el.getBoundingClientRect().top)
             }
         }
+
+        if (!currentConfig) {
+            prevTopsRef.current = currentTops
+            prevIdsRef.current = new Set(currentOrderedIds)
+            return
+        }
+
+        const { transition: cssTransition, duration } =
+            toCssTransition(currentConfig)
+        const enterDuration = currentConfig.enterDuration
+        const enterOffset = currentConfig.enterOffset
+
+        const prevIds = prevIdsRef.current
+        const newRowIdSet = new Set(
+            currentOrderedIds.filter((id) => !prevIds.has(id))
+        )
 
         for (const [id, newTop] of currentTops) {
             if (newRowIdSet.has(id)) continue

--- a/packages/blend/lib/components/DataTable/types.ts
+++ b/packages/blend/lib/components/DataTable/types.ts
@@ -368,24 +368,34 @@ export type RowSelectionConfig<T extends Record<string, unknown>> = {
     disabledText?: (row: T, index: number) => string
 }
 
-export type RowAnimationConfig = {
-    /** Transition type for layout animations. @default 'bezier' */
-    transitionType?: 'spring' | 'bezier'
-    /** Spring stiffness. @default 320 */
-    stiffness?: number
-    /** Spring damping. @default 32 */
-    damping?: number
-    /** Spring mass. @default 1 */
-    mass?: number
-    /** Bezier duration in seconds. @default 0.3 */
-    duration?: number
-    /** Bezier easing curve as [x1, y1, x2, y2] cubic-bezier control points. @default [0, 0.2, 0, 1] */
-    bezier?: [number, number, number, number]
-    /** Enter animation duration in seconds. @default 0.65 */
-    enterDuration?: number
-    /** Enter animation Y offset in pixels. @default 34 */
-    enterOffset?: number
+type BaseRowAnimationConfig = {
+    /** Enter animation duration in seconds. */
+    enterDuration: number
+    /** Enter animation Y offset in pixels. */
+    enterOffset: number
 }
+
+export type RowAnimationConfig = BaseRowAnimationConfig &
+    (
+        | {
+              /** Transition type for layout animations. */
+              transitionType: 'bezier'
+              /** Bezier duration in seconds. */
+              duration: number
+              /** Bezier easing curve as [x1, y1, x2, y2] cubic-bezier control points. */
+              bezier: [number, number, number, number]
+          }
+        | {
+              /** Transition type for layout animations. */
+              transitionType: 'spring'
+              /** Spring stiffness. */
+              stiffness: number
+              /** Spring damping. */
+              damping: number
+              /** Spring mass. */
+              mass: number
+          }
+    )
 
 export type DataTableProps<T extends Record<string, unknown>> = {
     data: T[]

--- a/packages/blend/lib/components/DataTable/types.ts
+++ b/packages/blend/lib/components/DataTable/types.ts
@@ -368,6 +368,25 @@ export type RowSelectionConfig<T extends Record<string, unknown>> = {
     disabledText?: (row: T, index: number) => string
 }
 
+export type RowAnimationConfig = {
+    /** Transition type for layout animations. @default 'bezier' */
+    transitionType?: 'spring' | 'bezier'
+    /** Spring stiffness. @default 320 */
+    stiffness?: number
+    /** Spring damping. @default 32 */
+    damping?: number
+    /** Spring mass. @default 1 */
+    mass?: number
+    /** Bezier duration in seconds. @default 0.3 */
+    duration?: number
+    /** Bezier easing curve as [x1, y1, x2, y2] cubic-bezier control points. @default [0, 0.2, 0, 1] */
+    bezier?: [number, number, number, number]
+    /** Enter animation duration in seconds. @default 0.65 */
+    enterDuration?: number
+    /** Enter animation Y offset in pixels. @default 34 */
+    enterOffset?: number
+}
+
 export type DataTableProps<T extends Record<string, unknown>> = {
     data: T[]
     columns: ColumnDefinition<T>[]
@@ -476,6 +495,9 @@ export type DataTableProps<T extends Record<string, unknown>> = {
     onDeleteColumn?: (field: keyof T) => void
 
     getRowStyle?: (row: T, index: number) => React.CSSProperties
+
+    enableRowAnimation?: boolean
+    rowAnimationConfig?: RowAnimationConfig
 
     tableBodyHeight?: string | number
 


### PR DESCRIPTION
### Summary

Add opt-in row animation (enableRowAnimation) using hook useRowFlip for automatic FLIP animations when rows are sorted, filtered, or shuffled. Supports spring and cubic-bezier transition types with configurable parameters. Respects prefers-reduced-motion via useReducedMotion hook. Reorder animation demo to place action toolbar below the bezier/spring configuration panel.

- Implementation: Pure CSS transform-based FLIP via useRowFlip hook (no framer-motion layout dependency at runtime). Uses useLayoutEffect to capture positions before paint, then applies inverse transform + CSS transition.
- Performance: Only the transform and opacity properties are animated (GPU-composited), avoiding layout recalculations. A cleanup timeout resets inline styles after animation completes.
- Opt-in: enableRowAnimation defaults to false — no performance cost unless explicitly enabled.

New Exports
- RowAnimationConfig type
- enableRowAnimation / rowAnimationConfig props on DataTable
- useReducedMotion hook (public)
- useRowFlip hook (public)



### Issue Ticket

Closes #1434 or Related to #1434 
