### PR TITLE
fix: Charts crashes when data is undefined is fixed

### DIFF
--- a/packages/blend/lib/components/Charts/ChartUtils.tsx
+++ b/packages/blend/lib/components/Charts/ChartUtils.tsx
@@ -6,6 +6,13 @@ import {
 } from './types'
 import { parseTimestamp, dateFormat } from './DateTimeFormatter'
 
+/** Replace null, undefined, or non-array `data` with `[]` (empty / no-data state). */
+export function normalizeChartData(
+    data: NewNestedDataPoint[] | null | undefined
+): NewNestedDataPoint[] {
+    return Array.isArray(data) ? data : []
+}
+
 export function transformNestedData(
     data: NewNestedDataPoint[],
     selectedKeys: string[] = []

--- a/packages/blend/lib/components/Charts/Charts.tsx
+++ b/packages/blend/lib/components/Charts/Charts.tsx
@@ -5,7 +5,7 @@ import ChartHeader from './ChartHeader'
 import ChartLegends from './ChartLegend'
 import { useRef, useState, useEffect, useCallback, useId, useMemo } from 'react'
 import { renderChart } from './renderChart'
-import { transformNestedData } from './ChartUtils'
+import { normalizeChartData, transformNestedData } from './ChartUtils'
 import Block from '../../components/Primitives/Block/Block'
 import { ChartTokensType } from './chart.tokens'
 import { FOUNDATION_THEME } from '../../tokens'
@@ -20,7 +20,7 @@ import ChartsSkeleton from './ChartsSkeleton'
 
 const Charts: React.FC<ChartsProps> = ({
     chartType = ChartType.LINE,
-    data,
+    data: dataProp,
     colors,
     slot1,
     slot2,
@@ -46,6 +46,8 @@ const Charts: React.FC<ChartsProps> = ({
     lineSeriesKeys,
     ...props
 }) => {
+    const data = normalizeChartData(dataProp)
+
     const { breakPointLabel } = useBreakpoints(BREAKPOINTS)
     const isSmallScreen = breakPointLabel === 'sm'
     const chartTokens = useResponsiveTokens<ChartTokensType>('CHARTS')

--- a/packages/blend/lib/components/Charts/CoreChart.tsx
+++ b/packages/blend/lib/components/Charts/CoreChart.tsx
@@ -3,11 +3,11 @@ import { ResponsiveContainer } from 'recharts'
 import { ChartType, CoreChartProps } from './types'
 import { DEFAULT_COLORS } from './utils'
 import { renderChart } from './renderChart'
-import { transformNestedData } from './ChartUtils'
+import { normalizeChartData, transformNestedData } from './ChartUtils'
 
 export const CoreChart: React.FC<CoreChartProps> = ({
     chartType = ChartType.LINE,
-    data,
+    data: dataProp,
     colors = DEFAULT_COLORS,
     barsize,
     xAxis,
@@ -22,6 +22,8 @@ export const CoreChart: React.FC<CoreChartProps> = ({
     enableHover = false,
     lineSeriesKeys,
 }) => {
+    const data = normalizeChartData(dataProp)
+
     const [internalHoveredKey, setInternalHoveredKey] = useState<string | null>(
         null
     )

--- a/packages/blend/lib/components/Charts/types.tsx
+++ b/packages/blend/lib/components/Charts/types.tsx
@@ -151,7 +151,7 @@ export type RenderChartProps = {
 
 export type CoreChartProps = {
     chartType?: ChartType
-    data: NewNestedDataPoint[]
+    data?: NewNestedDataPoint[] | null
     colors?: { key: string; color: string }[]
     barsize?: number
     xAxis?: XAxisConfig
@@ -175,7 +175,7 @@ export type ChartsSkeletonProps = {
 
 export type ChartsProps = {
     chartType?: ChartType
-    data: NewNestedDataPoint[]
+    data?: NewNestedDataPoint[] | null
     colors?: { key: string; color: string }[]
     slot1?: ReactNode
     slot2?: ReactNode


### PR DESCRIPTION
### Summary

Charts crashes when data is undefined is fixed

### Issue Ticket

Closes #1452 
