### PR TITLE
fix: ChartV2 crashes when rendered without options resolved

### DIFF
--- a/packages/blend/lib/components/ChartsV2/ChartV2.tsx
+++ b/packages/blend/lib/components/ChartsV2/ChartV2.tsx
@@ -32,7 +32,7 @@ const ChartV2 = forwardRef<ChartV2ReactRefObject, ChartV2Props>(
         ref
     ) => {
         const tokens = useResponsiveTokens<ChartV2TokensType>('CHARTSV2')
-        const { options, ...restProps } = props
+        const { options = {}, ...restProps } = props
 
         const hasSeriesData =
             (options.series as ChartV2SeriesOptionsType[] | undefined)?.some(


### PR DESCRIPTION
### Summary

ChartV2 crashes when rendered without options resolved

Closes #1454 
