### PR TITLE
fix: AvatarGroup crashes when  is undefined fixed

### DIFF
--- a/packages/blend/lib/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/blend/lib/components/AvatarGroup/AvatarGroup.tsx
@@ -17,7 +17,7 @@ import { AvatarTokensType } from '../Avatar/avatar.tokens'
 const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
     (
         {
-            avatars,
+            avatars = [],
             maxCount = 5,
             size = AvatarSize.MD,
             shape = AvatarShape.CIRCULAR,


### PR DESCRIPTION
### Summary

AvatarGroup crashes when  is undefined fixed

### Issue Ticket

Closes #1456 
