### PR TITLE
fix: DateRangePicker crashes on a controlled value missing startDate …

### DIFF
--- a/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
+++ b/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { isControlledDateRange } from '../../../lib/components/DateRangePicker/utils'
+
+describe('isControlledDateRange', () => {
+    it('returns false for null, undefined, and empty objects', () => {
+        expect(isControlledDateRange(undefined)).toBe(false)
+        expect(isControlledDateRange(null)).toBe(false)
+        expect(isControlledDateRange({} as { startDate: Date })).toBe(false)
+    })
+
+    it('returns false when startDate is missing or invalid', () => {
+        expect(isControlledDateRange({ endDate: new Date('2024-06-01') })).toBe(
+            false
+        )
+        expect(
+            isControlledDateRange({
+                startDate: new Date('invalid'),
+            })
+        ).toBe(false)
+        expect(
+            isControlledDateRange({
+                startDate: '2024-06-01' as unknown as Date,
+            })
+        ).toBe(false)
+    })
+
+    it('returns true when startDate is a valid Date', () => {
+        const startDate = new Date('2024-06-01')
+        expect(isControlledDateRange({ startDate })).toBe(true)
+        expect(
+            isControlledDateRange({
+                startDate,
+                endDate: new Date('2024-06-15'),
+            })
+        ).toBe(true)
+    })
+})

--- a/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -25,6 +25,8 @@ import {
     getPresetLabel,
     getTodayInTimezone,
     validateDateInput,
+    isControlledDateRange,
+    isValidDate,
 } from './utils'
 import CalendarGrid from './CalendarGrid'
 import QuickRangeSelector from './QuickRangeSelector'
@@ -408,7 +410,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
 
         const [selectedRange, setSelectedRange] = useState<
             DateRange | undefined
-        >(value)
+        >(() => (isControlledDateRange(value) ? value : undefined))
         const lastExternalValueRef = React.useRef<{
             start: number | null
             end: number | null
@@ -524,32 +526,44 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
 
         const resetValues = useCallback(
             (dateRangeObj?: DateRange) => {
-                setSelectedRange(dateRangeObj)
+                const normalizedRange = isControlledDateRange(dateRangeObj)
+                    ? dateRangeObj
+                    : undefined
+
+                setSelectedRange(normalizedRange)
                 setActivePreset(
-                    dateRangeObj
-                        ? detectPresetFromRange(dateRangeObj, timezone)
+                    normalizedRange
+                        ? detectPresetFromRange(normalizedRange, timezone)
                         : DateRangePreset.CUSTOM
                 )
                 setStartDate(
-                    dateRangeObj &&
-                        formatDate(dateRangeObj.startDate, dateFormat, timezone)
+                    normalizedRange &&
+                        formatDate(
+                            normalizedRange.startDate,
+                            dateFormat,
+                            timezone
+                        )
                 )
-                if (dateRangeObj && dateRangeObj.endDate) {
+                if (normalizedRange?.endDate) {
                     setEndDate(
-                        formatDate(dateRangeObj.endDate, dateFormat, timezone)
+                        formatDate(
+                            normalizedRange.endDate,
+                            dateFormat,
+                            timezone
+                        )
                     )
-                } else if (!dateRangeObj) {
+                } else if (!normalizedRange) {
                     setEndDate(undefined)
                 }
                 setStartTime(
-                    dateRangeObj &&
-                        formatDate(dateRangeObj.startDate, 'HH:mm', timezone)
+                    normalizedRange &&
+                        formatDate(normalizedRange.startDate, 'HH:mm', timezone)
                 )
-                if (dateRangeObj && dateRangeObj.endDate) {
+                if (normalizedRange?.endDate) {
                     setEndTime(
-                        formatDate(dateRangeObj.endDate, 'HH:mm', timezone)
+                        formatDate(normalizedRange.endDate, 'HH:mm', timezone)
                     )
-                } else if (!dateRangeObj) {
+                } else if (!normalizedRange) {
                     setEndTime(undefined)
                 }
                 setStartDateValidation({ isValid: true, error: 'none' })
@@ -562,7 +576,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
         )
 
         useEffect(() => {
-            if (!value) {
+            if (!isControlledDateRange(value)) {
                 if (lastExternalValueRef.current !== null) {
                     lastExternalValueRef.current = null
                     resetValues(undefined)
@@ -571,8 +585,11 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
             }
 
             const nextSignature = {
-                start: value.startDate.getTime() ?? null,
-                end: value.endDate?.getTime() ?? null,
+                start: value.startDate.getTime(),
+                end:
+                    value.endDate && isValidDate(value.endDate)
+                        ? value.endDate.getTime()
+                        : null,
                 dateFormat,
             }
 

--- a/packages/blend/lib/components/DateRangePicker/utils.ts
+++ b/packages/blend/lib/components/DateRangePicker/utils.ts
@@ -256,6 +256,11 @@ export const isValidDate = (date: Date): boolean => {
     return date instanceof Date && !isNaN(date.getTime())
 }
 
+/** True when a controlled `value` has a usable start date (avoids `.getTime()` on undefined). */
+export const isControlledDateRange = (
+    value?: DateRange | null
+): value is DateRange => !!value && isValidDate(value.startDate)
+
 /**
  * Formats time in 12-hour format
  * @param date The date to format


### PR DESCRIPTION
…resolved

### Summary

DateRangePicker crashes on a controlled value missing startDate …

### Issue Ticket

Closes #1462 
