### PR TITLE
refactor: collapse redundant PresetsConfig union members (#1479)

### DIFF
--- a/packages/blend/lib/components/DateRangePicker/types.ts
+++ b/packages/blend/lib/components/DateRangePicker/types.ts
@@ -194,11 +194,11 @@ export type CustomPresetDefinition = {
 /**
  * Presets configuration - can be predefined presets, custom configs, or custom definitions
  */
-export type PresetsConfig =
-    | DateRangePreset[]
-    | CustomPresetConfig[]
-    | CustomPresetDefinition[]
-    | (DateRangePreset | CustomPresetConfig | CustomPresetDefinition)[]
+export type PresetsConfig = (
+    | DateRangePreset
+    | CustomPresetConfig
+    | CustomPresetDefinition
+)[]
 
 // =============================================================================
 // COMPONENT PROPS


### PR DESCRIPTION
## Summary

Fixes #1479. `PresetsConfig` in `DateRangePicker/types.ts` declared four union members where the first three are redundant.

Since `X[]` is assignable to `(X | Y | Z)[]`, `DateRangePreset[]`, `CustomPresetConfig[]`, and `CustomPresetDefinition[]` are fully subsumed by the fourth member. Collapsed to the single equivalent form:

```ts
export type PresetsConfig = (
    | DateRangePreset
    | CustomPresetConfig
    | CustomPresetDefinition
)[]
```

## Impact

Type-only, **no runtime change**. The simplified type is structurally identical, so existing consumers (`customPresets?: PresetsConfig`, etc.) are unaffected.

## Verification

- tsc --noEmit clean
- eslint clean on the file
- prettier --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
