### PR TITLE
fix: fixing codeblock copy timeout leaks

### DIFF
--- a/packages/blend/lib/components/CodeEditor/CodeEditor.tsx
+++ b/packages/blend/lib/components/CodeEditor/CodeEditor.tsx
@@ -1,9 +1,8 @@
-import { forwardRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
 import Block from '../Primitives/Block/Block'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import type { CodeBlockTokenType } from '../CodeBlock/codeBlock.token'
 import { CodeEditorVariant, type CodeEditorProps } from './types'
-import { createCopyToClipboard } from '../CodeBlock/utils'
 import { shouldShowLineNumbers, getContainerStyles } from './utils'
 import { CodeEditorHeader } from './CodeEditorHeader'
 import { MonacoEditorWrapper } from './MonacoEditorWrapper'
@@ -37,6 +36,31 @@ const CodeEditor = forwardRef<HTMLDivElement, CodeEditorProps>(
     ) => {
         const tokens = useResponsiveTokens<CodeBlockTokenType>('CODE_BLOCK')
         const [isCopied, setIsCopied] = useState(false)
+        const copyFeedbackTimeoutRef = useRef<ReturnType<
+            typeof setTimeout
+        > | null>(null)
+
+        useEffect(() => {
+            return () => {
+                if (copyFeedbackTimeoutRef.current !== null) {
+                    clearTimeout(copyFeedbackTimeoutRef.current)
+                }
+            }
+        }, [])
+
+        const copyToClipboard = useCallback(() => {
+            navigator.clipboard.writeText(value)
+            setIsCopied(true)
+
+            if (copyFeedbackTimeoutRef.current !== null) {
+                clearTimeout(copyFeedbackTimeoutRef.current)
+            }
+
+            copyFeedbackTimeoutRef.current = setTimeout(() => {
+                setIsCopied(false)
+                copyFeedbackTimeoutRef.current = null
+            }, 2000)
+        }, [value])
 
         // Determine if line numbers should be shown
         const shouldShowLineNumbersValue = shouldShowLineNumbers(
@@ -44,8 +68,6 @@ const CodeEditor = forwardRef<HTMLDivElement, CodeEditorProps>(
             variant
         )
 
-        // Handlers
-        const copyToClipboard = createCopyToClipboard(value, setIsCopied)
         const containerStyles = getContainerStyles(minHeight, maxHeight)
 
         return (

--- a/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
@@ -342,6 +342,7 @@ export const MonacoEditorWrapper = ({
     const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null)
     const monacoRef = useRef<typeof import('monaco-editor') | null>(null)
     const shortcutDisposables = useRef<Monaco.IDisposable[]>([])
+    const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
     const [isEditorReady, setIsEditorReady] = useState(false)
     const monacoLanguage = useMemo(() => mapLanguage(language), [language])
 
@@ -449,6 +450,14 @@ export const MonacoEditorWrapper = ({
         }
     }, [disposeShortcuts, isEditorReady, registerKeyboardShortcuts])
 
+    useEffect(() => {
+        return () => {
+            if (focusTimeoutRef.current !== null) {
+                clearTimeout(focusTimeoutRef.current)
+            }
+        }
+    }, [])
+
     const handleEditorDidMount: OnMount = (editor, monacoInstance) => {
         editorRef.current = editor
         monacoRef.current = monacoInstance
@@ -502,7 +511,10 @@ export const MonacoEditorWrapper = ({
         editor.onDidBlurEditorText(() => onBlur?.())
 
         if (autoFocus && !disabled && !readOnly) {
-            setTimeout(() => editor.focus(), EDITOR_FOCUS_DELAY_MS)
+            focusTimeoutRef.current = setTimeout(
+                () => editor.focus(),
+                EDITOR_FOCUS_DELAY_MS
+            )
         }
     }
 


### PR DESCRIPTION
### Summary

fixing the timeout problem when copy in code editor and component unmounts.

### Issue Ticket

Closes #1483 or Related to #1483
