### PR TITLE
fix: added break-word to prevent large value overflow

### DIFF
--- a/packages/blend/lib/components/DataTable/TableHeader/FilterComponents.tsx
+++ b/packages/blend/lib/components/DataTable/TableHeader/FilterComponents.tsx
@@ -618,6 +618,8 @@ export const SingleSelectItems: React.FC<{
                                                         .header.filter
                                                         .sortOption.fontWeight,
                                                 flexGrow: 1,
+                                                overflowWrap: 'break-word',
+                                                minWidth: 0,
                                             }}
                                         >
                                             {label}
@@ -824,6 +826,8 @@ export const MultiSelectItems: React.FC<{
                                                         .header.filter
                                                         .sortOption.fontWeight,
                                                 flexGrow: 1,
+                                                overflowWrap: 'break-word',
+                                                minWidth: 0,
                                             }}
                                         >
                                             {label}


### PR DESCRIPTION
### Summary

added `overflowWrap: 'break-word'` to prevent the filter from overflowing

### Issue Ticket

Closes #1501 or Related to #1501
