### PR TITLE
fix: statcard tooltip not visible in mobile view

### DIFF
--- a/packages/blend/lib/components/StatCard/StatCard.tsx
+++ b/packages/blend/lib/components/StatCard/StatCard.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useMemo, useRef, useState, useId } from 'react'
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useId,
+    type ReactNode,
+} from 'react'
 import {
     BarChart,
     Bar,
@@ -50,14 +58,32 @@ type StatCardHeaderTitleTextProps = {
     title: string
     titleId: string
     statCardToken: StatCardTokenType
+    isSmallScreen: boolean
 }
 
 const StatCardHeaderTitleText = ({
     title,
     titleId,
     statCardToken,
-}: StatCardHeaderTitleTextProps) => (
-    <Tooltip content={title}>
+    isSmallScreen,
+}: StatCardHeaderTitleTextProps) => {
+    const [forceTooltipOpen, setForceTooltipOpen] = useState<boolean>(false)
+    const titleRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !forceTooltipOpen) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (titleRef.current?.contains(event.target as Node)) return
+            setForceTooltipOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, forceTooltipOpen])
+
+    const titleText = (
         <Text
             as="span"
             id={titleId}
@@ -77,58 +103,173 @@ const StatCardHeaderTitleText = ({
         >
             {title}
         </Text>
-    </Tooltip>
-)
+    )
+
+    if (!isSmallScreen) {
+        return <Tooltip content={title}>{titleText}</Tooltip>
+    }
+
+    return (
+        <Block
+            ref={titleRef}
+            minWidth={0}
+            flexGrow={1}
+            onClick={() => {
+                setForceTooltipOpen(!forceTooltipOpen)
+            }}
+            style={{ cursor: 'pointer' }}
+        >
+            <Tooltip open={forceTooltipOpen} content={title}>
+                {titleText}
+            </Tooltip>
+        </Block>
+    )
+}
 
 type StatCardHelpIconProps = {
     helpIconText?: string
     title: string
     statCardToken: StatCardTokenType
+    isSmallScreen: boolean
 }
 
 const StatCardHelpIcon = ({
     helpIconText,
     title,
     statCardToken,
+    isSmallScreen,
 }: StatCardHelpIconProps) => {
+    const [forceTooltipOpen, setForceTooltipOpen] = useState<boolean>(false)
+    const helpIconRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !forceTooltipOpen) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (helpIconRef.current?.contains(event.target as Node)) return
+            setForceTooltipOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, forceTooltipOpen])
+
     if (!helpIconText) return null
+
+    const helpIconTrigger = (
+        <Block
+            as="span"
+            display="inline-flex"
+            alignItems="center"
+            justifyContent="center"
+            role="button"
+            tabIndex={0}
+            aria-label={helpIconText || `Help for ${title}`}
+        >
+            <CircleHelp
+                width={parseInt(
+                    statCardToken.textContainer.header.helpIcon.width?.toString() ||
+                        '16'
+                )}
+                height={parseInt(
+                    statCardToken.textContainer.header.helpIcon.width?.toString() ||
+                        '16'
+                )}
+                color={
+                    statCardToken.textContainer.header.helpIcon.color.default
+                }
+                aria-hidden="true"
+            />
+        </Block>
+    )
+
+    if (!isSmallScreen) {
+        return (
+            <Block
+                data-element="help-icon"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                flexShrink={0}
+            >
+                <Tooltip content={helpIconText}>{helpIconTrigger}</Tooltip>
+            </Block>
+        )
+    }
 
     return (
         <Block
+            ref={helpIconRef}
             data-element="help-icon"
             display="flex"
             alignItems="center"
             justifyContent="center"
             flexShrink={0}
+            onClick={() => {
+                setForceTooltipOpen(!forceTooltipOpen)
+            }}
         >
-            <Tooltip content={helpIconText}>
-                <Block
-                    as="span"
-                    display="inline-flex"
-                    alignItems="center"
-                    justifyContent="center"
-                    role="button"
-                    tabIndex={0}
-                    aria-label={helpIconText || `Help for ${title}`}
-                >
-                    <CircleHelp
-                        width={parseInt(
-                            statCardToken.textContainer.header.helpIcon.width?.toString() ||
-                                '16'
-                        )}
-                        height={parseInt(
-                            statCardToken.textContainer.header.helpIcon.width?.toString() ||
-                                '16'
-                        )}
-                        color={
-                            statCardToken.textContainer.header.helpIcon.color
-                                .default
-                        }
-                        aria-hidden="true"
-                    />
-                </Block>
+            <Tooltip open={forceTooltipOpen} content={helpIconText}>
+                {helpIconTrigger}
             </Tooltip>
         </Block>
+    )
+}
+
+type StatCardValueTooltipProps = {
+    content: ReactNode
+    isSmallScreen: boolean
+    children: ReactNode
+}
+
+const StatCardValueTooltip = ({
+    content,
+    isSmallScreen,
+    children,
+}: StatCardValueTooltipProps) => {
+    const [open, setOpen] = useState(false)
+    const triggerRef = useRef<HTMLSpanElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !open || !content) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            const target = event.target as Node
+            if (triggerRef.current?.contains(target)) return
+
+            const tooltipEl = document.querySelector('[data-tooltip="tooltip"]')
+            if (tooltipEl?.contains(target)) return
+
+            setOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, open, content])
+
+    if (content === undefined || content === null || content === '') {
+        return <>{children}</>
+    }
+
+    if (!isSmallScreen) {
+        return <Tooltip content={content}>{children}</Tooltip>
+    }
+
+    return (
+        <Tooltip content={content} open={open}>
+            <span
+                ref={triggerRef}
+                style={{ display: 'inline-flex', cursor: 'pointer' }}
+                onClick={(event) => {
+                    event.stopPropagation()
+                    setOpen(true)
+                }}
+            >
+                {children}
+            </span>
+        </Tooltip>
     )
 }
 
@@ -496,11 +637,13 @@ const StatCard = ({
                                 title={title}
                                 titleId={titleId}
                                 statCardToken={statCardToken}
+                                isSmallScreen={isSmallScreen}
                             />
                             <StatCardHelpIcon
                                 helpIconText={helpIconText}
                                 title={title}
                                 statCardToken={statCardToken}
+                                isSmallScreen={isSmallScreen}
                             />
                         </Block>
                     </Block>
@@ -522,30 +665,31 @@ const StatCard = ({
                                     : 'center'
                             }
                         >
-                            {
-                                <Tooltip content={valueTooltip || ''}>
-                                    <Text
-                                        as="span"
-                                        fontSize={
-                                            statCardToken.textContainer.stats
-                                                .title.value[variant].fontSize
-                                        }
-                                        fontWeight={
-                                            statCardToken.textContainer.stats
-                                                .title.value[variant].fontWeight
-                                        }
-                                        color={
-                                            statCardToken.textContainer.stats
-                                                .title.value[variant].color
-                                        }
-                                        style={{
-                                            cursor: 'pointer',
-                                        }}
-                                    >
-                                        {'--'}
-                                    </Text>
-                                </Tooltip>
-                            }
+                            <StatCardValueTooltip
+                                content={valueTooltip}
+                                isSmallScreen={isSmallScreen}
+                            >
+                                <Text
+                                    as="span"
+                                    fontSize={
+                                        statCardToken.textContainer.stats.title
+                                            .value[variant].fontSize
+                                    }
+                                    fontWeight={
+                                        statCardToken.textContainer.stats.title
+                                            .value[variant].fontWeight
+                                    }
+                                    color={
+                                        statCardToken.textContainer.stats.title
+                                            .value[variant].color
+                                    }
+                                    style={{
+                                        cursor: 'pointer',
+                                    }}
+                                >
+                                    {'--'}
+                                </Text>
+                            </StatCardValueTooltip>
                         </Block>
                         {!isSmallScreen && (
                             <Text
@@ -677,16 +821,17 @@ const StatCard = ({
                                                 title={title}
                                                 titleId={titleId}
                                                 statCardToken={statCardToken}
+                                                isSmallScreen={isSmallScreen}
                                             />
                                             <StatCardHelpIcon
                                                 helpIconText={helpIconText}
                                                 title={title}
                                                 statCardToken={statCardToken}
+                                                isSmallScreen={isSmallScreen}
                                             />
                                         </Block>
                                     )}
                                     {actionIcon &&
-                                        !isSmallScreen &&
                                         direction !==
                                             StatCardDirection.HORIZONTAL && (
                                             <Block
@@ -767,110 +912,37 @@ const StatCard = ({
                                                             .header.gap
                                                     }
                                                 >
-                                                    <Tooltip content={title}>
-                                                        <Text
-                                                            as="span"
-                                                            id={titleId}
-                                                            fontSize={
-                                                                statCardToken
-                                                                    .textContainer
-                                                                    .header
-                                                                    .title
-                                                                    .fontSize
-                                                            }
-                                                            fontWeight={
-                                                                statCardToken
-                                                                    .textContainer
-                                                                    .header
-                                                                    .title
-                                                                    .fontWeight
-                                                            }
-                                                            color={
-                                                                statCardToken
-                                                                    .textContainer
-                                                                    .header
-                                                                    .title.color
-                                                            }
-                                                            style={{
-                                                                display:
-                                                                    '-webkit-box',
-                                                                WebkitLineClamp: 1,
-                                                                WebkitBoxOrient:
-                                                                    'vertical',
-                                                                overflow:
-                                                                    'hidden',
-                                                                textOverflow:
-                                                                    'ellipsis',
-                                                                wordBreak:
-                                                                    'break-word',
-                                                            }}
-                                                            data-element="statcard-header"
-                                                            data-id={
-                                                                title ||
-                                                                'statcard-header'
-                                                            }
-                                                        >
-                                                            {title}
-                                                        </Text>
-                                                    </Tooltip>
-                                                    {helpIconText && (
-                                                        <Block
-                                                            data-element="help-icon"
-                                                            flexShrink={0}
-                                                            display="flex"
-                                                            alignItems="center"
-                                                            justifyContent="center"
-                                                        >
-                                                            <Tooltip
-                                                                content={
-                                                                    helpIconText
-                                                                }
-                                                            >
-                                                                <Block
-                                                                    as="span"
-                                                                    display="inline-flex"
-                                                                    alignItems="center"
-                                                                    justifyContent="center"
-                                                                    role="button"
-                                                                    tabIndex={0}
-                                                                    aria-label={
-                                                                        helpIconText ||
-                                                                        `Help for ${title}`
-                                                                    }
-                                                                >
-                                                                    <CircleHelp
-                                                                        width={parseInt(
-                                                                            statCardToken.textContainer.header.helpIcon.width?.toString() ||
-                                                                                '16'
-                                                                        )}
-                                                                        height={parseInt(
-                                                                            statCardToken.textContainer.header.helpIcon.width?.toString() ||
-                                                                                '16'
-                                                                        )}
-                                                                        color={
-                                                                            statCardToken
-                                                                                .textContainer
-                                                                                .header
-                                                                                .helpIcon
-                                                                                .color
-                                                                                .default
-                                                                        }
-                                                                        aria-hidden="true"
-                                                                    />
-                                                                </Block>
-                                                            </Tooltip>
-                                                        </Block>
-                                                    )}
+                                                    <StatCardHeaderTitleText
+                                                        title={title}
+                                                        titleId={titleId}
+                                                        statCardToken={
+                                                            statCardToken
+                                                        }
+                                                        isSmallScreen={
+                                                            isSmallScreen
+                                                        }
+                                                    />
+                                                    <StatCardHelpIcon
+                                                        helpIconText={
+                                                            helpIconText
+                                                        }
+                                                        title={title}
+                                                        statCardToken={
+                                                            statCardToken
+                                                        }
+                                                        isSmallScreen={
+                                                            isSmallScreen
+                                                        }
+                                                    />
                                                 </Block>
-                                                {actionIcon &&
-                                                    !isSmallScreen && (
-                                                        <Block
-                                                            data-element="view-more"
-                                                            flexShrink={0}
-                                                        >
-                                                            {actionIcon}
-                                                        </Block>
-                                                    )}
+                                                {actionIcon && (
+                                                    <Block
+                                                        data-element="view-more"
+                                                        flexShrink={0}
+                                                    >
+                                                        {actionIcon}
+                                                    </Block>
+                                                )}
                                             </Block>
                                         </Block>
                                     )}
@@ -887,7 +959,10 @@ const StatCard = ({
                                         alignItems="center"
                                         gap={4}
                                     >
-                                        <Tooltip content={valueTooltip || ''}>
+                                        <StatCardValueTooltip
+                                            content={valueTooltip}
+                                            isSmallScreen={isSmallScreen}
+                                        >
                                             <Text
                                                 as="span"
                                                 id={valueId}
@@ -914,7 +989,7 @@ const StatCard = ({
                                             >
                                                 {formatMainValue(value || '--')}
                                             </Text>
-                                        </Tooltip>
+                                        </StatCardValueTooltip>
 
                                         {formattedChange && (
                                             <Tooltip
@@ -1006,7 +1081,7 @@ const StatCard = ({
                                 style={{ flex: 1 }}
                                 position="relative"
                             >
-                                {actionIcon && !isSmallScreen && (
+                                {actionIcon && (
                                     <Block
                                         data-element="action-icon"
                                         display="flex"
@@ -1053,11 +1128,13 @@ const StatCard = ({
                                             title={title}
                                             titleId={titleId}
                                             statCardToken={statCardToken}
+                                            isSmallScreen={isSmallScreen}
                                         />
                                         <StatCardHelpIcon
                                             helpIconText={helpIconText}
                                             title={title}
                                             statCardToken={statCardToken}
+                                            isSmallScreen={isSmallScreen}
                                         />
                                     </Block>
                                 </Block>
@@ -1085,48 +1162,42 @@ const StatCard = ({
                                                 : 'center'
                                         }
                                     >
-                                        {
-                                            <Tooltip
-                                                content={valueTooltip || ''}
+                                        <StatCardValueTooltip
+                                            content={valueTooltip}
+                                            isSmallScreen={isSmallScreen}
+                                        >
+                                            <Text
+                                                as="span"
+                                                id={valueId}
+                                                fontSize={
+                                                    statCardToken.textContainer
+                                                        .stats.title.value[
+                                                        variant
+                                                    ].fontSize
+                                                }
+                                                fontWeight={
+                                                    statCardToken.textContainer
+                                                        .stats.title.value[
+                                                        variant
+                                                    ].fontWeight
+                                                }
+                                                color={
+                                                    statCardToken.textContainer
+                                                        .stats.title.value[
+                                                        variant
+                                                    ].color
+                                                }
+                                                style={{
+                                                    cursor: 'pointer',
+                                                }}
+                                                data-numeric={formatMainValue(
+                                                    value || '--'
+                                                )}
+                                                data-element="statcard-data"
                                             >
-                                                <Text
-                                                    as="span"
-                                                    id={valueId}
-                                                    fontSize={
-                                                        statCardToken
-                                                            .textContainer.stats
-                                                            .title.value[
-                                                            variant
-                                                        ].fontSize
-                                                    }
-                                                    fontWeight={
-                                                        statCardToken
-                                                            .textContainer.stats
-                                                            .title.value[
-                                                            variant
-                                                        ].fontWeight
-                                                    }
-                                                    color={
-                                                        statCardToken
-                                                            .textContainer.stats
-                                                            .title.value[
-                                                            variant
-                                                        ].color
-                                                    }
-                                                    style={{
-                                                        cursor: 'pointer',
-                                                    }}
-                                                    data-numeric={formatMainValue(
-                                                        value || '--'
-                                                    )}
-                                                    data-element="statcard-data"
-                                                >
-                                                    {formatMainValue(
-                                                        value || '--'
-                                                    )}
-                                                </Text>
-                                            </Tooltip>
-                                        }
+                                                {formatMainValue(value || '--')}
+                                            </Text>
+                                        </StatCardValueTooltip>
                                         {formattedChange && (
                                             <Tooltip
                                                 content={change?.tooltip || ''}

--- a/packages/blend/lib/components/StatCardV2/StatCardV2.tsx
+++ b/packages/blend/lib/components/StatCardV2/StatCardV2.tsx
@@ -37,6 +37,7 @@ const StatCardV2 = forwardRef<HTMLDivElement, StatCardV2Props>(
             variant = StatCardV2Variant.NUMBER,
             actionIcon,
             value,
+            valueTooltip,
             progressValue,
             change,
             subtitle,
@@ -198,6 +199,7 @@ const StatCardV2 = forwardRef<HTMLDivElement, StatCardV2Props>(
                                     title={title}
                                     helpIconText={helpIconText}
                                     tokens={tokens}
+                                    isSmallScreen={isSmallScreen}
                                 />
                                 <Block
                                     display="flex"
@@ -215,8 +217,10 @@ const StatCardV2 = forwardRef<HTMLDivElement, StatCardV2Props>(
                                         <StatCardV2Value
                                             id={valueId}
                                             value={value}
+                                            valueTooltip={valueTooltip}
                                             tokens={tokens}
                                             variant={variant}
+                                            isSmallScreen={isSmallScreen}
                                         />
                                         <StatCardV2Change
                                             id={changeId}
@@ -227,6 +231,7 @@ const StatCardV2 = forwardRef<HTMLDivElement, StatCardV2Props>(
                                                 effectiveArrowDirection
                                             }
                                             changeType={effectiveChangeType}
+                                            tooltip={change?.tooltip}
                                             tokens={tokens}
                                         />
                                     </Block>

--- a/packages/blend/lib/components/StatCardV2/StatCardV2Change.tsx
+++ b/packages/blend/lib/components/StatCardV2/StatCardV2Change.tsx
@@ -2,6 +2,7 @@ import { ArrowDown, ArrowUp } from 'lucide-react'
 import { addPxToValue } from '../../global-utils/GlobalUtils'
 import Block from '../Primitives/Block/Block'
 import Text from '../Text/Text'
+import { Tooltip } from '../Tooltip'
 import {
     StatCardV2ArrowDirection,
     type StatCardV2ChangeProps,
@@ -13,6 +14,7 @@ const StatCardV2Change = ({
     rightSymbol,
     arrowDirection,
     changeType,
+    tooltip,
     tokens,
     id,
 }: StatCardV2ChangeProps) => {
@@ -24,7 +26,7 @@ const StatCardV2Change = ({
 
     if (changeValueText === undefined || changeValueText === null) return null
 
-    return (
+    const changeContent = (
         <Block
             display="flex"
             alignItems="center"
@@ -33,6 +35,7 @@ const StatCardV2Change = ({
                     .gap
             }
             data-element="statcard-delta"
+            cursor={tooltip ? 'pointer' : undefined}
         >
             <Block
                 data-element="change-arrow"
@@ -84,6 +87,12 @@ const StatCardV2Change = ({
             </Block>
         </Block>
     )
+
+    if (!tooltip) {
+        return changeContent
+    }
+
+    return <Tooltip content={tooltip}>{changeContent}</Tooltip>
 }
 
 export default StatCardV2Change

--- a/packages/blend/lib/components/StatCardV2/StatCardV2NoData.tsx
+++ b/packages/blend/lib/components/StatCardV2/StatCardV2NoData.tsx
@@ -102,6 +102,7 @@ const StatCardV2NoData = ({
                             title={title}
                             helpIconText={helpIconText}
                             tokens={tokens}
+                            isSmallScreen={isSmallScreen}
                         />
                     </Block>
                 </Block>

--- a/packages/blend/lib/components/StatCardV2/StatCardV2Title.tsx
+++ b/packages/blend/lib/components/StatCardV2/StatCardV2Title.tsx
@@ -1,80 +1,210 @@
+import { useEffect, useRef, useState } from 'react'
 import { CircleHelp } from 'lucide-react'
 import { addPxToValue } from '../../global-utils/GlobalUtils'
 import Block from '../Primitives/Block/Block'
 import Text from '../Text/Text'
 import { Tooltip } from '../Tooltip'
 import type { StatCardV2TitleProps } from './statcardV2.types'
+import type { StatCardV2TokensType } from './statcardV2.tokens'
+
+type StatCardV2TitleTextProps = {
+    title: string
+    id?: string
+    tokens: StatCardV2TokensType
+    isSmallScreen: boolean
+}
+
+const StatCardV2TitleText = ({
+    title,
+    id,
+    tokens,
+    isSmallScreen,
+}: StatCardV2TitleTextProps) => {
+    const [forceTooltipOpen, setForceTooltipOpen] = useState(false)
+    const titleRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !forceTooltipOpen) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (titleRef.current?.contains(event.target as Node)) return
+            setForceTooltipOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, forceTooltipOpen])
+
+    const titleText = (
+        <Text
+            id={id}
+            fontSize={
+                tokens.topContainer.dataContainer.titleContainer.title.fontSize
+            }
+            fontWeight={
+                tokens.topContainer.dataContainer.titleContainer.title
+                    .fontWeight
+            }
+            lineHeight={addPxToValue(
+                tokens.topContainer.dataContainer.titleContainer.title
+                    .lineHeight
+            )}
+            color={tokens.topContainer.dataContainer.titleContainer.title.color}
+            style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                wordBreak: 'break-word',
+            }}
+            data-element="statcard-header"
+            data-id={title || 'statcard-header'}
+        >
+            {title}
+        </Text>
+    )
+
+    if (!isSmallScreen) {
+        return <Tooltip content={title}>{titleText}</Tooltip>
+    }
+
+    return (
+        <Block
+            ref={titleRef}
+            minWidth={0}
+            flexGrow={1}
+            onClick={() => {
+                setForceTooltipOpen(!forceTooltipOpen)
+            }}
+            style={{ cursor: 'pointer' }}
+        >
+            <Tooltip open={forceTooltipOpen} content={title}>
+                {titleText}
+            </Tooltip>
+        </Block>
+    )
+}
+
+type StatCardV2HelpIconProps = {
+    helpIconText: string
+    title: string
+    tokens: StatCardV2TokensType
+    isSmallScreen: boolean
+}
+
+const StatCardV2HelpIcon = ({
+    helpIconText,
+    title,
+    tokens,
+    isSmallScreen,
+}: StatCardV2HelpIconProps) => {
+    const [forceTooltipOpen, setForceTooltipOpen] = useState(false)
+    const helpIconRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !forceTooltipOpen) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            if (helpIconRef.current?.contains(event.target as Node)) return
+            setForceTooltipOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, forceTooltipOpen])
+
+    const helpIconTrigger = (
+        <Block
+            as="span"
+            display="inline-flex"
+            alignItems="center"
+            justifyContent="center"
+            role="button"
+            tabIndex={0}
+            aria-label={helpIconText || `Help for ${title}`}
+        >
+            <CircleHelp
+                width={
+                    tokens.topContainer.dataContainer.titleContainer.helpIcon
+                        .width
+                }
+                height={
+                    tokens.topContainer.dataContainer.titleContainer.helpIcon
+                        .height
+                }
+                color={
+                    tokens.topContainer.dataContainer.titleContainer.helpIcon
+                        .color.default
+                }
+                aria-hidden="true"
+            />
+        </Block>
+    )
+
+    if (!isSmallScreen) {
+        return (
+            <Block
+                data-element="help-icon"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                flexShrink={0}
+            >
+                <Tooltip content={helpIconText}>{helpIconTrigger}</Tooltip>
+            </Block>
+        )
+    }
+
+    return (
+        <Block
+            ref={helpIconRef}
+            data-element="help-icon"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            flexShrink={0}
+            onClick={() => {
+                setForceTooltipOpen(!forceTooltipOpen)
+            }}
+        >
+            <Tooltip open={forceTooltipOpen} content={helpIconText}>
+                {helpIconTrigger}
+            </Tooltip>
+        </Block>
+    )
+}
 
 const StatCardV2Title = ({
     title,
     helpIconText,
     tokens,
     id,
+    isSmallScreen = false,
 }: StatCardV2TitleProps) => {
     if (!title) return null
+
     return (
         <Block
             display="flex"
             alignItems="center"
             gap={tokens.topContainer.dataContainer.titleContainer.gap}
         >
-            <Text
+            <StatCardV2TitleText
+                title={title}
                 id={id}
-                fontSize={
-                    tokens.topContainer.dataContainer.titleContainer.title
-                        .fontSize
-                }
-                fontWeight={
-                    tokens.topContainer.dataContainer.titleContainer.title
-                        .fontWeight
-                }
-                lineHeight={addPxToValue(
-                    tokens.topContainer.dataContainer.titleContainer.title
-                        .lineHeight
-                )}
-                color={
-                    tokens.topContainer.dataContainer.titleContainer.title.color
-                }
-                data-element="statcard-header"
-                data-id={title || 'statcard-header'}
-            >
-                {title}
-            </Text>
+                tokens={tokens}
+                isSmallScreen={isSmallScreen}
+            />
             {helpIconText && (
-                <Block
-                    data-element="help-icon"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                >
-                    <Tooltip content={helpIconText}>
-                        <Block
-                            as="span"
-                            display="inline-flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            role="button"
-                            tabIndex={0}
-                            aria-label={helpIconText || `Help for ${title}`}
-                        >
-                            <CircleHelp
-                                width={
-                                    tokens.topContainer.dataContainer
-                                        .titleContainer.helpIcon.width
-                                }
-                                height={
-                                    tokens.topContainer.dataContainer
-                                        .titleContainer.helpIcon.height
-                                }
-                                color={
-                                    tokens.topContainer.dataContainer
-                                        .titleContainer.helpIcon.color.default
-                                }
-                                aria-hidden="true"
-                            />
-                        </Block>
-                    </Tooltip>
-                </Block>
+                <StatCardV2HelpIcon
+                    helpIconText={helpIconText}
+                    title={title}
+                    tokens={tokens}
+                    isSmallScreen={isSmallScreen}
+                />
             )}
         </Block>
     )

--- a/packages/blend/lib/components/StatCardV2/StatCardV2Value.tsx
+++ b/packages/blend/lib/components/StatCardV2/StatCardV2Value.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { addPxToValue } from '../../global-utils/GlobalUtils'
 import Block from '../Primitives/Block/Block'
 import Text from '../Text/Text'
+import { Tooltip } from '../Tooltip'
 import type { StatCardV2Props, StatCardV2Variant } from './statcardV2.types'
 import type { StatCardV2TokensType } from './statcardV2.tokens'
 
@@ -32,16 +34,76 @@ export const renderVariantFallbackValue = (
     )
 }
 
+type StatCardV2ValueTooltipProps = {
+    content: ReactNode
+    isSmallScreen: boolean
+    children: ReactNode
+}
+
+const StatCardV2ValueTooltip = ({
+    content,
+    isSmallScreen,
+    children,
+}: StatCardV2ValueTooltipProps) => {
+    const [open, setOpen] = useState(false)
+    const triggerRef = useRef<HTMLSpanElement>(null)
+
+    useEffect(() => {
+        if (!isSmallScreen || !open || !content) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            const target = event.target as Node
+            if (triggerRef.current?.contains(target)) return
+
+            const tooltipEl = document.querySelector('[data-tooltip="tooltip"]')
+            if (tooltipEl?.contains(target)) return
+
+            setOpen(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () =>
+            document.removeEventListener('pointerdown', handlePointerDown)
+    }, [isSmallScreen, open, content])
+
+    if (content === undefined || content === null || content === '') {
+        return <>{children}</>
+    }
+
+    if (!isSmallScreen) {
+        return <Tooltip content={content}>{children}</Tooltip>
+    }
+
+    return (
+        <Tooltip content={content} open={open}>
+            <span
+                ref={triggerRef}
+                style={{ display: 'inline-flex', cursor: 'pointer' }}
+                onClick={(event) => {
+                    event.stopPropagation()
+                    setOpen(true)
+                }}
+            >
+                {children}
+            </span>
+        </Tooltip>
+    )
+}
+
 const StatCardV2Value = ({
     value,
+    valueTooltip,
     tokens,
     variant,
     id,
+    isSmallScreen = false,
 }: {
     value: StatCardV2Props['value']
+    valueTooltip?: ReactNode
     tokens: StatCardV2TokensType
     variant: StatCardV2Variant
     id?: string
+    isSmallScreen?: boolean
 }) => {
     const valueTokens = tokens.topContainer.dataContainer.statsContainer.value
 
@@ -51,16 +113,22 @@ const StatCardV2Value = ({
             : STATCARD_FALLBACK_DISPLAY
 
     return (
-        <Text
-            id={id}
-            fontSize={valueTokens[variant].fontSize}
-            fontWeight={valueTokens[variant].fontWeight}
-            lineHeight={addPxToValue(valueTokens[variant].lineHeight)}
-            color={valueTokens[variant].color}
-            data-element="statcard-data"
+        <StatCardV2ValueTooltip
+            content={valueTooltip}
+            isSmallScreen={isSmallScreen}
         >
-            {displayValue}
-        </Text>
+            <Text
+                id={id}
+                fontSize={valueTokens[variant].fontSize}
+                fontWeight={valueTokens[variant].fontWeight}
+                lineHeight={addPxToValue(valueTokens[variant].lineHeight)}
+                color={valueTokens[variant].color}
+                style={valueTooltip ? { cursor: 'pointer' } : undefined}
+                data-element="statcard-data"
+            >
+                {displayValue}
+            </Text>
+        </StatCardV2ValueTooltip>
     )
 }
 

--- a/packages/blend/lib/components/StatCardV2/statcardV2.types.ts
+++ b/packages/blend/lib/components/StatCardV2/statcardV2.types.ts
@@ -50,6 +50,7 @@ export type StatCardV2TitleProps = {
     helpIconText?: string
     tokens: StatCardV2TokensType
     id?: string
+    isSmallScreen?: boolean
 }
 
 export type StatCardV2ChangeProps = {
@@ -59,6 +60,7 @@ export type StatCardV2ChangeProps = {
     arrowDirection: StatCardV2ArrowDirection
     changeType: StatCardV2ChangeType
     tokens: StatCardV2TokensType
+    tooltip?: ReactNode
     id?: string
 }
 
@@ -76,6 +78,7 @@ export type StatCardV2Props = {
     value?: string
     progressValue?: number
     helpIconText?: string
+    valueTooltip?: ReactNode
     change?: StatCardV2Change
     subtitle?: string
     options?: ChartV2Options


### PR DESCRIPTION


https://github.com/user-attachments/assets/06b01660-0afe-4728-9ad4-b2e3f0f50d1c


### Summary

statcard tooltip not visible in mobile view fixed
### Issue Ticket

Closes #1514 
