### PR TITLE
fix: added border below tabs v2 in underline variant

### DIFF
--- a/apps/site/src/demos/SidebarV2Demo.tsx
+++ b/apps/site/src/demos/SidebarV2Demo.tsx
@@ -700,7 +700,7 @@ const SidebarV2Demo = () => {
                         showOnMobile: true,
                     },
                     {
-                        label: 'Tag ejdojdojodjoejdoejdoejdojdojedojeodjeodjedd ejodjoejdoehdohedoh',
+                        label: 'Tag',
                         leftSlot: (
                             <TagIcon
                                 style={{ width: '16px', height: '16px' }}

--- a/packages/blend/lib/components/TabsV2/TabsV2List.tsx
+++ b/packages/blend/lib/components/TabsV2/TabsV2List.tsx
@@ -343,6 +343,7 @@ const TabsV2List = forwardRef<HTMLDivElement, TabsV2ListProps>(
                 data-element="tabs-list"
                 data-status={expanded ? 'expanded' : 'collapsed'}
                 style={{
+                    width: '100%',
                     position: stickyHeader ? 'sticky' : 'relative',
                     top: stickyHeader ? offsetTop : 'auto',
                     zIndex: stickyHeader
@@ -351,7 +352,10 @@ const TabsV2List = forwardRef<HTMLDivElement, TabsV2ListProps>(
                     backgroundColor: stickyHeader
                         ? stickyHeaderBackground
                         : 'transparent',
-                    borderBottom: 'none',
+                    borderBottom:
+                        variant === TabsV2Variant.UNDERLINE && !hasAnySkeleton
+                            ? tabsToken.tabList.borderBottom[variant]
+                            : 'none',
                     boxShadow: stickyHeader
                         ? tabsToken.tabList.stickyHeader.boxShadow
                         : 'none',

--- a/packages/blend/lib/components/TabsV2/tabsV2.dark.tokens.ts
+++ b/packages/blend/lib/components/TabsV2/tabsV2.dark.tokens.ts
@@ -123,6 +123,12 @@ export const getTabsV2DarkTokens = (
                         },
                     },
                 },
+                borderBottom: {
+                    [TabsV2Variant.UNDERLINE]: `${foundationToken.border.width[1]} solid ${foundationToken.colors.gray[700]}`,
+                    [TabsV2Variant.BOXED]: 'none',
+                    [TabsV2Variant.FLOATING]: 'none',
+                    [TabsV2Variant.PILLS]: 'none',
+                },
                 activeIndicator: {
                     height: foundationToken.border.width[2],
                     color: foundationToken.colors.gray[200],
@@ -457,6 +463,12 @@ export const getTabsV2DarkTokens = (
                             left: foundationToken.unit[4],
                         },
                     },
+                },
+                borderBottom: {
+                    [TabsV2Variant.UNDERLINE]: `${foundationToken.border.width[1]} solid ${foundationToken.colors.gray[700]}`,
+                    [TabsV2Variant.BOXED]: 'none',
+                    [TabsV2Variant.FLOATING]: 'none',
+                    [TabsV2Variant.PILLS]: 'none',
                 },
                 activeIndicator: {
                     height: foundationToken.border.width[2],

--- a/packages/blend/lib/components/TabsV2/tabsV2.light.tokens.ts
+++ b/packages/blend/lib/components/TabsV2/tabsV2.light.tokens.ts
@@ -123,6 +123,12 @@ export const getTabsV2LightTokens = (
                         },
                     },
                 },
+                borderBottom: {
+                    [TabsV2Variant.UNDERLINE]: `${foundationToken.border.width[1]} solid ${foundationToken.colors.gray[200]}`,
+                    [TabsV2Variant.BOXED]: 'none',
+                    [TabsV2Variant.FLOATING]: 'none',
+                    [TabsV2Variant.PILLS]: 'none',
+                },
                 activeIndicator: {
                     height: foundationToken.border.width[2],
                     color: foundationToken.colors.gray[700],
@@ -457,6 +463,12 @@ export const getTabsV2LightTokens = (
                             left: foundationToken.unit[4],
                         },
                     },
+                },
+                borderBottom: {
+                    [TabsV2Variant.UNDERLINE]: `${foundationToken.border.width[1]} solid ${foundationToken.colors.gray[200]}`,
+                    [TabsV2Variant.BOXED]: 'none',
+                    [TabsV2Variant.FLOATING]: 'none',
+                    [TabsV2Variant.PILLS]: 'none',
                 },
                 activeIndicator: {
                     height: foundationToken.border.width[2],

--- a/packages/blend/lib/components/TabsV2/tabsV2.tokens.types.ts
+++ b/packages/blend/lib/components/TabsV2/tabsV2.tokens.types.ts
@@ -25,6 +25,9 @@ export type TabsV2TokensType = {
                 }
             }
         }
+        borderBottom: {
+            [key in TabsV2Variant]: CSSObject['borderBottom']
+        }
         activeIndicator: {
             height: CSSObject['height']
             color: CSSObject['color']


### PR DESCRIPTION
### Summary

added border bottom in in tabsv2 

### Issue Ticket

Closes #1523 or Related to #1523

<img width="1552" height="572" alt="Screenshot 2026-06-16 at 3 26 27 PM" src="https://github.com/user-attachments/assets/ad1bd4e9-64f2-4f34-8df9-167e96c50f96" />
