### PR TITLE
fix: explicit flat return types for useSkeletonBase and getTruncatedText

### DIFF
--- a/packages/blend/lib/components/Skeleton/hooks/useSkeletonBase.ts
+++ b/packages/blend/lib/components/Skeleton/hooks/useSkeletonBase.ts
@@ -2,11 +2,21 @@ import { type ReactNode } from 'react'
 import { useResponsiveTokens } from '../../../hooks/useResponsiveTokens'
 import type { SkeletonTokensType } from '../skeleton.tokens'
 
+export type UseSkeletonBaseResult = {
+    shouldRender: boolean
+    fallback: ReactNode | null
+    tokens: SkeletonTokensType | null
+    prefersReducedMotion: boolean
+}
+
 /**
  * Shared hook for all skeleton components to eliminate code duplication
  * Handles token fetching, loading state, and motion preferences
  */
-export const useSkeletonBase = (loading: boolean, children?: ReactNode) => {
+export const useSkeletonBase = (
+    loading: boolean,
+    children?: ReactNode
+): UseSkeletonBaseResult => {
     const tokens = useResponsiveTokens<SkeletonTokensType>('SKELETON')
 
     // Check for motion preferences (accessibility)

--- a/packages/blend/lib/global-utils/GlobalUtils.ts
+++ b/packages/blend/lib/global-utils/GlobalUtils.ts
@@ -18,7 +18,16 @@ export const capitalizeFirstLetter = (string: string): string => {
     return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
 }
 
-export const getTruncatedText = (text: string, limit?: number) => {
+export type TruncatedTextResult = {
+    truncatedValue: string
+    fullValue: string
+    isTruncated: boolean
+}
+
+export const getTruncatedText = (
+    text: string,
+    limit?: number
+): TruncatedTextResult => {
     const shouldTruncate =
         typeof limit === 'number' && limit > 0 && text.length > limit
 


### PR DESCRIPTION
## Summary
Closes #1533.

`useSkeletonBase`'s return type was **inferred** as a 2-arm union of two object shapes with identical keys (only `fallback`/`tokens` flip between a value and `null`). With no discriminant the union was never narrowable, so the split bought nothing while leaking a verbose inferred type (the full React 19 `ReactNode` expansion — incl. `Promise<AwaitedReactNode>` / `bigint`) into the published `.d.ts`.

This PR replaces it with a single explicit flat type.

## Changes
- **`useSkeletonBase`** (`packages/blend/lib/components/Skeleton/hooks/useSkeletonBase.ts`): added explicit `UseSkeletonBaseResult` return type, exactly as proposed in the issue.
- **`getTruncatedText`** (`packages/blend/lib/global-utils/GlobalUtils.ts`): found while reviewing for the same pattern — it had the identical issue (inferred `isTruncated: false | true` 2-arm union). Now typed via an explicit `TruncatedTextResult`.

Both existing return branches satisfy the new flat types; backward-compatible for field readers (the old unions were never narrowable anyway).

## Type-only
No runtime behavior change. `tsc`, `eslint`, and prettier all pass.

> Note on the secondary suggestion in the issue (reviewing whether internal helpers like `getItemSlots`, `createStubAnchorClickEvent`, `configureLanguageDefaults` belong on the public export surface): left out of this PR since it's an API-surface decision, not a type-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)