### PR TITLE
fix: removing the override of the datatable text size

### DIFF
--- a/packages/blend/lib/components/DataTable/TableCell/index.tsx
+++ b/packages/blend/lib/components/DataTable/TableCell/index.tsx
@@ -485,8 +485,6 @@ const TableCell = forwardRef<
                         <TruncatedTextWithTooltip
                             text={date ? formatDate(date) : '-'}
                             style={{
-                                fontSize:
-                                    FOUNDATION_THEME.font.size.body.sm.fontSize,
                                 color: FOUNDATION_THEME.colors.gray[700],
                             }}
                         />


### PR DESCRIPTION
### Summary

fix the size of text in date column 

### Issue Ticket

Closes #1539 or Related to #1539
