### PR TITLE
fix: fix the header getting overlapped in statCard

### DIFF
--- a/apps/site/src/demos/StatCardDemo.tsx
+++ b/apps/site/src/demos/StatCardDemo.tsx
@@ -116,7 +116,7 @@ const StatCardDemo = () => {
         return (
             <Popover
                 heading="Help Information"
-                trigger={<span>+4 more</span>}
+                trigger={<span className="text-blue-500">+4 more</span>}
                 side="top"
                 showCloseButton={false}
                 minWidth={280}
@@ -142,6 +142,170 @@ const StatCardDemo = () => {
 
     return (
         <div className="p-8 space-y-12">
+            {/* Refund Dashboard */}
+            <div className="space-y-6">
+                <h2 className="text-2xl font-bold">Refund Dashboard</h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <StatCard
+                        title="Refunds Success Rate"
+                        value="92.75%"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Percentage of refunds processed successfully"
+                    />
+                    <StatCard
+                        title="Refunds Volume"
+                        value="8.83L"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Total number of refund transactions"
+                    />
+                    <StatCard
+                        title="Processed Refund Amount"
+                        value="₹62.62Cr"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Total amount of refunds processed"
+                        actionIcon={<InfoPopoverExample />}
+                    />
+                    <StatCard
+                        title="Manual Review Rate"
+                        value="0.00%"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Percentage of refunds requiring manual review"
+                    />
+                    <StatCard
+                        title="Manual Review Count"
+                        value="33"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Number of refunds pending manual review"
+                    />
+                    <StatCard
+                        title="Refund Pending Rate"
+                        value="7.00%"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Percentage of refunds still pending"
+                    />
+                    <StatCard
+                        title="Refund Pending for 5+ days"
+                        value="0"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Refunds pending for more than 5 days"
+                    />
+                    <StatCard
+                        title="Refund Latency"
+                        value="24M 32S"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Average time taken to process refunds"
+                    />
+                    <StatCard
+                        title="TP 50 Latency"
+                        value="21M 7S"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="50th percentile refund processing time"
+                    />
+                    <StatCard
+                        title="ARN Latency (TP 50)"
+                        value="0S"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="50th percentile ARN generation time"
+                    />
+                    <StatCard
+                        title="ARN Latency (TP 90)"
+                        value="0S"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="90th percentile ARN generation time"
+                    />
+                    <StatCard
+                        title="ARN Availability Rate"
+                        value="83.09%"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Percentage of refunds with ARN available"
+                    />
+                </div>
+            </div>
+
+            {/* Refund Details Table */}
+            <div className="space-y-4">
+                <h3 className="text-lg font-semibold">Refund Details</h3>
+                <div className="border rounded-lg overflow-hidden">
+                    <table className="w-full text-sm text-left">
+                        <thead className="bg-gray-50 text-gray-700">
+                            <tr>
+                                <th className="px-4 py-3 font-medium">
+                                    Merchant Id
+                                </th>
+                                <th className="px-4 py-3 font-medium">
+                                    Payment Gateway
+                                </th>
+                                <th className="px-4 py-3 font-medium">
+                                    Payment Method Type
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                            <tr className="bg-white">
+                                <td className="px-4 py-3 text-gray-500">—</td>
+                                <td className="px-4 py-3 text-gray-500">—</td>
+                                <td className="px-4 py-3 text-gray-500">—</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {/* Overlap Failure Scenarios */}
+            <div className="space-y-6">
+                <h2 className="text-2xl font-bold">
+                    Overlap Failure Scenarios
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <StatCard
+                        title="Very long title that should collide with a wide +4 more button in a narrow card"
+                        value="₹62.62Cr"
+                        variant={StatCardVariant.NUMBER}
+                        actionIcon={<InfoPopoverExample />}
+                    />
+                    <div className="max-w-50">
+                        <StatCard
+                            title="Processed Refund Amount"
+                            value="₹62.62Cr"
+                            variant={StatCardVariant.NUMBER}
+                            actionIcon={<InfoPopoverExample />}
+                        />
+                    </div>
+                    <StatCard
+                        title="Processed Refund Amount"
+                        value="₹62.62Cr"
+                        variant={StatCardVariant.NUMBER}
+                        actionIcon={
+                            <span className="text-blue-500 whitespace-nowrap">
+                                +4 more
+                            </span>
+                        }
+                    />
+                    <StatCard
+                        title="Processed Refund Amount"
+                        value="₹62.62Cr"
+                        variant={StatCardVariant.NUMBER}
+                        helpIconText="Total amount of refunds processed"
+                        actionIcon={<InfoPopoverExample />}
+                    />
+                    <div className="max-w-60">
+                        <StatCard
+                            title="Processed Refund Amount"
+                            value="₹62.62Cr"
+                            variant={StatCardVariant.NUMBER}
+                            helpIconText="Total amount of refunds processed"
+                            actionIcon={<InfoPopoverExample />}
+                        />
+                    </div>
+                    <StatCard
+                        title="Successful Authorized Amount"
+                        value="0 د.إ"
+                        variant={StatCardVariant.NUMBER}
+                        actionIcon={<InfoPopoverExample />}
+                    />
+                </div>
+            </div>
+
             {/* Playground Section */}
             <div className="space-y-6">
                 <h2 className="text-2xl font-bold">Playground</h2>

--- a/packages/blend/lib/components/StatCard/StatCard.tsx
+++ b/packages/blend/lib/components/StatCard/StatCard.tsx
@@ -39,6 +39,7 @@ import type { StatCardTokenType } from './statcard.tokens'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { BREAKPOINTS } from '../../breakpoints/breakPoints'
 import { useBreakpoints } from '../../hooks/useBreakPoints'
+import { useResizeObserver } from '../../hooks/useResizeObserver'
 import {
     SelectMenuSize,
     SelectMenuVariant,
@@ -304,6 +305,12 @@ const StatCard = ({
     const isSmallScreen = breakPointLabel === 'sm'
     const titleIconRef = useRef<HTMLDivElement>(null)
     const titleIconWidth = titleIconRef.current?.offsetWidth || 0
+    const actionIconRef = useRef<HTMLDivElement>(null)
+    const [actionIconWidth, setActionIconWidth] = useState(0)
+
+    useResizeObserver(actionIconRef, (rect) => {
+        setActionIconWidth(rect.width)
+    })
 
     const [hoveredBarIndex, setHoveredBarIndex] = useState<number | null>(null)
 
@@ -824,6 +831,16 @@ const StatCard = ({
                                                 statCardToken.textContainer
                                                     .header.gap
                                             }
+                                            paddingRight={
+                                                actionIcon
+                                                    ? actionIconWidth +
+                                                      toPixels(
+                                                          statCardToken
+                                                              .textContainer
+                                                              .header.gap
+                                                      )
+                                                    : undefined
+                                            }
                                         >
                                             <StatCardHeaderTitleText
                                                 title={title}
@@ -843,6 +860,7 @@ const StatCard = ({
                                         direction !==
                                             StatCardDirection.HORIZONTAL && (
                                             <Block
+                                                ref={actionIconRef}
                                                 data-element="view-more"
                                                 display="flex"
                                                 alignItems="center"
@@ -1091,6 +1109,7 @@ const StatCard = ({
                             >
                                 {actionIcon && (
                                     <Block
+                                        ref={actionIconRef}
                                         data-element="action-icon"
                                         display="flex"
                                         alignItems="flex-start"
@@ -1130,6 +1149,16 @@ const StatCard = ({
                                         gap={
                                             statCardToken.textContainer.header
                                                 .gap
+                                        }
+                                        paddingRight={
+                                            actionIcon
+                                                ? actionIconWidth +
+                                                  toPixels(
+                                                      statCardToken
+                                                          .textContainer.header
+                                                          .gap
+                                                  )
+                                                : undefined
                                         }
                                     >
                                         <StatCardHeaderTitleText


### PR DESCRIPTION
### Summary

fixing the header of the statCard getting overlapped with the right slot

### Issue Ticket

Closes #1551 or Related to #1551


before 
<img width="895" height="348" alt="Screenshot 2026-07-01 at 3 23 28 PM" src="https://github.com/user-attachments/assets/f3aae438-dcd8-4641-bad6-4c0547e0c438" />

after
<img width="895" height="348" alt="Screenshot 2026-07-01 at 3 35 44 PM" src="https://github.com/user-attachments/assets/ead20d76-4c6a-4ef2-8caa-2d13397eb300" />
