### PR TITLE
feat: add search ranking and onEnter callback to MenuV2

### DIFF
--- a/apps/site/src/demos/MenuV2Demo.tsx
+++ b/apps/site/src/demos/MenuV2Demo.tsx
@@ -22,6 +22,7 @@ import {
     MapPin,
     Star,
     Shield,
+    Search,
 } from 'lucide-react'
 
 const basicItems: MenuV2GroupType[] = [
@@ -165,6 +166,172 @@ const manyItems: MenuV2GroupType[] = [
         ],
     },
 ]
+
+const rankedSearchItems: MenuV2GroupType[] = [
+    {
+        label: 'Results',
+        items: [
+            {
+                label: {
+                    text: 'Advanced Search Tools',
+                    leftSlot: <Search size={16} />,
+                },
+                onClick: () => console.log('Advanced Search Tools clicked'),
+            },
+            {
+                label: {
+                    text: 'Search',
+                    leftSlot: <Search size={16} />,
+                },
+                onClick: () => console.log('Search clicked'),
+            },
+            {
+                label: {
+                    text: 'Search Settings',
+                    leftSlot: <Settings size={16} />,
+                },
+                onClick: () => console.log('Search Settings clicked'),
+            },
+            {
+                label: {
+                    text: 'Deep Search',
+                    leftSlot: <Search size={16} />,
+                },
+                onClick: () => console.log('Deep Search clicked'),
+            },
+        ],
+    },
+]
+
+const submenuSearchItems: MenuV2GroupType[] = [
+    {
+        label: 'Locations',
+        showSeparator: true,
+        items: [
+            {
+                label: {
+                    text: 'United States',
+                    leftSlot: <MapPin size={16} />,
+                },
+                enableSubMenuSearch: true,
+                subMenuSearchPlaceholder: 'Search states...',
+                subMenu: [
+                    {
+                        label: { text: 'California' },
+                        onClick: () => console.log('California'),
+                    },
+                    {
+                        label: { text: 'New York' },
+                        onClick: () => console.log('New York'),
+                    },
+                    {
+                        label: { text: 'Texas' },
+                        onClick: () => console.log('Texas'),
+                    },
+                    {
+                        label: { text: 'Washington' },
+                        onClick: () => console.log('Washington'),
+                    },
+                ],
+            },
+        ],
+    },
+]
+
+// Edge-case demo data ----------------------------------------------------
+
+const subLabelRankItems: MenuV2GroupType[] = [
+    {
+        label: 'Mixed matches',
+        items: [
+            {
+                label: { text: 'Advanced Tools' },
+                subLabel: 'Search',
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Search' },
+                subLabel: 'Quick find',
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Deep Search' },
+                subLabel: 'Full-text index',
+                onClick: () => {},
+            },
+        ],
+    },
+]
+
+const disabledInSearchItems: MenuV2GroupType[] = [
+    {
+        label: 'Actions',
+        items: [
+            {
+                label: { text: 'Search' },
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Search Archives (disabled)' },
+                disabled: true,
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Recent' },
+                onClick: () => {},
+            },
+        ],
+    },
+]
+
+const edgeCaseItems: MenuV2GroupType[] = [
+    {
+        label: 'Edge cases',
+        items: [
+            {
+                label: { text: 'Apple' },
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Banana' },
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Apricot' },
+                onClick: () => {},
+            },
+            {
+                label: { text: 'Avocado' },
+                onClick: () => {},
+            },
+        ],
+    },
+]
+
+const submenuEnterItems: MenuV2GroupType[] = [
+    {
+        label: 'Locations',
+        items: [
+            {
+                label: { text: 'United States' },
+                enableSubMenuSearch: true,
+                subMenuSearchPlaceholder: 'Search states...',
+                onSubMenuSearchEnter: (query, results) => {
+                    console.log(
+                        `Sub-menu Enter: query="${query}", results=[${results
+                            .map((r) => r.label.text)
+                            .join(', ')}]`
+                    )
+                },
+                subMenu: [
+                    { label: { text: 'California' } },
+                    { label: { text: 'New York' } },
+                    { label: { text: 'Texas' } },
+                ],
+            },
+        ],
+    },
+]
 function generateLargeMenu(count: number): MenuV2GroupType[] {
     const items: MenuV2ItemType[] = Array.from({ length: count }, (_, i) => ({
         id: `item-${i}`,
@@ -186,6 +353,7 @@ function generateLargeMenu(count: number): MenuV2GroupType[] {
 
 const MenuV2Demo = () => {
     const [lastAction, setLastAction] = useState<string>('')
+    const [lastEnter, setLastEnter] = useState<string>('')
 
     // Playground state
     const [triggerLabel, setTriggerLabel] = useState('Open menu')
@@ -199,7 +367,25 @@ const MenuV2Demo = () => {
     )
     const [side, setSide] = useState<MenuV2Side>(MenuV2Side.BOTTOM)
     const [enableVirtualScrolling, setEnableVirtualScrolling] = useState(false)
+    const [useCustomSort, setUseCustomSort] = useState(false)
     const largeItems = useMemo(() => generateLargeMenu(500), [])
+
+    // Reverse-alphabetical custom sort, overrides the default ranking
+    const customSortFn = useMemo(
+        () => (items: MenuV2ItemType[]) =>
+            [...items].sort((a, b) => b.label.text.localeCompare(a.label.text)),
+        []
+    )
+
+    // Identity sort: returns items unchanged (simulates "keep my order")
+    const identitySortFn = useMemo(() => (items: MenuV2ItemType[]) => items, [])
+
+    // Last-enter trackers for the edge-case demos
+    const [edgeEnter, setEdgeEnter] = useState<string>('none')
+    const [subLabelEnter, setSubLabelEnter] = useState<string>('none')
+    const [emptyEnter, setEmptyEnter] = useState<string>('none')
+    const [whitespaceEnter, setWhitespaceEnter] = useState<string>('none')
+    const [topMatchEnter, setTopMatchEnter] = useState<string>('none')
 
     const withLog = (items: MenuV2GroupType[]): MenuV2GroupType[] =>
         items.map((group) => ({
@@ -426,11 +612,366 @@ const MenuV2Demo = () => {
                 </div>
             </section>
 
+            <section className="space-y-4">
+                <h2 className="text-2xl font-bold">
+                    Search ranking &amp; Enter callback
+                </h2>
+                <p className="text-gray-600">
+                    By default, search results are ranked{' '}
+                    <strong>exact → prefix → substring</strong>. Toggle the
+                    custom sort to override the default ranking, and type a
+                    query then press <kbd>Enter</kbd> to fire{' '}
+                    <code>onEnter</code>.
+                </p>
+
+                <div className="flex items-center gap-6 flex-wrap">
+                    <Switch
+                        label="Use custom reverse-alpha sort"
+                        checked={useCustomSort}
+                        onChange={() => setUseCustomSort(!useCustomSort)}
+                    />
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2">
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">Ranked search</h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open ranked search"
+                                />
+                            }
+                            items={withLog(rankedSearchItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'search'..."
+                            searchSortFn={
+                                useCustomSort ? customSortFn : undefined
+                            }
+                            onEnter={(query, filteredGroups) => {
+                                const top = filteredGroups[0]?.items[0]
+                                setLastEnter(
+                                    top
+                                        ? `"${query}" → "${top.label.text}"`
+                                        : `"${query}" → no results`
+                                )
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Try <code>search</code>. Default ranks the exact
+                            “Search” item first; with custom sort on, results
+                            are reverse-alphabetical.
+                        </p>
+                    </div>
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            Sub-menu search ranking
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open submenu search"
+                                />
+                            }
+                            items={withLog(submenuSearchItems)}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Hover <strong>United States</strong> and type in the
+                            sub-menu search. Results are ranked the same way.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <section className="space-y-4">
+                <h2 className="text-2xl font-bold">
+                    Search &amp; Enter edge cases
+                </h2>
+                <p className="text-gray-600">
+                    Each card below exercises a specific edge case of the search
+                    ranking and <code>onEnter</code> callback.
+                </p>
+
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {/* 1. SubLabel-only exact match ranks above label substring */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            1. subLabel exact beats label substring
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (subLabel ranking)"
+                                />
+                            }
+                            items={withLog(subLabelRankItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'search'..."
+                            onEnter={(query, filteredGroups) => {
+                                const top = filteredGroups[0]?.items[0]
+                                setSubLabelEnter(
+                                    top
+                                        ? `"${query}" → "${top.label.text}" (sub: "${top.subLabel}")`
+                                        : `"${query}" → no results`
+                                )
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Item “Advanced Tools” has subLabel “Search” (exact).
+                            It should rank above “Deep Search” (label
+                            substring). Type <code>search</code>.
+                        </p>
+                    </div>
+
+                    {/* 2. No matches at all */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            2. no matches → Enter with empty results
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (no matches)"
+                                />
+                            }
+                            items={withLog(edgeCaseItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'xyz'..."
+                            onEnter={(query, filteredGroups) => {
+                                setEmptyEnter(
+                                    `"${query}" → ${filteredGroups.length} groups, ${filteredGroups.reduce(
+                                        (n, g) => n + g.items.length,
+                                        0
+                                    )} items`
+                                )
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Type <code>xyz</code> (matches nothing). Pressing
+                            Enter still fires <code>onEnter</code> with an empty
+                            result set.
+                        </p>
+                    </div>
+
+                    {/* 3. Disabled items still appear in search */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            3. disabled items still match
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (disabled in search)"
+                                />
+                            }
+                            items={withLog(disabledInSearchItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'search'..."
+                        />
+                        <p className="text-xs text-gray-500">
+                            The disabled “Search Archives” item still appears
+                            for <code>search</code> — filtering is by match, not
+                            by disabled state.
+                        </p>
+                    </div>
+
+                    {/* 4. Case-insensitive ranking */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            4. case-insensitive ranking
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (case-insensitive)"
+                                />
+                            }
+                            items={withLog(rankedSearchItems)}
+                            enableSearch
+                            searchPlaceholder="Try 'SEARCH' vs 'search'..."
+                        />
+                        <p className="text-xs text-gray-500">
+                            <code>SEARCH</code> and <code>search</code> produce
+                            identical ranking — comparison is lowercased.
+                        </p>
+                    </div>
+
+                    {/* 5. Whitespace-only query is a no-op */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            5. whitespace-only query → no-op
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (whitespace query)"
+                                />
+                            }
+                            items={withLog(edgeCaseItems)}
+                            enableSearch
+                            searchPlaceholder="Type only spaces..."
+                            onEnter={(query, filteredGroups) => {
+                                setWhitespaceEnter(
+                                    `"${query}" → ${filteredGroups.reduce(
+                                        (n, g) => n + g.items.length,
+                                        0
+                                    )} items (unchanged)`
+                                )
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Typing only spaces is treated as an empty query —
+                            all items remain, in their original order.
+                        </p>
+                    </div>
+
+                    {/* 6. Custom identity sort keeps declaration order */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            6. identity sort overrides ranking
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (identity sort)"
+                                />
+                            }
+                            items={withLog(rankedSearchItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'search'..."
+                            searchSortFn={identitySortFn}
+                        />
+                        <p className="text-xs text-gray-500">
+                            A custom <code>searchSortFn</code> that returns
+                            items unchanged — declaration order survives, even
+                            though matches are filtered.
+                        </p>
+                    </div>
+
+                    {/* 7. Empty search text Enter */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            7. Enter on empty query
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (empty Enter)"
+                                />
+                            }
+                            items={withLog(edgeCaseItems)}
+                            enableSearch
+                            searchPlaceholder="Press Enter without typing..."
+                            onEnter={(query, filteredGroups) => {
+                                setEdgeEnter(
+                                    `"${query}" → ${filteredGroups.reduce(
+                                        (n, g) => n + g.items.length,
+                                        0
+                                    )} items`
+                                )
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Press Enter without typing. <code>onEnter</code>{' '}
+                            fires with the full, unfiltered item list.
+                        </p>
+                    </div>
+
+                    {/* 8. Sub-menu search Enter callback */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            8. sub-menu search Enter
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (sub-menu Enter)"
+                                />
+                            }
+                            items={withLog(submenuEnterItems)}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Hover <strong>United States</strong>, type{' '}
+                            <code>cal</code> in the sub-menu search, press
+                            Enter. <code>onSubMenuSearchEnter</code> fires with
+                            the sub-results (see console).
+                        </p>
+                    </div>
+
+                    {/* 9. Partial query + Enter → open the first match */}
+                    <div className="space-y-2">
+                        <h3 className="text-lg font-semibold">
+                            9. partial type + Enter → first match
+                        </h3>
+                        <MenuV2
+                            trigger={
+                                <Button
+                                    buttonType={ButtonType.SECONDARY}
+                                    text="Open (partial Enter)"
+                                />
+                            }
+                            items={withLog(rankedSearchItems)}
+                            enableSearch
+                            searchPlaceholder="Type 'se' then press Enter..."
+                            onEnter={(query, filteredGroups) => {
+                                const top = filteredGroups[0]?.items[0]
+                                if (top) {
+                                    setTopMatchEnter(
+                                        `"${query}" → opened "${top.label.text}"`
+                                    )
+                                    top.onClick?.()
+                                } else {
+                                    setTopMatchEnter(`"${query}" → no match`)
+                                }
+                            }}
+                        />
+                        <p className="text-xs text-gray-500">
+                            Type a partial query like <code>se</code> and press
+                            Enter without arrowing down. The handler reads the
+                            top-ranked result from <code>filteredGroups</code>{' '}
+                            and triggers its <code>onClick</code> directly —
+                            command-palette style.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
             {lastAction && (
                 <p className="text-sm text-gray-500">
                     Last action: <strong>{lastAction}</strong>
                 </p>
             )}
+            {lastEnter && (
+                <p className="text-sm text-gray-500">
+                    Last Enter: <strong>{lastEnter}</strong>
+                </p>
+            )}
+            <div className="text-xs text-gray-500 space-y-1">
+                <p>
+                    Edge 1 subLabel Enter: <strong>{subLabelEnter}</strong>
+                </p>
+                <p>
+                    Edge 2 no-match Enter: <strong>{emptyEnter}</strong>
+                </p>
+                <p>
+                    Edge 5 whitespace Enter: <strong>{whitespaceEnter}</strong>
+                </p>
+                <p>
+                    Edge 7 empty-query Enter: <strong>{edgeEnter}</strong>
+                </p>
+                <p>
+                    Edge 9 partial-type Enter: <strong>{topMatchEnter}</strong>
+                </p>
+            </div>
         </div>
     )
 }

--- a/apps/storybook/stories/components/Menu/v2/MenuV2.stories.tsx
+++ b/apps/storybook/stories/components/Menu/v2/MenuV2.stories.tsx
@@ -5,6 +5,7 @@ import { expect, userEvent, within } from '@storybook/test'
 import {
     MenuV2,
     type MenuV2GroupType,
+    type MenuV2ItemType,
     MenuV2Alignment,
     MenuV2Side,
 } from '../../../../../../packages/blend/lib/components/MenuV2'
@@ -92,6 +93,8 @@ import { MenuV2 } from '@juspay/blend-design-system';
 - Grouped items with optional separators
 - Nested sub-menus
 - Optional search inside the menu
+- Search results ranked by relevance (exact → prefix → substring) by default; override via \`searchSortFn\`
+- \`onEnter\` callback for command-palette-style "confirm search" behavior
 - Controlled or uncontrolled open state
 
                 `,
@@ -145,6 +148,16 @@ import { MenuV2 } from '@juspay/blend-design-system';
         onOpenChange: {
             action: 'openChange',
             description: 'Called when menu opens or closes',
+        },
+        searchSortFn: {
+            control: false,
+            description:
+                'Custom sort function `(items, searchText) => items`. Overrides the default exact → prefix → substring ranking.',
+        },
+        onEnter: {
+            action: 'enter',
+            description:
+                'Fired when Enter is pressed while the search input is focused. Receives `(searchText, filteredGroups)`.',
         },
     },
     tags: ['autodocs'],
@@ -314,6 +327,186 @@ export const Interactive: Story = {
         docs: {
             description: {
                 story: 'Open the menu and choose an action. The button label and Actions panel show the result.',
+            },
+        },
+    },
+}
+
+const rankedItems: MenuV2GroupType[] = [
+    {
+        label: 'Results',
+        items: [
+            { label: { text: 'Advanced Search Tools' } },
+            { label: { text: 'Search' } },
+            { label: { text: 'Search Settings' } },
+            { label: { text: 'Deep Search' } },
+        ],
+    },
+]
+
+export const WithSearchRanking: Story = {
+    render: function WithSearchRankingRender() {
+        return (
+            <div className="flex flex-col gap-3">
+                <MenuV2
+                    trigger={
+                        <Button buttonType={ButtonType.SECONDARY}>
+                            Ranked search
+                        </Button>
+                    }
+                    items={rankedItems}
+                    enableSearch
+                    searchPlaceholder="Type 'search' to see ranking..."
+                />
+                <p className="text-xs text-gray-600">
+                    Type <code>search</code> in the box. Results are ordered
+                    exact match → prefix match → substring match. The item
+                    declared last (“Search”) jumps to the top.
+                </p>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `Search results are ranked by relevance using a stable tiered sort:
+**exact match → prefix match → substring match**.
+
+This is the default behavior — no prop required. Items at the same tier
+preserve their original declaration order (stable sort).`,
+            },
+        },
+    },
+}
+
+export const WithCustomSearchSort: Story = {
+    render: function WithCustomSearchSortRender() {
+        // Reverse-alphabetical custom sort overrides the default ranking
+        const customSort = (
+            items: MenuV2ItemType[],
+            _searchText: string
+        ): MenuV2ItemType[] =>
+            [...items].sort((a, b) => b.label.text.localeCompare(a.label.text))
+
+        return (
+            <div className="flex flex-col gap-3">
+                <MenuV2
+                    trigger={
+                        <Button buttonType={ButtonType.SECONDARY}>
+                            Custom sort
+                        </Button>
+                    }
+                    items={rankedItems}
+                    enableSearch
+                    searchPlaceholder="Custom reverse-alpha sort..."
+                    searchSortFn={customSort}
+                />
+                <p className="text-xs text-gray-600">
+                    A custom <code>searchSortFn</code> fully overrides the
+                    default ranking. Here results are sorted reverse-
+                    alphabetically regardless of match tier.
+                </p>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `Pass a \`searchSortFn: (items, searchText) => items\` to fully control result ordering. The default tiered ranking is skipped entirely when this prop is supplied.`,
+            },
+        },
+    },
+}
+
+export const WithSearchEnter: Story = {
+    render: function WithSearchEnterRender() {
+        const [lastEnter, setLastEnter] = React.useState<string>('none')
+
+        return (
+            <div className="flex flex-col gap-3">
+                <MenuV2
+                    trigger={
+                        <Button buttonType={ButtonType.SECONDARY}>
+                            Search + Enter
+                        </Button>
+                    }
+                    items={rankedItems}
+                    enableSearch
+                    searchPlaceholder="Type, then press Enter..."
+                    onEnter={(query, filteredGroups) => {
+                        const top = filteredGroups[0]?.items[0]
+                        setLastEnter(
+                            top
+                                ? `query="${query}" → top="${top.label.text}"`
+                                : `query="${query}" → no results`
+                        )
+                    }}
+                />
+                <div className="text-xs text-gray-600">
+                    Last Enter: <strong>{lastEnter}</strong>
+                </div>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `When the user presses **Enter** while focused on the search input, \`onEnter(searchText, filteredGroups)\` fires — letting the consumer act on the query or the top-ranked result (e.g. command-palette-style navigation).`,
+            },
+        },
+    },
+}
+
+const submenuSearchItems: MenuV2GroupType[] = [
+    {
+        label: 'Locations',
+        items: [
+            {
+                label: { text: 'United States' },
+                enableSubMenuSearch: true,
+                subMenuSearchPlaceholder: 'Search states...',
+                onSubMenuSearchEnter: (query, results) => {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                        `Sub-menu Enter: query="${query}", top="${results[0]?.label.text ?? 'none'}"`
+                    )
+                },
+                subMenu: [
+                    { label: { text: 'California' } },
+                    { label: { text: 'New York' } },
+                    { label: { text: 'Texas' } },
+                    { label: { text: 'Washington' } },
+                ],
+            },
+        ],
+    },
+]
+
+export const WithSubmenuSearchRanking: Story = {
+    render: function WithSubmenuSearchRankingRender() {
+        return (
+            <div className="flex flex-col gap-3">
+                <MenuV2
+                    trigger={
+                        <Button buttonType={ButtonType.SECONDARY}>
+                            Submenu search
+                        </Button>
+                    }
+                    items={submenuSearchItems}
+                />
+                <p className="text-xs text-gray-600">
+                    Open the menu, hover <strong>United States</strong> to
+                    reveal its sub-menu search. Typing in the sub-menu search
+                    applies the same exact → prefix → substring ranking, and
+                    pressing Enter fires <code>onSubMenuSearchEnter</code>.
+                </p>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `Per-item sub-menu search also ranks results by relevance. Set \`enableSubMenuSearch\` on the parent item and (optionally) \`onSubMenuSearchEnter\` to handle Enter while the sub-menu search input is focused.`,
             },
         },
     },

--- a/packages/blend/__tests__/components/MenuV2/MenuV2.test.tsx
+++ b/packages/blend/__tests__/components/MenuV2/MenuV2.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '../../test-utils'
+import { render, screen, waitFor, fireEvent } from '../../test-utils'
 import userEvent from '@testing-library/user-event'
 import MenuV2 from '../../../lib/components/MenuV2/MenuV2'
 import type { MenuV2GroupType } from '../../../lib/components/MenuV2/menuV2.types'
@@ -39,6 +39,36 @@ const createSearchItems = (): MenuV2GroupType[] => [
             { label: { text: 'Mostar' } },
             { label: { text: 'Moscow' } },
             { label: { text: 'Mumbai' } },
+        ],
+    },
+]
+
+const createRankedSearchItems = (): MenuV2GroupType[] => [
+    {
+        label: 'Results',
+        items: [
+            { label: { text: 'Advanced Search Tools' }, onClick: vi.fn() },
+            { label: { text: 'Search' }, onClick: vi.fn() },
+            { label: { text: 'Search Settings' }, onClick: vi.fn() },
+        ],
+    },
+]
+
+const createSubmenuSearchItems = (): MenuV2GroupType[] => [
+    {
+        label: 'Locations',
+        items: [
+            {
+                label: { text: 'United States' },
+                enableSubMenuSearch: true,
+                subMenuSearchPlaceholder: 'Search states...',
+                onSubMenuSearchEnter: vi.fn(),
+                subMenu: [
+                    { label: { text: 'California' }, onClick: vi.fn() },
+                    { label: { text: 'New York' }, onClick: vi.fn() },
+                    { label: { text: 'Texas' }, onClick: vi.fn() },
+                ],
+            },
         ],
     },
 ]
@@ -252,5 +282,154 @@ describe('MenuV2', () => {
         await waitFor(() => {
             expect(screen.getByText('California')).toBeInTheDocument()
         })
+    })
+
+    it('ranks search results so exact match appears before prefix and substring', async () => {
+        const user = userEvent.setup()
+        render(
+            <MenuV2
+                trigger={<button type="button">Ranked</button>}
+                items={createRankedSearchItems()}
+                enableSearch
+                searchPlaceholder="Search..."
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: /ranked/i }))
+        const searchInput = await screen.findByPlaceholderText('Search...')
+        await user.type(searchInput, 'search')
+
+        await waitFor(() => {
+            const items = screen.getAllByRole('menuitem')
+            const texts = items.map((i) => i.textContent)
+            // Exact "Search" should come before prefix "Search Settings"
+            // and substring "Advanced Search Tools"
+            const searchIdx = texts.findIndex((t) => t === 'Search')
+            const prefixIdx = texts.findIndex((t) => t === 'Search Settings')
+            const subIdx = texts.findIndex((t) => t === 'Advanced Search Tools')
+            expect(searchIdx).toBeLessThan(prefixIdx)
+            expect(prefixIdx).toBeLessThan(subIdx)
+        })
+    })
+
+    it('calls onEnter with the current search text and filtered groups when Enter is pressed in the search input', async () => {
+        const user = userEvent.setup()
+        const onEnter = vi.fn()
+        render(
+            <MenuV2
+                trigger={<button type="button">Enter</button>}
+                items={createSearchItems()}
+                enableSearch
+                searchPlaceholder="Search cities..."
+                onEnter={onEnter}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: /enter/i }))
+        const searchInput =
+            await screen.findByPlaceholderText('Search cities...')
+        await user.type(searchInput, 'mos')
+        await user.keyboard('{Enter}')
+
+        await waitFor(() => {
+            expect(onEnter).toHaveBeenCalledTimes(1)
+        })
+        const [query, filteredGroups] = onEnter.mock.calls[0]
+        expect(query).toBe('mos')
+        // At least one group, with at least one matching item (Moscow, Mostar)
+        expect(filteredGroups.length).toBeGreaterThan(0)
+        const matchedTexts = filteredGroups[0].items.map(
+            (i: { label: { text: string } }) => i.label.text
+        )
+        expect(matchedTexts).toContain('Moscow')
+        expect(matchedTexts).toContain('Mostar')
+    })
+
+    it('does not call onEnter when enableSearch is false', async () => {
+        const user = userEvent.setup()
+        const onEnter = vi.fn()
+        render(
+            <MenuV2
+                trigger={<button type="button">No search</button>}
+                items={createBasicItems()}
+                onEnter={onEnter}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: /no search/i }))
+        await user.keyboard('{Enter}')
+        expect(onEnter).not.toHaveBeenCalled()
+    })
+
+    it('honors a custom searchSortFn that overrides the default ranking', async () => {
+        const user = userEvent.setup()
+        // Reverse-alphabetical custom sort
+        const customSort = (
+            items: { label: { text: string } }[],
+            _searchText: string
+        ) => [...items].sort().reverse()
+        render(
+            <MenuV2
+                trigger={<button type="button">Custom sort</button>}
+                items={createSearchItems()}
+                enableSearch
+                searchPlaceholder="Search cities..."
+                searchSortFn={customSort as never}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: /custom sort/i }))
+        const searchInput =
+            await screen.findByPlaceholderText('Search cities...')
+        await user.type(searchInput, 'mo')
+
+        await waitFor(() => {
+            const items = screen.getAllByRole('menuitem')
+            const texts = items.map((i) => i.textContent)
+            // Custom sort reverses alphabetical order of matches
+            const mostarIdx = texts.findIndex((t) => t === 'Mostar')
+            const moscowIdx = texts.findIndex((t) => t === 'Moscow')
+            const mumbaiIdx = texts.findIndex((t) => t === 'Mumbai')
+            // Mumbai shouldn't match "mo" at all
+            expect(mumbaiIdx).toBe(-1)
+            expect(moscowIdx).toBeLessThan(mostarIdx)
+        })
+    })
+
+    it('fires onSubMenuSearchEnter with query and filtered results when Enter is pressed in the sub-menu search input', async () => {
+        const user = userEvent.setup()
+        const items = createSubmenuSearchItems()
+        const onSubMenuSearchEnter = items[0].items[0]
+            .onSubMenuSearchEnter as ReturnType<typeof vi.fn>
+
+        render(
+            <MenuV2
+                trigger={<button type="button">Submenu search</button>}
+                items={items}
+            />
+        )
+
+        await user.click(
+            screen.getByRole('button', { name: /submenu search/i })
+        )
+        const parent = await screen.findByRole('menuitem', {
+            name: /united states/i,
+        })
+        await user.click(parent)
+
+        const subSearchInput =
+            await screen.findByPlaceholderText('Search states...')
+        // fireEvent is used for the keydown to reliably target the sub-menu
+        // portal input in jsdom (userEvent.keyboard can lose focus in portals).
+        fireEvent.change(subSearchInput, { target: { value: 'cal' } })
+        fireEvent.keyDown(subSearchInput, { key: 'Enter', code: 'Enter' })
+
+        await waitFor(() => {
+            expect(onSubMenuSearchEnter).toHaveBeenCalledTimes(1)
+        })
+        const [query, filteredResults] = onSubMenuSearchEnter.mock.calls[0]
+        expect(query).toBe('cal')
+        expect(filteredResults.length).toBe(1)
+        expect(filteredResults[0].label.text).toBe('California')
     })
 })

--- a/packages/blend/__tests__/components/MenuV2/MenuV2.test.tsx
+++ b/packages/blend/__tests__/components/MenuV2/MenuV2.test.tsx
@@ -364,10 +364,8 @@ describe('MenuV2', () => {
     it('honors a custom searchSortFn that overrides the default ranking', async () => {
         const user = userEvent.setup()
         // Reverse-alphabetical custom sort
-        const customSort = (
-            items: { label: { text: string } }[],
-            _searchText: string
-        ) => [...items].sort().reverse()
+        const customSort = (items: { label: { text: string } }[]) =>
+            [...items].sort().reverse()
         render(
             <MenuV2
                 trigger={<button type="button">Custom sort</button>}

--- a/packages/blend/__tests__/components/MenuV2/utils.test.ts
+++ b/packages/blend/__tests__/components/MenuV2/utils.test.ts
@@ -4,6 +4,9 @@ import {
     filterMenuV2Item,
     getItemSlots,
     flattenMenuV2Groups,
+    getItemMatchRank,
+    defaultSearchSortFn,
+    MenuV2MatchRank,
 } from '../../../lib/components/MenuV2/menuV2.utils'
 import type {
     MenuV2GroupType,
@@ -153,5 +156,167 @@ describe('MenuV2 utils', () => {
         expect(result).toHaveLength(1)
         expect(result[0].label).toBe('Second')
         expect(result[0].items[0].label.text).toBe('Beta')
+    })
+
+    describe('getItemMatchRank', () => {
+        it('returns EXACT when label.text equals the query (case-insensitive)', () => {
+            const item = createItem({ label: { text: 'Search' } })
+            // getItemMatchRank expects a pre-lowercased query (internal helper)
+            expect(getItemMatchRank(item, 'search')).toBe(MenuV2MatchRank.EXACT)
+        })
+
+        it('returns EXACT for label.text that matches ignoring case (caller lowercases)', () => {
+            const item = createItem({ label: { text: 'SEARCH' } })
+            expect(getItemMatchRank(item, 'search')).toBe(MenuV2MatchRank.EXACT)
+        })
+
+        it('returns PREFIX when label.text starts with the query', () => {
+            const item = createItem({ label: { text: 'Settings' } })
+            expect(getItemMatchRank(item, 'set')).toBe(MenuV2MatchRank.PREFIX)
+        })
+
+        it('returns SUBSTRING when the query appears mid-string', () => {
+            const item = createItem({
+                label: { text: 'Advanced Search Tools' },
+            })
+            expect(getItemMatchRank(item, 'search')).toBe(
+                MenuV2MatchRank.SUBSTRING
+            )
+        })
+
+        it('returns NONE when neither label nor subLabel matches', () => {
+            const item = createItem({
+                label: { text: 'Profile' },
+                subLabel: 'Account info',
+            })
+            expect(getItemMatchRank(item, 'xyz')).toBe(MenuV2MatchRank.NONE)
+        })
+
+        it('uses the better rank across label.text and subLabel', () => {
+            const item = createItem({
+                label: { text: 'Advanced Search Tools' },
+                subLabel: 'Search',
+            })
+            // label is SUBSTRING, subLabel is EXACT -> best rank is EXACT
+            expect(getItemMatchRank(item, 'search')).toBe(MenuV2MatchRank.EXACT)
+        })
+
+        it('matches via subLabel only when label.text does not match', () => {
+            const item = createItem({
+                label: { text: 'Enterprise' },
+                subLabel: 'Full feature set',
+            })
+            expect(getItemMatchRank(item, 'full')).toBe(MenuV2MatchRank.PREFIX)
+        })
+    })
+
+    describe('defaultSearchSortFn', () => {
+        it('returns items unchanged when search text is empty', () => {
+            const items = [
+                createItem({ id: 'a', label: { text: 'Apple' } }),
+                createItem({ id: 'b', label: { text: 'Banana' } }),
+            ]
+            expect(defaultSearchSortFn(items, '')).toEqual(items)
+        })
+
+        it('returns items unchanged when search text is whitespace', () => {
+            const items = [
+                createItem({ id: 'a', label: { text: 'Apple' } }),
+                createItem({ id: 'b', label: { text: 'Banana' } }),
+            ]
+            expect(defaultSearchSortFn(items, '   ')).toEqual(items)
+        })
+
+        it('ranks exact match before prefix before substring', () => {
+            // Deliberately declare substring match first to verify reordering
+            const items = [
+                createItem({
+                    id: 'sub',
+                    label: { text: 'Advanced Search Tools' },
+                }),
+                createItem({ id: 'pre', label: { text: 'Search Settings' } }),
+                createItem({ id: 'exact', label: { text: 'Search' } }),
+            ]
+            const sorted = defaultSearchSortFn(items, 'search')
+            expect(sorted.map((i) => i.id)).toEqual(['exact', 'pre', 'sub'])
+        })
+
+        it('preserves original relative order for items at the same rank (stable)', () => {
+            const items = [
+                createItem({ id: 'first', label: { text: 'Search One' } }),
+                createItem({ id: 'second', label: { text: 'Search Two' } }),
+                createItem({ id: 'third', label: { text: 'Search Three' } }),
+            ]
+            const sorted = defaultSearchSortFn(items, 'search')
+            // All three are prefix matches -> order must be preserved
+            expect(sorted.map((i) => i.id)).toEqual([
+                'first',
+                'second',
+                'third',
+            ])
+        })
+
+        it('does not mutate the input array', () => {
+            const items = [
+                createItem({ id: 'sub', label: { text: 'Advanced Search' } }),
+                createItem({ id: 'exact', label: { text: 'Search' } }),
+            ]
+            const inputCopy = [...items]
+            defaultSearchSortFn(items, 'search')
+            expect(items.map((i) => i.id)).toEqual(inputCopy.map((i) => i.id))
+        })
+    })
+
+    describe('filterMenuV2Groups ranking integration', () => {
+        it('applies default ranking so exact matches come first within a group', () => {
+            const groups: MenuV2GroupType[] = [
+                {
+                    label: 'Results',
+                    items: [
+                        createItem({
+                            id: 'sub',
+                            label: { text: 'Advanced Search Tools' },
+                        }),
+                        createItem({
+                            id: 'exact',
+                            label: { text: 'Search' },
+                        }),
+                        createItem({
+                            id: 'pre',
+                            label: { text: 'Search Settings' },
+                        }),
+                    ],
+                },
+            ]
+
+            const result = filterMenuV2Groups(groups, 'search')
+            expect(result[0].items.map((i) => i.id)).toEqual([
+                'exact',
+                'pre',
+                'sub',
+            ])
+        })
+
+        it('honors a custom searchSortFn and overrides the default ranking', () => {
+            const groups: MenuV2GroupType[] = [
+                {
+                    label: 'Results',
+                    items: [
+                        createItem({ id: 'a', label: { text: 'Alpha' } }),
+                        createItem({ id: 'b', label: { text: 'Beta' } }),
+                    ],
+                },
+            ]
+
+            // Reverse alphabetical sort
+            const reverseSort = (
+                items: MenuV2ItemType[],
+                _searchText: string
+            ): MenuV2ItemType[] => [...items].sort().reverse()
+
+            const result = filterMenuV2Groups(groups, 'a', reverseSort)
+            const ids = result[0].items.map((i) => i.id)
+            expect(ids).toEqual(['b', 'a'])
+        })
     })
 })

--- a/packages/blend/__tests__/components/MenuV2/utils.test.ts
+++ b/packages/blend/__tests__/components/MenuV2/utils.test.ts
@@ -309,10 +309,8 @@ describe('MenuV2 utils', () => {
             ]
 
             // Reverse alphabetical sort
-            const reverseSort = (
-                items: MenuV2ItemType[],
-                _searchText: string
-            ): MenuV2ItemType[] => [...items].sort().reverse()
+            const reverseSort = (items: MenuV2ItemType[]): MenuV2ItemType[] =>
+                [...items].sort().reverse()
 
             const result = filterMenuV2Groups(groups, 'a', reverseSort)
             const ids = result[0].items.map((i) => i.id)

--- a/packages/blend/lib/components/MenuV2/MenuV2.tsx
+++ b/packages/blend/lib/components/MenuV2/MenuV2.tsx
@@ -23,6 +23,8 @@ const MenuV2 = React.forwardRef<HTMLDivElement, MenuV2Props>(
             dimensions = {} as MenuV2Dimensions,
             enableSearch = false,
             searchPlaceholder = 'Search',
+            searchSortFn,
+            onEnter,
             enableVirtualScrolling = false,
             virtualScrolling,
             open: controlledOpen,
@@ -61,9 +63,13 @@ const MenuV2 = React.forwardRef<HTMLDivElement, MenuV2Props>(
         )
 
         const filteredItems = useMemo(
-            () => filterMenuV2Groups(items, searchText),
-            [items, searchText]
+            () => filterMenuV2Groups(items, searchText, searchSortFn),
+            [items, searchText, searchSortFn]
         )
+
+        const handleSearchEnter = useCallback(() => {
+            onEnter?.(searchText, filteredItems)
+        }, [onEnter, searchText, filteredItems])
 
         const handleInteractOutside = useCallback((e: unknown) => {
             const event = e as {
@@ -104,6 +110,7 @@ const MenuV2 = React.forwardRef<HTMLDivElement, MenuV2Props>(
                         searchPlaceholder={searchPlaceholder}
                         searchText={searchText}
                         onSearchTextChange={setSearchText}
+                        onEnter={handleSearchEnter}
                         maxHeight={
                             dimensions.maxHeight as CSSObject['maxHeight']
                         }

--- a/packages/blend/lib/components/MenuV2/MenuV2Content.tsx
+++ b/packages/blend/lib/components/MenuV2/MenuV2Content.tsx
@@ -104,6 +104,7 @@ export type MenuV2ContentProps = {
     searchPlaceholder: string
     searchText: string
     onSearchTextChange: (value: string) => void
+    onEnter?: () => void
     maxHeight?: CSSObject['maxHeight']
     minHeight?: CSSObject['minHeight']
     minWidth?: CSSObject['minWidth']
@@ -130,6 +131,7 @@ const MenuV2Content = React.forwardRef<HTMLDivElement, MenuV2ContentProps>(
             searchPlaceholder,
             searchText,
             onSearchTextChange,
+            onEnter,
             maxHeight,
             minHeight,
             minWidth: minWidthProp,
@@ -250,6 +252,10 @@ const MenuV2Content = React.forwardRef<HTMLDivElement, MenuV2ContentProps>(
                             onChange={(e) => onSearchTextChange(e.target.value)}
                             onKeyDown={(e) => {
                                 e.stopPropagation()
+                                if (e.key === 'Enter') {
+                                    e.preventDefault()
+                                    onEnter?.()
+                                }
                             }}
                             aria-label={
                                 searchPlaceholder

--- a/packages/blend/lib/components/MenuV2/MenuV2SubMenu.tsx
+++ b/packages/blend/lib/components/MenuV2/MenuV2SubMenu.tsx
@@ -14,6 +14,7 @@ import {
     getMenuItemDescriptionColor,
     filterMenuV2Item,
     getItemSlots,
+    defaultSearchSortFn,
 } from './menuV2.utils'
 import { menuV2SubmenuContentAnimations } from './menuV2.animations'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
@@ -64,12 +65,15 @@ const MenuV2SubMenu = ({ item, index, maxHeight }: MenuV2SubMenuProps) => {
 
         const lower = searchText.toLowerCase()
 
-        return item.subMenu.reduce<MenuV2ItemType[]>((acc, sub) => {
+        const matched = item.subMenu.reduce<MenuV2ItemType[]>((acc, sub) => {
             const result = filterMenuV2Item(sub, lower)
             if (result) acc.push(result)
             return acc
         }, [])
-    }, [item.subMenu, searchText])
+
+        const sortFn = item.subMenuSearchSortFn ?? defaultSearchSortFn
+        return sortFn(matched, searchText)
+    }, [item.subMenu, searchText, item.subMenuSearchSortFn])
 
     const {
         bgDefault,
@@ -262,6 +266,16 @@ const MenuV2SubMenu = ({ item, index, maxHeight }: MenuV2SubMenuProps) => {
                                 }
                                 value={searchText}
                                 onChange={(e) => setSearchText(e.target.value)}
+                                onKeyDown={(e) => {
+                                    e.stopPropagation()
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault()
+                                        item.onSubMenuSearchEnter?.(
+                                            searchText,
+                                            filteredSubMenuItems
+                                        )
+                                    }
+                                }}
                                 aria-label="Search submenu"
                             />
                         </Block>

--- a/packages/blend/lib/components/MenuV2/menuV2.types.ts
+++ b/packages/blend/lib/components/MenuV2/menuV2.types.ts
@@ -38,6 +38,10 @@ export type MenuV2ItemLabel = {
     text: string
     leftSlot?: React.ReactElement
 }
+export type MenuV2SearchSortFn = (
+    items: MenuV2ItemType[],
+    searchText: string
+) => MenuV2ItemType[]
 export type MenuV2ItemType = {
     id?: string
     label: MenuV2ItemLabel
@@ -49,6 +53,11 @@ export type MenuV2ItemType = {
     subMenu?: MenuV2ItemType[]
     enableSubMenuSearch?: boolean
     subMenuSearchPlaceholder?: string
+    subMenuSearchSortFn?: MenuV2SearchSortFn
+    onSubMenuSearchEnter?: (
+        searchText: string,
+        filteredResults: MenuV2ItemType[]
+    ) => void
     tooltip?: string | ReactNode
     tooltipProps?: MenuV2ItemTooltipProps
 }
@@ -82,6 +91,8 @@ export type MenuV2Props = {
     dimensions?: MenuV2Dimensions
     enableSearch?: boolean
     searchPlaceholder?: string
+    searchSortFn?: MenuV2SearchSortFn
+    onEnter?: (searchText: string, filteredGroups: MenuV2GroupType[]) => void
     enableVirtualScrolling?: boolean
     virtualScrolling?: MenuV2VirtualScrollingConfig
     open?: boolean

--- a/packages/blend/lib/components/MenuV2/menuV2.utils.ts
+++ b/packages/blend/lib/components/MenuV2/menuV2.utils.ts
@@ -1,5 +1,9 @@
 import type { ReactNode } from 'react'
-import type { MenuV2GroupType, MenuV2ItemType } from './menuV2.types'
+import type {
+    MenuV2GroupType,
+    MenuV2ItemType,
+    MenuV2SearchSortFn,
+} from './menuV2.types'
 import type { MenuV2TokensType } from './menuV2.tokens'
 
 import { MenuV2ItemActionType, MenuV2ItemVariant } from './menuV2.types'
@@ -9,6 +13,43 @@ type MenuV2ItemTokens = MenuV2TokensType['group']['item']
 
 export const getItemSlots = (item: MenuV2ItemType): [ReactNode?] => {
     return [item.label.leftSlot]
+}
+
+export enum MenuV2MatchRank {
+    EXACT = 0,
+    PREFIX = 1,
+    SUBSTRING = 2,
+    NONE = 3,
+}
+
+const getFieldMatchRank = (
+    fieldValue: string | undefined,
+    lower: string
+): MenuV2MatchRank => {
+    if (!fieldValue) return MenuV2MatchRank.NONE
+    const value = fieldValue.toLowerCase()
+    if (value === lower) return MenuV2MatchRank.EXACT
+    if (value.startsWith(lower)) return MenuV2MatchRank.PREFIX
+    if (value.includes(lower)) return MenuV2MatchRank.SUBSTRING
+    return MenuV2MatchRank.NONE
+}
+
+export const getItemMatchRank = (
+    item: MenuV2ItemType,
+    lower: string
+): MenuV2MatchRank => {
+    return Math.min(
+        getFieldMatchRank(item.label.text, lower),
+        getFieldMatchRank(item.subLabel, lower)
+    ) as MenuV2MatchRank
+}
+
+export const defaultSearchSortFn: MenuV2SearchSortFn = (items, searchText) => {
+    if (!searchText.trim()) return items
+    const lower = searchText.toLowerCase()
+    return [...items].sort(
+        (a, b) => getItemMatchRank(a, lower) - getItemMatchRank(b, lower)
+    )
 }
 
 export const filterMenuV2Item = (
@@ -140,7 +181,8 @@ export const flattenMenuV2Groups = (
 
 export const filterMenuV2Groups = (
     groups: MenuV2GroupType[],
-    searchText: string
+    searchText: string,
+    searchSortFn: MenuV2SearchSortFn = defaultSearchSortFn
 ): MenuV2GroupType[] => {
     if (!searchText) return groups
     const lower = searchText.toLowerCase()
@@ -150,7 +192,7 @@ export const filterMenuV2Groups = (
                 .map((item) => filterMenuV2Item(item, lower))
                 .filter(Boolean) as MenuV2ItemType[]
             if (filteredItems.length === 0) return null
-            return { ...group, items: filteredItems }
+            return { ...group, items: searchSortFn(filteredItems, searchText) }
         })
         .filter(Boolean) as MenuV2GroupType[]
 }


### PR DESCRIPTION
### Summary

MenuV2 search now ranks results by relevance (exact → prefix → substring, stable) by default, and exposes an onEnter callback for command-palette-style "confirm search" behavior. Both are opt-in extensions; all new props are optional 

### Issue Ticket

Closes #1550 or Related to #1550





https://github.com/user-attachments/assets/420e5d09-3bc5-44f8-9f09-87e2d355efea


