### PR TITLE
fix: rename tokens dist entry so it stops shadowing dist/tokens/ (#1556)

### DIFF
--- a/packages/blend/package.json
+++ b/packages/blend/package.json
@@ -23,8 +23,8 @@
             "types": "./dist/node.d.ts"
         },
         "./tokens": {
-            "import": "./dist/tokens.js",
-            "types": "./dist/tokens.d.ts"
+            "import": "./dist/token-engine.js",
+            "types": "./dist/token-engine.d.ts"
         },
         "./tokens/server": {
             "import": "./dist/tokens-server.js",
@@ -36,7 +36,8 @@
     "scripts": {
         "lint": "eslint .",
         "check:circular": "node scripts/check-circular.mjs",
-        "build": "pnpm lint && vite build",
+        "check:dist": "node scripts/check-dist.mjs",
+        "build": "pnpm lint && vite build && pnpm check:dist",
         "prepublishOnly": "pnpm run build",
         "test": "vitest",
         "test:ui": "vitest --ui",

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -1,0 +1,107 @@
+// Post-build packaging gate for `dist/` (see issue #1556).
+//
+// Guards against the file-shadows-directory class of packaging bug: when
+// `dist/X.d.ts` (or `dist/X.js`) is emitted next to a `dist/X/` directory,
+// every standard TS resolution mode (Bundler, NodeNext, Node10) resolves a
+// relative `./X` to the FILE, not the directory. The root re-exports in
+// `dist/main.d.ts` (e.g. `export * from './tokens'`) then silently point at
+// the wrong module and their symbols type as `any` for every consumer —
+// runtime is bundled and unaffected, so nothing fails until a typed consumer
+// notices. This happened in 0.0.37-beta.x: the token-engine entry was named
+// `tokens`, emitting `dist/tokens.d.ts` next to `dist/tokens/`, which broke
+// `FOUNDATION_THEME` (and everything else re-exported `from './tokens'`).
+//
+// Check 1 (collision guard) fails the build on ANY such basename collision.
+// Check 2 (type smoke test) type-checks key root exports of `dist/main.d.ts`
+// and fails if a symbol is missing or resolves to `any`.
+import { readdirSync, existsSync, statSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '../dist')
+
+if (!existsSync(distDir)) {
+    console.error(`✖ ${distDir} does not exist — run the build first.`)
+    process.exit(1)
+}
+
+let failed = false
+
+// ---------------------------------------------------------------------------
+// Check 1: no dist/X.d.ts or dist/X.js may coexist with a dist/X/ directory
+// ---------------------------------------------------------------------------
+const entries = readdirSync(distDir)
+const directories = new Set(
+    entries.filter((e) => statSync(resolve(distDir, e)).isDirectory())
+)
+
+const collisions = entries.filter((e) => {
+    const base = e.replace(/\.d\.ts$|\.js$/, '')
+    return base !== e && directories.has(base)
+})
+
+if (collisions.length > 0) {
+    failed = true
+    console.error('✖ dist/ file-shadows-directory collision(s) found:\n')
+    for (const file of collisions) {
+        const base = file.replace(/\.d\.ts$|\.js$/, '')
+        console.error(`  dist/${file} shadows dist/${base}/`)
+    }
+    console.error(
+        '\nA file always beats a sibling directory in TS module resolution, so\n' +
+            'relative `./X` imports inside dist/ now resolve to the file — the\n' +
+            'directory (and everything re-exported from it) becomes unreachable\n' +
+            'and types silently degrade to `any`. Rename the vite build entry so\n' +
+            'its output name does not clash with a lib/ directory (see the\n' +
+            '`token-engine` entry in vite.config.ts).\n'
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: key root exports must exist and must not type as `any`
+// ---------------------------------------------------------------------------
+const KEY_EXPORTS = ['FOUNDATION_THEME']
+
+const mainDts = resolve(distDir, 'main.d.ts')
+const program = ts.createProgram([mainDts], {
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+    skipLibCheck: true,
+    noEmit: true,
+})
+const checker = program.getTypeChecker()
+const sourceFile = program.getSourceFile(mainDts)
+const moduleSymbol = sourceFile && checker.getSymbolAtLocation(sourceFile)
+
+if (!moduleSymbol) {
+    failed = true
+    console.error(`✖ Could not load ${mainDts} as a module.`)
+} else {
+    const exportsOfMain = checker.getExportsOfModule(moduleSymbol)
+    for (const name of KEY_EXPORTS) {
+        const symbol = exportsOfMain.find((s) => s.name === name)
+        if (!symbol) {
+            failed = true
+            console.error(`✖ dist/main.d.ts does not export \`${name}\`.`)
+            continue
+        }
+        const type = checker.getTypeOfSymbolAtLocation(symbol, sourceFile)
+        if (type.flags & ts.TypeFlags.Any) {
+            failed = true
+            console.error(
+                `✖ dist/main.d.ts exports \`${name}\` but it types as \`any\` — ` +
+                    'its re-export chain is broken (likely a file/directory collision above).'
+            )
+        }
+    }
+}
+
+if (failed) {
+    process.exit(1)
+}
+
+console.log(
+    `✔ dist/ has no file/directory collisions; key exports (${KEY_EXPORTS.join(', ')}) are typed.`
+)

--- a/packages/blend/vite.config.ts
+++ b/packages/blend/vite.config.ts
@@ -42,7 +42,16 @@ export default defineConfig({
             entry: {
                 main: resolve(__dirname, 'lib/main.ts'),
                 node: resolve(__dirname, 'lib/node.ts'),
-                tokens: resolve(__dirname, 'lib/token-engine.ts'),
+                // IMPORTANT: this entry must NOT be named `tokens` — that would
+                // emit `dist/tokens.js` / `dist/tokens.d.ts` next to the
+                // `dist/tokens/` directory (built from `lib/tokens/`), and in
+                // TypeScript module resolution a file always beats a directory.
+                // The root's relative `./tokens` re-exports (FOUNDATION_THEME
+                // etc.) would then resolve to the token-engine stub instead of
+                // `dist/tokens/index.d.ts`, silently typing them as `any` for
+                // every consumer. See issue #1556; scripts/check-dist.mjs
+                // guards this class of collision post-build.
+                'token-engine': resolve(__dirname, 'lib/token-engine.ts'),
                 'tokens-server': resolve(
                     __dirname,
                     'lib/token-engine-server.ts'


### PR DESCRIPTION
## Summary

Fixes #1556.

Since `0.0.37-beta.x`, `FOUNDATION_THEME` (and everything else the root re-exports via `from './tokens'`) types as **`any`** for every TypeScript consumer. The breakage is silent — runtime is bundled and unaffected — and was only caught downstream by typed consumers (`rescript-bindgen`, blocker for `juspay/blend-rescript#105`).

## Root cause

PR #1370 named the token-engine vite entry `tokens`, emitting `dist/tokens.js` + `dist/tokens.d.ts` (a stub: `export * from './token-engine'`) next to the pre-existing **`dist/tokens/` directory**. Relative imports don't go through the exports map — they hit the filesystem, where a **file always beats a directory** in every standard TS resolution mode (Bundler, NodeNext, Node10). So `dist/main.d.ts`'s `export * from './tokens'` resolved to the token-engine stub — which doesn't export `FOUNDATION_THEME` — instead of `dist/tokens/index.d.ts`.

## Fix (no consumer-facing change)

- Rename the vite entry output `tokens` → `token-engine` — the dts plugin already emits `dist/token-engine.d.ts` from `lib/token-engine.ts`, so entry JS and types now share one collision-free name.
- Point the `./tokens` exports-map subpath at `./dist/token-engine.js` / `./dist/token-engine.d.ts`.
- The public subpath **`@juspay/blend-design-system/tokens` is unchanged** — exports-map subpath names are independent of file names. (`apps/blend-studio` aliases that subpath to workspace source, so it's unaffected too.)

## Prevention: `scripts/check-dist.mjs` (wired into `pnpm build`)

Nothing in the existing pipeline can catch this class of bug — it only exists in the built output. The new post-build gate fails the build on:
1. **Collision guard** — any `dist/X.d.ts`/`dist/X.js` coexisting with a `dist/X/` directory (`dist/` has directories named `components`, `hooks`, `utils`, `tokens`, `context`… any future entry named like one of them would silently re-break types).
2. **Type smoke test** — key root exports (`FOUNDATION_THEME`) missing or typing as `any` in `dist/main.d.ts`, checked via the TS compiler API.

## Verification

- Ran `check-dist.mjs` against the **pre-fix** dist → fails on both checks (flags `tokens.js`/`tokens.d.ts` shadowing `dist/tokens/`, and `FOUNDATION_THEME` typing as `any`) — exact repro of the issue.
- Clean `pnpm build` (lint + vite build + check:dist) with the fix → ✅ green; `dist/` has `token-engine.js`/`token-engine.d.ts`, no `tokens.js`/`tokens.d.ts`, `dist/tokens/index.d.ts` intact with `FOUNDATION_THEME` typed.
- Runtime check of the subpath entry: `import('./dist/token-engine.js')` → 47 exports incl. `resolveBrandTokens` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)