### PR TITLE
fix: fixing custom preset label not coming in date picker

### DIFF
--- a/apps/site/src/demos/DateRangePickerDemo.tsx
+++ b/apps/site/src/demos/DateRangePickerDemo.tsx
@@ -208,6 +208,22 @@ const DateRangePickerDemo = () => {
         startDate: new Date(),
         endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     })
+
+    // State for custom preset trigger label reproduction (bug #DateRangePicker)
+    // "Last 2 Hours" is a non-built-in duration (2h is not 30m/1h/6h/24h),
+    // so the trigger should show "Last 2 Hours" but currently shows "Custom".
+    const [customPresetLabelRange, setCustomPresetLabelRange] =
+        useState<DateRange>(() => {
+            const now = new Date()
+            return {
+                startDate: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+                endDate: now,
+            }
+        })
+
+    const handleCustomPresetLabelChange = (range: DateRange) => {
+        setCustomPresetLabelRange(range)
+    }
     const [popoverClipControlRange, setPopoverClipControlRange] =
         useState<DateRange>({
             startDate: new Date(),
@@ -1737,6 +1753,70 @@ const DateRangePickerDemo = () => {
                             <div className="text-gray-600">
                                 Check console logs when you select presets to
                                 see the callback data
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Custom Preset Trigger Label Reproduction */}
+                    <div className="p-6 bg-white border border-gray-200 rounded-lg min-h-[200px] flex flex-col">
+                        <h3 className="text-lg font-semibold text-gray-700 mb-2">
+                            🐛 Custom Preset Trigger Label
+                        </h3>
+                        <p className="text-sm text-gray-600 mb-4 flex-grow">
+                            The trigger should show{' '}
+                            <strong>&quot;Last 2 Hours&quot;</strong> (the
+                            custom preset&apos;s label), but it shows{' '}
+                            <strong>&quot;Custom&quot;</strong> because the
+                            active-preset detector does not consult
+                            customPresets. 2h is not a built-in duration
+                            (30m/1h/6h/24h), so it falls back to CUSTOM. Click
+                            the preset in the dropdown — the range applies, but
+                            the trigger label reverts to &quot;Custom&quot; on
+                            the next render.
+                        </p>
+                        <div className="overflow-hidden">
+                            <DateRangePicker
+                                value={customPresetLabelRange}
+                                onChange={handleCustomPresetLabelChange}
+                                showPresets={true}
+                                showDateTimePicker={true}
+                                formatConfig={{
+                                    preset: DateFormatPreset.MEDIUM_RANGE,
+                                    includeTime: true,
+                                    timeFormat: '12h',
+                                }}
+                                customPresets={[
+                                    {
+                                        id: 'last2Hours',
+                                        label: 'Last 2 Hours',
+                                        getDateRange: () => {
+                                            const now = new Date()
+                                            return {
+                                                startDate: new Date(
+                                                    now.getTime() -
+                                                        2 * 60 * 60 * 1000
+                                                ),
+                                                endDate: now,
+                                            }
+                                        },
+                                    },
+                                    DateRangePreset.LAST_30_MINUTES,
+                                    DateRangePreset.LAST_1_HOUR,
+                                    DateRangePreset.LAST_6_HOURS,
+                                    DateRangePreset.LAST_24_HOURS,
+                                ]}
+                            />
+                        </div>
+                        <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded text-xs font-mono">
+                            <div className="text-red-600 mb-1">
+                                🐛 Reproduction: trigger shows
+                                &quot;Custom&quot; instead of &quot;Last 2
+                                Hours&quot;
+                            </div>
+                            <div className="text-gray-600">
+                                Expected: &quot;Last 2 Hours&quot; (custom
+                                label). Actual: &quot;Custom&quot; (built-in
+                                fallback).
                             </div>
                         </div>
                     </div>

--- a/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
+++ b/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { isControlledDateRange } from '../../../lib/components/DateRangePicker/utils'
+import {
+    isControlledDateRange,
+    detectPresetFromRange,
+    processCustomPresets,
+    getPresetLabelWithCustom,
+} from '../../../lib/components/DateRangePicker/utils'
+import { DateRangePreset } from '../../../lib/components/DateRangePicker/types'
+import type {
+    CustomPresetConfig,
+    CustomPresetDefinition,
+} from '../../../lib/components/DateRangePicker/types'
 
 describe('isControlledDateRange', () => {
     it('returns false for null, undefined, and empty objects', () => {
@@ -9,9 +19,11 @@ describe('isControlledDateRange', () => {
     })
 
     it('returns false when startDate is missing or invalid', () => {
-        expect(isControlledDateRange({ endDate: new Date('2024-06-01') })).toBe(
-            false
-        )
+        expect(
+            isControlledDateRange({
+                endDate: new Date('2024-06-01'),
+            } as unknown as { startDate: Date })
+        ).toBe(false)
         expect(
             isControlledDateRange({
                 startDate: new Date('invalid'),
@@ -33,5 +45,144 @@ describe('isControlledDateRange', () => {
                 endDate: new Date('2024-06-15'),
             })
         ).toBe(true)
+    })
+})
+
+describe('detectPresetFromRange - custom presets', () => {
+    // Helper: build presetConfigs from a CustomPresetDefinition so that the
+    // definition is registered in the module-level customPresetDefinitions Map
+    // (processCustomPresets has the side effect of populating that Map).
+    const buildConfigs = (
+        definitions: CustomPresetDefinition[]
+    ): CustomPresetConfig[] => {
+        return processCustomPresets(definitions)
+    }
+
+    it('returns CUSTOM for a non-built-in range when no presetConfigs are given', () => {
+        const now = new Date()
+        const range = {
+            startDate: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+            endDate: now,
+        }
+        expect(detectPresetFromRange(range)).toBe(DateRangePreset.CUSTOM)
+    })
+
+    it('returns the custom preset id when the range matches a custom definition', () => {
+        const now = new Date()
+        const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+        const last2Hours: CustomPresetDefinition = {
+            id: 'last2Hours',
+            label: 'Last 2 Hours',
+            getDateRange: () => ({ startDate: twoHoursAgo, endDate: now }),
+        }
+        const presetConfigs = buildConfigs([last2Hours])
+
+        const range = { startDate: twoHoursAgo, endDate: now }
+        expect(detectPresetFromRange(range, undefined, presetConfigs)).toBe(
+            'last2Hours' as DateRangePreset
+        )
+    })
+
+    it('matches a custom preset within the tolerance window', () => {
+        const now = new Date()
+        const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+        const last2Hours: CustomPresetDefinition = {
+            id: 'last2Hours',
+            label: 'Last 2 Hours',
+            getDateRange: () => ({ startDate: twoHoursAgo, endDate: now }),
+        }
+        const presetConfigs = buildConfigs([last2Hours])
+
+        // Off by 30 seconds (within the 1-minute tolerance)
+        const range = {
+            startDate: new Date(twoHoursAgo.getTime() + 30 * 1000),
+            endDate: new Date(now.getTime() - 30 * 1000),
+        }
+        expect(detectPresetFromRange(range, undefined, presetConfigs)).toBe(
+            'last2Hours' as DateRangePreset
+        )
+    })
+
+    it('does not match a custom preset outside the tolerance window', () => {
+        const now = new Date()
+        const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+        const last2Hours: CustomPresetDefinition = {
+            id: 'last2Hours',
+            label: 'Last 2 Hours',
+            getDateRange: () => ({ startDate: twoHoursAgo, endDate: now }),
+        }
+        const presetConfigs = buildConfigs([last2Hours])
+
+        // Off by 2 minutes (outside the 1-minute tolerance)
+        const range = {
+            startDate: new Date(twoHoursAgo.getTime() + 2 * 60 * 1000),
+            endDate: now,
+        }
+        expect(detectPresetFromRange(range, undefined, presetConfigs)).toBe(
+            DateRangePreset.CUSTOM
+        )
+    })
+
+    it('still detects built-in presets even when presetConfigs are provided', () => {
+        const now = new Date()
+        const thirtyMinsAgo = new Date(now.getTime() - 30 * 60 * 1000)
+        const last2Hours: CustomPresetDefinition = {
+            id: 'last2Hours',
+            label: 'Last 2 Hours',
+            getDateRange: () => ({
+                startDate: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+                endDate: now,
+            }),
+        }
+        const presetConfigs = buildConfigs([last2Hours])
+
+        const range = { startDate: thirtyMinsAgo, endDate: now }
+        expect(detectPresetFromRange(range, undefined, presetConfigs)).toBe(
+            DateRangePreset.LAST_30_MINUTES
+        )
+    })
+
+    it('skips custom definitions whose getDateRange returns no endDate', () => {
+        const now = new Date()
+        const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+        const singleDay: CustomPresetDefinition = {
+            id: 'singleDay',
+            label: 'Single Day',
+            // Returns a range with no endDate — should not match a full range.
+            getDateRange: () => ({ startDate: twoHoursAgo }),
+        }
+        const presetConfigs = buildConfigs([singleDay])
+
+        const range = { startDate: twoHoursAgo, endDate: now }
+        expect(detectPresetFromRange(range, undefined, presetConfigs)).toBe(
+            DateRangePreset.CUSTOM
+        )
+    })
+})
+
+describe('getPresetLabelWithCustom', () => {
+    it('returns the custom label when a matching custom config exists', () => {
+        const last2Hours: CustomPresetDefinition = {
+            id: 'last2Hours',
+            label: 'Last 2 Hours',
+            getDateRange: () => ({
+                startDate: new Date(),
+                endDate: new Date(),
+            }),
+        }
+        const presetConfigs = processCustomPresets([last2Hours])
+
+        expect(
+            getPresetLabelWithCustom(
+                'last2Hours' as DateRangePreset,
+                presetConfigs
+            )
+        ).toBe('Last 2 Hours')
+    })
+
+    it('falls back to the built-in label when no custom config matches', () => {
+        expect(getPresetLabelWithCustom(DateRangePreset.LAST_7_DAYS)).toBe(
+            'Last 7 days'
+        )
     })
 })

--- a/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -534,7 +534,11 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                 setSelectedRange(normalizedRange)
                 setActivePreset(
                     normalizedRange
-                        ? detectPresetFromRange(normalizedRange, timezone)
+                        ? detectPresetFromRange(
+                              normalizedRange,
+                              timezone,
+                              presetConfigs
+                          )
                         : DateRangePreset.CUSTOM
                 )
                 setStartDate(
@@ -573,7 +577,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                     error: 'none',
                 })
             },
-            [timezone, dateFormat]
+            [timezone, dateFormat, presetConfigs]
         )
 
         useEffect(() => {

--- a/packages/blend/lib/components/DateRangePicker/utils.ts
+++ b/packages/blend/lib/components/DateRangePicker/utils.ts
@@ -3974,7 +3974,8 @@ export const matchesLastMonthPreset = (range: DateRange): boolean => {
  */
 export const detectPresetFromRange = (
     range: DateRange,
-    timezone?: string
+    timezone?: string,
+    presetConfigs?: CustomPresetConfig[]
 ): DateRangePreset => {
     if (!range.startDate || !range.endDate) {
         return DateRangePreset.CUSTOM
@@ -4117,6 +4118,32 @@ export const detectPresetFromRange = (
 
     if (startIsToday && monthsDiff === 12) {
         return DateRangePreset.NEXT_12_MONTHS
+    }
+
+    // Check custom preset definitions (from customPresets prop) before giving up.
+    if (presetConfigs && presetConfigs.length > 0) {
+        const toleranceMs =
+            DATE_RANGE_PICKER_CONSTANTS.PRESET_DETECTION_TOLERANCE_MS
+        for (const config of presetConfigs) {
+            const definition = getCustomPresetDefinition(
+                config.preset as string
+            )
+            if (!definition) continue
+
+            const presetRange = definition.getDateRange()
+            if (
+                presetRange.startDate &&
+                presetRange.endDate &&
+                Math.abs(
+                    range.startDate.getTime() - presetRange.startDate.getTime()
+                ) <= toleranceMs &&
+                Math.abs(
+                    range.endDate.getTime() - presetRange.endDate.getTime()
+                ) <= toleranceMs
+            ) {
+                return config.preset
+            }
+        }
     }
 
     return DateRangePreset.CUSTOM


### PR DESCRIPTION
### Summary

fixing custom preset label coming as custom in the date picker 

### Issue Ticket

Closes #1566 or Related to #1566

before
<img width="561" height="372" alt="Screenshot 2026-07-08 at 6 23 32 PM" src="https://github.com/user-attachments/assets/5d100411-f0c9-4b65-82c7-0903df4a1c46" />



After
<img width="561" height="372" alt="Screenshot 2026-07-08 at 6 23 56 PM" src="https://github.com/user-attachments/assets/abfd5584-e82e-4387-96de-23b210f92f65" />
