### PR TITLE
fix: type compound statics that reuse flat exports as typeof (#1576)

### DIFF
--- a/packages/blend/lib/components/Skeleton/SkeletonCompound.tsx
+++ b/packages/blend/lib/components/Skeleton/SkeletonCompound.tsx
@@ -5,6 +5,25 @@ import SkeletonCard from './SkeletonCard'
 
 import type { SkeletonProps } from './types'
 
+const SkeletonRoot = forwardRef<HTMLDivElement, SkeletonProps>((props, ref) => (
+    <Skeleton {...props} ref={ref} />
+))
+
+// Convenience aliases (no flat export — they exist only as compound statics)
+const SkeletonCircle = forwardRef<HTMLDivElement, Omit<SkeletonProps, 'shape'>>(
+    (props, ref) => <Skeleton {...props} shape="circle" ref={ref} />
+)
+
+const SkeletonRectangle = forwardRef<
+    HTMLDivElement,
+    Omit<SkeletonProps, 'shape'>
+>((props, ref) => <Skeleton {...props} shape="rectangle" ref={ref} />)
+
+const SkeletonRounded = forwardRef<
+    HTMLDivElement,
+    Omit<SkeletonProps, 'shape'>
+>((props, ref) => <Skeleton {...props} shape="rounded" ref={ref} />)
+
 /**
  * Enhanced Skeleton with compound component pattern
  *
@@ -17,40 +36,35 @@ import type { SkeletonProps } from './types'
  * Or traditional:
  * <Skeleton.Text loading={isLoading} lines={3} />
  */
-const SkeletonCompound = Object.assign(
-    forwardRef<HTMLDivElement, SkeletonProps>((props, ref) => (
-        <Skeleton {...props} ref={ref} />
-    )),
-    {
-        /**
-         * Avatar skeleton with circular or square shapes and multiple sizes
-         */
-        Avatar: SkeletonAvatar,
+// Statics that reuse a flat export are typed as `typeof` that export so the
+// emitted declarations state the value identity instead of re-declaring props.
+const SkeletonCompound: typeof SkeletonRoot & {
+    /**
+     * Avatar skeleton with circular or square shapes and multiple sizes
+     */
+    Avatar: typeof SkeletonAvatar
 
-        /**
-         * Card skeleton with default layout or custom children
-         */
-        Card: SkeletonCard,
+    /**
+     * Card skeleton with default layout or custom children
+     */
+    Card: typeof SkeletonCard
 
-        /**
-         * Base skeleton component for custom shapes and layouts
-         */
-        Base: Skeleton,
+    /**
+     * Base skeleton component for custom shapes and layouts
+     */
+    Base: typeof Skeleton
 
-        // Convenience aliases
-        Circle: forwardRef<HTMLDivElement, Omit<SkeletonProps, 'shape'>>(
-            (props, ref) => <Skeleton {...props} shape="circle" ref={ref} />
-        ),
-
-        Rectangle: forwardRef<HTMLDivElement, Omit<SkeletonProps, 'shape'>>(
-            (props, ref) => <Skeleton {...props} shape="rectangle" ref={ref} />
-        ),
-
-        Rounded: forwardRef<HTMLDivElement, Omit<SkeletonProps, 'shape'>>(
-            (props, ref) => <Skeleton {...props} shape="rounded" ref={ref} />
-        ),
-    }
-)
+    Circle: typeof SkeletonCircle
+    Rectangle: typeof SkeletonRectangle
+    Rounded: typeof SkeletonRounded
+} = Object.assign(SkeletonRoot, {
+    Avatar: SkeletonAvatar,
+    Card: SkeletonCard,
+    Base: Skeleton,
+    Circle: SkeletonCircle,
+    Rectangle: SkeletonRectangle,
+    Rounded: SkeletonRounded,
+})
 
 // Display names for better debugging
 SkeletonCompound.displayName = 'Skeleton'

--- a/packages/blend/lib/components/Timeline/Timeline.tsx
+++ b/packages/blend/lib/components/Timeline/Timeline.tsx
@@ -95,7 +95,15 @@ const TimelineRoot = forwardRef<HTMLDivElement, TimelineRootProps>(
 
 TimelineRoot.displayName = 'Timeline'
 
-const Timeline = Object.assign(TimelineRoot, {
+// Statics reuse the flat exports, so they are typed as `typeof` those exports
+// to keep the emitted declarations stating the value identity.
+const Timeline: typeof TimelineRoot & {
+    Label: typeof TimelineLabel
+    Header: typeof TimelineHeader
+    Substep: typeof TimelineSubstep
+    Node: typeof TimelineNode
+    ShowMore: typeof TimelineShowMore
+} = Object.assign(TimelineRoot, {
     Label: TimelineLabel,
     Header: TimelineHeader,
     Substep: TimelineSubstep,

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -170,6 +170,11 @@ try {
     )
 }
 
+// Every uppercase own property of an export is treated as public API,
+// including non-component statics. A static that is deliberately kept out of
+// the declared type must be exempted here as '<Export>.<Static>' (none today).
+const UNDECLARED_STATIC_ALLOWLIST = new Set([])
+
 let verifiedStatics = 0
 if (moduleSymbol && compoundStatics.length > 0) {
     const resolveAlias = (symbol) =>
@@ -178,6 +183,7 @@ if (moduleSymbol && compoundStatics.length > 0) {
             : symbol
 
     for (const { compound, key, flatNames } of compoundStatics) {
+        if (UNDECLARED_STATIC_ALLOWLIST.has(`${compound}.${key}`)) continue
         const compoundSymbol = exportsOfMain.find((s) => s.name === compound)
         if (!compoundSymbol) {
             failed = true
@@ -226,12 +232,16 @@ if (moduleSymbol && compoundStatics.length > 0) {
             verifiedStatics++
         } else {
             failed = true
+            const flats = flatNames.map((f) => `\`${f}\``).join(' / ')
+            const expected = flatNames
+                .map((f) => `\`typeof ${f}\``)
+                .join(' or ')
             console.error(
                 `✖ \`${compound}.${key}\` is the same runtime value as export ` +
-                    `\`${flatNames[0]}\`, but its emitted declaration is not ` +
-                    `\`typeof ${flatNames[0]}\`. Annotate the compound const ` +
-                    'explicitly (see SkeletonCompound.tsx) so declaration emit ' +
-                    'states the value identity instead of inlining the props.'
+                    `${flats}, but its emitted declaration is not ${expected}. ` +
+                    'Annotate the compound const explicitly (see ' +
+                    'SkeletonCompound.tsx) so declaration emit states the ' +
+                    'value identity instead of inlining the props.'
             )
         }
     }

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -127,6 +127,12 @@ const UNDECLARED_STATIC_ALLOWLIST = new Set()
 
 const compoundStatics = []
 try {
+    // The bundle runs its module-load side effects on import (e.g. Highcharts
+    // reads `window`), so provide a minimal browser environment. This only
+    // needs globals touched at module-load time — NOT render/effect-time ones
+    // like ResizeObserver, which never run here since the script imports but
+    // never renders. If a future dependency reads a new global at load, the
+    // import below throws and is caught (see catch); add the global here.
     const { JSDOM } = await import('jsdom')
     const dom = new JSDOM('', { pretendToBeVisual: true })
     global.window = dom.window
@@ -179,7 +185,9 @@ try {
 } catch (error) {
     failed = true
     console.error(
-        `✖ Could not import dist/main.js to discover compound statics: ${error.message}`
+        '✖ Could not import dist/main.js to discover compound statics ' +
+            '(a browser global read at module-load may need shimming in the ' +
+            `setup block above): ${error.message}`
     )
 }
 

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -14,13 +14,16 @@
 // Check 1 (collision guard) fails the build on ANY such basename collision.
 // Check 2 (type smoke test) type-checks key root exports of `dist/main.d.ts`
 // and fails if a symbol is missing or resolves to `any`.
-// Check 3 (compound identity, issue #1576) discovers at runtime every
-// compound static that is the SAME VALUE as a flat export (e.g.
-// `Skeleton.Avatar === SkeletonAvatar`) and fails if its emitted declaration
-// is an inline prop re-declaration instead of `typeof <FlatExport>` — inline
-// types claim two independent components where there is one, so type-driven
-// tooling emits duplicates. Discovery is by value identity, so new compounds
-// are covered automatically without registering them here.
+// Check 3 (compound statics, issue #1576) enumerates at runtime every
+// public static on every export (e.g. `Skeleton.Avatar`) and asserts two
+// things against `dist/main.d.ts`: (a) the static exists in the declared
+// type at all — an explicit compound annotation silently drops statics that
+// are added to `Object.assign` without updating it; and (b) a static that is
+// the SAME VALUE as a flat export (`Skeleton.Avatar === SkeletonAvatar`) is
+// declared as `typeof <FlatExport>`, not an inline prop re-declaration —
+// inline types claim two independent components where there is one, so
+// type-driven tooling emits duplicates. Discovery is by runtime value, so
+// new compounds are covered automatically without registering them here.
 import { readdirSync, existsSync, statSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -81,12 +84,14 @@ const program = ts.createProgram([mainDts], {
 const checker = program.getTypeChecker()
 const sourceFile = program.getSourceFile(mainDts)
 const moduleSymbol = sourceFile && checker.getSymbolAtLocation(sourceFile)
+const exportsOfMain = moduleSymbol
+    ? checker.getExportsOfModule(moduleSymbol)
+    : []
 
 if (!moduleSymbol) {
     failed = true
     console.error(`✖ Could not load ${mainDts} as a module.`)
 } else {
-    const exportsOfMain = checker.getExportsOfModule(moduleSymbol)
     for (const name of KEY_EXPORTS) {
         const symbol = exportsOfMain.find((s) => s.name === name)
         if (!symbol) {
@@ -106,13 +111,15 @@ if (!moduleSymbol) {
 }
 
 // ---------------------------------------------------------------------------
-// Check 3: compound statics that reuse a flat export must be typed `typeof`
+// Check 3: compound statics must be declared, and flat-export aliases `typeof`
 // ---------------------------------------------------------------------------
-// Runtime identity is the ground truth: a static counts as an alias only when
-// it is `===` a top-level export. The emitted type must then be a `typeof`
+// Runtime is the ground truth: every uppercase own property of an export is a
+// public static and must appear in the declared type (explicit compound
+// annotations drop statics added to `Object.assign` without updating them).
+// A static that is `===` a top-level export must additionally be a `typeof`
 // query resolving to that export's declaration. (A structural type comparison
-// cannot catch this — the inline form is structurally identical.)
-const compoundPairs = []
+// cannot catch that — the inline form is structurally identical.)
+const compoundStatics = []
 try {
     const { JSDOM } = await import('jsdom')
     const dom = new JSDOM('', { pretendToBeVisual: true })
@@ -145,14 +152,15 @@ try {
             if (!/^[A-Z]/.test(key)) continue
             const staticValue = value[key]
             if (staticValue === value) continue
-            const flatNames = namesByValue.get(staticValue)
-            if (!flatNames) continue
+            // null flatNames = a compound-only static (no flat export) — only
+            // its presence in the declared type is asserted
+            const flatNames = namesByValue.get(staticValue) ?? null
             // the same compound value can be exported under several names —
             // check each (compound value, static) pair once
             const id = namesByValue.get(value)?.[0] + '.' + key
             if (seen.has(id)) continue
             seen.add(id)
-            compoundPairs.push({ compound: name, key, flatNames })
+            compoundStatics.push({ compound: name, key, flatNames })
         }
     }
 } catch (error) {
@@ -162,35 +170,61 @@ try {
     )
 }
 
-if (moduleSymbol && compoundPairs.length > 0) {
-    const exportsOfMain = checker.getExportsOfModule(moduleSymbol)
+let verifiedStatics = 0
+if (moduleSymbol && compoundStatics.length > 0) {
     const resolveAlias = (symbol) =>
         symbol && symbol.flags & ts.SymbolFlags.Alias
             ? checker.getAliasedSymbol(symbol)
             : symbol
 
-    for (const { compound, key, flatNames } of compoundPairs) {
+    for (const { compound, key, flatNames } of compoundStatics) {
         const compoundSymbol = exportsOfMain.find((s) => s.name === compound)
-        if (!compoundSymbol) continue
+        if (!compoundSymbol) {
+            failed = true
+            console.error(
+                `✖ \`${compound}\` exists at runtime in dist/main.js but ` +
+                    'dist/main.d.ts does not export it.'
+            )
+            continue
+        }
         const compoundType = checker.getTypeOfSymbolAtLocation(
             compoundSymbol,
             sourceFile
         )
-        const propDecl = compoundType.getProperty(key)?.declarations?.[0]
-        const typeNode = propDecl?.type
+        const prop = compoundType.getProperty(key)
+        if (!prop) {
+            failed = true
+            console.error(
+                `✖ \`${compound}.${key}\` exists at runtime but is missing ` +
+                    `from \`${compound}\`'s declared type — its explicit ` +
+                    'annotation has drifted behind the `Object.assign` value.'
+            )
+            continue
+        }
+        if (!flatNames) {
+            // compound-only static — nothing to alias, presence is enough
+            verifiedStatics++
+            continue
+        }
 
+        const typeNode = prop.declarations?.[0]?.type
         let ok = false
         if (typeNode && ts.isTypeQueryNode(typeNode)) {
             const target = resolveAlias(
                 checker.getSymbolAtLocation(typeNode.exprName)
             )
-            ok = flatNames.some(
-                (flat) =>
-                    resolveAlias(exportsOfMain.find((s) => s.name === flat)) ===
-                    target
-            )
+            ok =
+                target !== undefined &&
+                flatNames.some(
+                    (flat) =>
+                        resolveAlias(
+                            exportsOfMain.find((s) => s.name === flat)
+                        ) === target
+                )
         }
-        if (!ok) {
+        if (ok) {
+            verifiedStatics++
+        } else {
             failed = true
             console.error(
                 `✖ \`${compound}.${key}\` is the same runtime value as export ` +
@@ -209,6 +243,9 @@ if (failed) {
 
 console.log(
     `✔ dist/ has no file/directory collisions; key exports (${KEY_EXPORTS.join(', ')}) are typed; ` +
-        `${compoundPairs.length} compound statics verified as \`typeof\` aliases.`
+        `${verifiedStatics} compound statics declared (flat-export aliases as \`typeof\`).`
 )
+// Importing dist/main.js leaves live handles behind (styled-components /
+// framer-motion timers under jsdom), so Node would hang without an explicit
+// exit.
 process.exit(0)

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -119,6 +119,12 @@ if (!moduleSymbol) {
 // A static that is `===` a top-level export must additionally be a `typeof`
 // query resolving to that export's declaration. (A structural type comparison
 // cannot catch that — the inline form is structurally identical.)
+//
+// A static that is deliberately kept out of the declared type must be
+// exempted as '<Export>.<Static>' (none today); any export name of the
+// owning component works.
+const UNDECLARED_STATIC_ALLOWLIST = new Set()
+
 const compoundStatics = []
 try {
     const { JSDOM } = await import('jsdom')
@@ -157,9 +163,16 @@ try {
             const flatNames = namesByValue.get(staticValue) ?? null
             // the same compound value can be exported under several names —
             // check each (compound value, static) pair once
-            const id = namesByValue.get(value)?.[0] + '.' + key
+            const compoundNames = namesByValue.get(value)
+            const id = compoundNames[0] + '.' + key
             if (seen.has(id)) continue
             seen.add(id)
+            if (
+                compoundNames.some((n) =>
+                    UNDECLARED_STATIC_ALLOWLIST.has(`${n}.${key}`)
+                )
+            )
+                continue
             compoundStatics.push({ compound: name, key, flatNames })
         }
     }
@@ -170,11 +183,6 @@ try {
     )
 }
 
-// Every uppercase own property of an export is treated as public API,
-// including non-component statics. A static that is deliberately kept out of
-// the declared type must be exempted here as '<Export>.<Static>' (none today).
-const UNDECLARED_STATIC_ALLOWLIST = new Set([])
-
 let verifiedStatics = 0
 if (moduleSymbol && compoundStatics.length > 0) {
     const resolveAlias = (symbol) =>
@@ -183,7 +191,6 @@ if (moduleSymbol && compoundStatics.length > 0) {
             : symbol
 
     for (const { compound, key, flatNames } of compoundStatics) {
-        if (UNDECLARED_STATIC_ALLOWLIST.has(`${compound}.${key}`)) continue
         const compoundSymbol = exportsOfMain.find((s) => s.name === compound)
         if (!compoundSymbol) {
             failed = true

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -14,6 +14,13 @@
 // Check 1 (collision guard) fails the build on ANY such basename collision.
 // Check 2 (type smoke test) type-checks key root exports of `dist/main.d.ts`
 // and fails if a symbol is missing or resolves to `any`.
+// Check 3 (compound identity, issue #1576) discovers at runtime every
+// compound static that is the SAME VALUE as a flat export (e.g.
+// `Skeleton.Avatar === SkeletonAvatar`) and fails if its emitted declaration
+// is an inline prop re-declaration instead of `typeof <FlatExport>` — inline
+// types claim two independent components where there is one, so type-driven
+// tooling emits duplicates. Discovery is by value identity, so new compounds
+// are covered automatically without registering them here.
 import { readdirSync, existsSync, statSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -98,10 +105,110 @@ if (!moduleSymbol) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Check 3: compound statics that reuse a flat export must be typed `typeof`
+// ---------------------------------------------------------------------------
+// Runtime identity is the ground truth: a static counts as an alias only when
+// it is `===` a top-level export. The emitted type must then be a `typeof`
+// query resolving to that export's declaration. (A structural type comparison
+// cannot catch this — the inline form is structurally identical.)
+const compoundPairs = []
+try {
+    const { JSDOM } = await import('jsdom')
+    const dom = new JSDOM('', { pretendToBeVisual: true })
+    global.window = dom.window
+    global.document = dom.window.document
+    global.HTMLElement = dom.window.HTMLElement
+    global.getComputedStyle = dom.window.getComputedStyle
+    Object.defineProperty(global, 'navigator', {
+        value: dom.window.navigator,
+        configurable: true,
+    })
+
+    const mod = await import(resolve(distDir, 'main.js'))
+
+    const isComponentLike = (v) =>
+        typeof v === 'function' ||
+        (typeof v === 'object' && v !== null && '$$typeof' in v)
+
+    const namesByValue = new Map()
+    for (const [name, value] of Object.entries(mod)) {
+        if (name === 'default' || !isComponentLike(value)) continue
+        if (!namesByValue.has(value)) namesByValue.set(value, [])
+        namesByValue.get(value).push(name)
+    }
+
+    const seen = new Set()
+    for (const [name, value] of Object.entries(mod)) {
+        if (name === 'default' || !isComponentLike(value)) continue
+        for (const key of Object.keys(value)) {
+            if (!/^[A-Z]/.test(key)) continue
+            const staticValue = value[key]
+            if (staticValue === value) continue
+            const flatNames = namesByValue.get(staticValue)
+            if (!flatNames) continue
+            // the same compound value can be exported under several names —
+            // check each (compound value, static) pair once
+            const id = namesByValue.get(value)?.[0] + '.' + key
+            if (seen.has(id)) continue
+            seen.add(id)
+            compoundPairs.push({ compound: name, key, flatNames })
+        }
+    }
+} catch (error) {
+    failed = true
+    console.error(
+        `✖ Could not import dist/main.js to discover compound statics: ${error.message}`
+    )
+}
+
+if (moduleSymbol && compoundPairs.length > 0) {
+    const exportsOfMain = checker.getExportsOfModule(moduleSymbol)
+    const resolveAlias = (symbol) =>
+        symbol && symbol.flags & ts.SymbolFlags.Alias
+            ? checker.getAliasedSymbol(symbol)
+            : symbol
+
+    for (const { compound, key, flatNames } of compoundPairs) {
+        const compoundSymbol = exportsOfMain.find((s) => s.name === compound)
+        if (!compoundSymbol) continue
+        const compoundType = checker.getTypeOfSymbolAtLocation(
+            compoundSymbol,
+            sourceFile
+        )
+        const propDecl = compoundType.getProperty(key)?.declarations?.[0]
+        const typeNode = propDecl?.type
+
+        let ok = false
+        if (typeNode && ts.isTypeQueryNode(typeNode)) {
+            const target = resolveAlias(
+                checker.getSymbolAtLocation(typeNode.exprName)
+            )
+            ok = flatNames.some(
+                (flat) =>
+                    resolveAlias(exportsOfMain.find((s) => s.name === flat)) ===
+                    target
+            )
+        }
+        if (!ok) {
+            failed = true
+            console.error(
+                `✖ \`${compound}.${key}\` is the same runtime value as export ` +
+                    `\`${flatNames[0]}\`, but its emitted declaration is not ` +
+                    `\`typeof ${flatNames[0]}\`. Annotate the compound const ` +
+                    'explicitly (see SkeletonCompound.tsx) so declaration emit ' +
+                    'states the value identity instead of inlining the props.'
+            )
+        }
+    }
+}
+
 if (failed) {
     process.exit(1)
 }
 
 console.log(
-    `✔ dist/ has no file/directory collisions; key exports (${KEY_EXPORTS.join(', ')}) are typed.`
+    `✔ dist/ has no file/directory collisions; key exports (${KEY_EXPORTS.join(', ')}) are typed; ` +
+        `${compoundPairs.length} compound statics verified as \`typeof\` aliases.`
 )
+process.exit(0)


### PR DESCRIPTION
## Summary
Fixes #1576.

Compound-component statics that are the **same runtime value** as a flat top-level export (`Skeleton.Avatar` = `SkeletonAvatar`, `Skeleton.Card` = `SkeletonCard`, `Skeleton.Base` = `SkeletonBase`, and all five `Timeline.*` statics) were emitted in the public `.d.ts` as full inline prop re-declarations, so the typings claimed two independent components where there is really one. Type-driven tooling (e.g. the ReScript binding generator) couldn't prove the identity and generated duplicate bindings.

## Changes
- `SkeletonCompound.tsx`: hoisted the root/alias `forwardRef` components to named consts and annotated `SkeletonCompound` explicitly, so declaration emit preserves `Avatar: typeof SkeletonAvatar`, `Card: typeof SkeletonCard`, `Base: typeof Skeleton` instead of inlining the props. `Circle`/`Rectangle`/`Rounded` have no flat export and stay self-contained.
- `Timeline.tsx`: annotated the `Timeline` compound so `Label`/`Header`/`Substep`/`Node`/`ShowMore` are emitted as `typeof` their flat exports.
- `scripts/check-dist.mjs`: added a **generalized regression gate** (Check 3) to the existing post-build `check:dist` step. It imports `dist/main.js` under jsdom and enumerates every public static on every export (runtime is the ground truth — no hardcoded list, so new compounds are covered automatically), then asserts against `dist/main.d.ts`:
  - every static **exists in the declared type** — catches annotation drift, where a static added to `Object.assign` but not to the compound's explicit annotation silently vanishes from the public type;
  - every static that is `===` a flat export is declared as a `typeof` query resolving to that export — a structural type comparison could not catch this, since the inline form is structurally identical to the `typeof` form.

Today the gate verifies 16 statics: 12 flat-export aliases as `typeof` — BreadcrumbV2 (4, already followed this pattern in source), Skeleton (3), Timeline (5) — plus 4 compound-only statics verified as declared.

No runtime change — the values assigned via `Object.assign` are untouched; only the declared types (and therefore the emitted `.d.ts`) changed.

## Emitted declarations (after)
```ts
declare const SkeletonCompound: typeof SkeletonRoot & {
    Avatar: typeof SkeletonAvatar;
    Card: typeof SkeletonCard;
    Base: typeof Skeleton;
    Circle: typeof SkeletonCircle;
    Rectangle: typeof SkeletonRectangle;
    Rounded: typeof SkeletonRounded;
};
```
```ts
declare const Timeline: typeof TimelineRoot & {
    Label: typeof TimelineLabel;
    Header: typeof TimelineHeader;
    Substep: typeof TimelineSubstep;
    Node: typeof TimelineNode;
    ShowMore: typeof TimelineShowMore;
};
```

## Testing
- `pnpm build` in `packages/blend` (lint + vite build + dts emit + `check:dist` incl. the new gate) passes; verified the regenerated `dist` declarations above.
- Negative-tested the gate both ways: hand-reverting `Avatar` in the dist `.d.ts` to an inline type fails the build with `✖ \`Skeleton.Avatar\` is the same runtime value as export \`SkeletonAvatar\`, but its emitted declaration is not \`typeof SkeletonAvatar\`...`, and deleting the `Rounded` property fails with `✖ \`Skeleton.Rounded\` exists at runtime but is missing from \`Skeleton\`'s declared type...`
- Timeline test suite passes (40/40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
