### PR TITLE
fix: fixing esc not appearing in searchbar

### DIFF
--- a/apps/ascent/components/showcase/SearchBar.tsx
+++ b/apps/ascent/components/showcase/SearchBar.tsx
@@ -221,7 +221,7 @@ export default function SearchBar({
                                 </motion.button>
                             ) : (
                                 <motion.div
-                                    key="shortcut"
+                                    key={isExpanded ? 'esc' : 'shortcut'}
                                     initial={{ opacity: 0 }}
                                     animate={{ opacity: 1 }}
                                     exit={{ opacity: 0 }}
@@ -229,7 +229,7 @@ export default function SearchBar({
                                     aria-hidden="true"
                                 >
                                     <span className="flex items-center text-[11px] text-muted-foreground bg-secondary/50 border border-border/50 rounded-md px-1.5 py-0.5">
-                                        F
+                                        {isExpanded ? 'Esc' : 'F'}
                                     </span>
                                 </motion.div>
                             )}


### PR DESCRIPTION
### Summary

fixing searchbar in showcase page esc not appearing when active 

### Issue Ticket

Closes #1580 or Related to #1580


https://github.com/user-attachments/assets/e50a45e3-25ef-4782-afec-fd41105e76be


