### PR TITLE
fix: fixed min max and customdisableDates and introduce maxRange

### DIFF
--- a/apps/site/src/demos/DateRangePickerDemo.tsx
+++ b/apps/site/src/demos/DateRangePickerDemo.tsx
@@ -140,6 +140,16 @@ const DateRangePickerDemo = () => {
         endDate: new Date(),
     })
 
+    // Bounded & disabled dates demos
+    const [minMaxRange, setMinMaxRange] = useState<DateRange | undefined>({
+        startDate: new Date(),
+        endDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+    })
+    const [disabledDaysRange, setDisabledDaysRange] = useState<
+        DateRange | undefined
+    >()
+    const [maxRangeRange, setMaxRangeRange] = useState<DateRange | undefined>()
+
     // Simple yesterday range - component handles timezone internally
     const [yesterdayRange, setYesterdayRange] = useState<DateRange>(() => {
         const yesterday = new Date()
@@ -4258,6 +4268,137 @@ const DateRangePickerDemo = () => {
                         handles UI, formatting, preset detection, and timezone
                         conversion. Timezone support uses native Intl API.
                     </p>
+                </div>
+            </div>
+
+            {/* Bounded & Disabled Dates */}
+            <div className="space-y-6">
+                <h2 className="text-2xl font-bold">
+                    Bounded &amp; Disabled Dates
+                </h2>
+                <p className="text-gray-600">
+                    <code className="bg-gray-100 px-1 rounded">minDate</code>,{' '}
+                    <code className="bg-gray-100 px-1 rounded">maxDate</code>,{' '}
+                    <code className="bg-gray-100 px-1 rounded">
+                        customDisableDates
+                    </code>{' '}
+                    and{' '}
+                    <code className="bg-gray-100 px-1 rounded">
+                        maxRangeDays
+                    </code>{' '}
+                    are enforced in both the cell styling <em>and</em> the
+                    click/keyboard handlers — disabled dates cannot be selected
+                    via mouse or Enter/Space.
+                </p>
+
+                {/* minDate / maxDate */}
+                <div className="p-4 border border-gray-200 rounded-lg bg-gray-50 space-y-3">
+                    <h3 className="text-lg font-semibold text-gray-700">
+                        minDate / maxDate — hard window
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                        Only dates within{' '}
+                        <code className="bg-white px-1 rounded">minDate</code>{' '}
+                        and{' '}
+                        <code className="bg-white px-1 rounded">maxDate</code>{' '}
+                        are selectable. Days outside the window render disabled
+                        and ignore clicks and keyboard activation.
+                    </p>
+                    <DateRangePicker
+                        value={minMaxRange}
+                        onChange={setMinMaxRange}
+                        minDate={
+                            new Date(
+                                new Date().getFullYear(),
+                                new Date().getMonth(),
+                                1
+                            )
+                        }
+                        maxDate={
+                            new Date(
+                                new Date().getFullYear(),
+                                new Date().getMonth() + 1,
+                                0
+                            )
+                        }
+                        showDateTimePicker={false}
+                        showPresets={false}
+                    />
+                </div>
+
+                {/* customDisableDates — Sundays disabled */}
+                <div className="p-4 border border-gray-200 rounded-lg bg-gray-50 space-y-3">
+                    <h3 className="text-lg font-semibold text-gray-700">
+                        customDisableDates — block Sundays
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                        The callback receives{' '}
+                        <code className="bg-white px-1 rounded">
+                            (date, currentRange)
+                        </code>
+                        . Here Sundays are disabled. Try focusing a Sunday cell
+                        and pressing Enter — it stays blocked.
+                    </p>
+                    <DateRangePicker
+                        value={disabledDaysRange}
+                        onChange={setDisabledDaysRange}
+                        customDisableDates={(date) => date.getDay() === 0}
+                        showDateTimePicker={false}
+                        showPresets={false}
+                    />
+                </div>
+
+                {/* maxRangeDays */}
+                <div className="p-4 border border-gray-200 rounded-lg bg-gray-50 space-y-3">
+                    <h3 className="text-lg font-semibold text-gray-700">
+                        maxRangeDays — cap in-progress range (7 days)
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                        Pick a start date — days more than 7 away from the start
+                        become disabled until an end date is chosen. The cap is
+                        lifted once both start and end are set (a new click
+                        starts a fresh range).
+                    </p>
+                    <DateRangePicker
+                        value={maxRangeRange}
+                        onChange={setMaxRangeRange}
+                        maxRangeDays={7}
+                        showDateTimePicker={false}
+                        showPresets={false}
+                    />
+                </div>
+
+                {/* Combined */}
+                <div className="p-4 border border-indigo-200 rounded-lg bg-indigo-50 space-y-3">
+                    <h3 className="text-lg font-semibold text-indigo-700">
+                        Combined — window + disabled days + range cap
+                    </h3>
+                    <p className="text-sm text-indigo-600">
+                        All three constraints active at once: bounded to this
+                        month, Sundays disabled, max 7-day range.
+                    </p>
+                    <DateRangePicker
+                        value={maxRangeRange}
+                        onChange={setMaxRangeRange}
+                        minDate={
+                            new Date(
+                                new Date().getFullYear(),
+                                new Date().getMonth(),
+                                1
+                            )
+                        }
+                        maxDate={
+                            new Date(
+                                new Date().getFullYear(),
+                                new Date().getMonth() + 1,
+                                0
+                            )
+                        }
+                        customDisableDates={(date) => date.getDay() === 0}
+                        maxRangeDays={7}
+                        showDateTimePicker={false}
+                        showPresets={false}
+                    />
                 </div>
             </div>
 

--- a/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
+++ b/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
@@ -433,6 +433,49 @@ describe('handleCalendarDateClick - minDate/maxDate/customDisableDates/maxRangeD
             )
         ).not.toBeNull()
     })
+
+    it('minDate with a time component does not disable same-day clicks', () => {
+        // minDate at noon on June 10; a midnight click on June 10 must still be allowed
+        const minDate = new Date('2026-06-10T12:00:00')
+        const sameDay = new Date('2026-06-10T00:00:00')
+
+        expect(
+            handleCalendarDateClick(
+                sameDay,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).not.toBeNull()
+    })
+
+    it('maxDate with a time component does not disable same-day clicks', () => {
+        // maxDate at midnight on June 20; a noon click on June 20 must still be allowed
+        const maxDate = new Date('2026-06-20T00:00:00')
+        const sameDay = new Date('2026-06-20T12:00:00')
+
+        expect(
+            handleCalendarDateClick(
+                sameDay,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                maxDate
+            )
+        ).not.toBeNull()
+    })
 })
 
 describe('handleCustomRangeCalendarDateClick - minDate/maxDate/customDisableDates guards', () => {

--- a/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
+++ b/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.utils.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
     isControlledDateRange,
     detectPresetFromRange,
     processCustomPresets,
     getPresetLabelWithCustom,
+    handleCalendarDateClick,
+    handleCustomRangeCalendarDateClick,
 } from '../../../lib/components/DateRangePicker/utils'
 import { DateRangePreset } from '../../../lib/components/DateRangePicker/types'
 import type {
     CustomPresetConfig,
     CustomPresetDefinition,
+    DateRange,
 } from '../../../lib/components/DateRangePicker/types'
 
 describe('isControlledDateRange', () => {
@@ -184,5 +187,340 @@ describe('getPresetLabelWithCustom', () => {
         expect(getPresetLabelWithCustom(DateRangePreset.LAST_7_DAYS)).toBe(
             'Last 7 days'
         )
+    })
+})
+
+describe('handleCalendarDateClick - minDate/maxDate/customDisableDates/maxRangeDays guards', () => {
+    const today = new Date('2026-06-15T12:00:00')
+
+    it('blocks clicks before minDate and allows clicks on/after minDate', () => {
+        const minDate = new Date('2026-06-10')
+        const before = new Date('2026-06-09')
+        const on = new Date('2026-06-10')
+        const after = new Date('2026-06-11')
+
+        expect(
+            handleCalendarDateClick(
+                before,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).toBeNull()
+
+        expect(
+            handleCalendarDateClick(
+                on,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).not.toBeNull()
+
+        expect(
+            handleCalendarDateClick(
+                after,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).not.toBeNull()
+    })
+
+    it('blocks clicks after maxDate and allows clicks on/before maxDate', () => {
+        const maxDate = new Date('2026-06-20')
+        const before = new Date('2026-06-19')
+        const on = new Date('2026-06-20')
+        const after = new Date('2026-06-21')
+
+        expect(
+            handleCalendarDateClick(
+                before,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                maxDate
+            )
+        ).not.toBeNull()
+
+        expect(
+            handleCalendarDateClick(
+                on,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                maxDate
+            )
+        ).not.toBeNull()
+
+        expect(
+            handleCalendarDateClick(
+                after,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                maxDate
+            )
+        ).toBeNull()
+    })
+
+    it('blocks clicks when customDisableDates returns true', () => {
+        const disableSundays = (d: Date) => d.getDay() === 0
+        const sunday = new Date('2026-06-21') // Sunday
+        const monday = new Date('2026-06-22') // Monday
+
+        expect(
+            handleCalendarDateClick(
+                sunday,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                disableSundays
+            )
+        ).toBeNull()
+
+        expect(
+            handleCalendarDateClick(
+                monday,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                disableSundays
+            )
+        ).not.toBeNull()
+    })
+
+    it('passes the current selectedRange as the second arg to customDisableDates', () => {
+        const spy = vi.fn(() => false)
+        const range: DateRange = {
+            startDate: new Date('2026-06-10'),
+            endDate: new Date('2026-06-12'),
+        }
+        const clicked = new Date('2026-06-11')
+
+        handleCalendarDateClick(
+            clicked,
+            false,
+            today,
+            false,
+            false,
+            false,
+            undefined,
+            range,
+            false,
+            undefined,
+            undefined,
+            spy
+        )
+
+        expect(spy).toHaveBeenCalledWith(clicked, range)
+    })
+
+    it('maxRangeDays blocks clicks beyond start + maxRangeDays when range is half-selected', () => {
+        const start = new Date('2026-06-10')
+        const selectedRange: DateRange = { startDate: start }
+        const maxRangeDays = 7
+
+        // within window — allowed
+        const within = new Date('2026-06-17') // 7 days away (== maxRangeDays, allowed)
+        expect(
+            handleCalendarDateClick(
+                within,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                selectedRange,
+                false,
+                undefined,
+                undefined,
+                undefined,
+                maxRangeDays
+            )
+        ).not.toBeNull()
+
+        // beyond window — blocked
+        const beyond = new Date('2026-06-19') // 9 days away
+        expect(
+            handleCalendarDateClick(
+                beyond,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                selectedRange,
+                false,
+                undefined,
+                undefined,
+                undefined,
+                maxRangeDays
+            )
+        ).toBeNull()
+    })
+
+    it('maxRangeDays is inactive when no start date is selected yet', () => {
+        const clicked = new Date('2026-06-25')
+        // No selectedRange — even a far-future click should not be blocked by maxRangeDays
+        expect(
+            handleCalendarDateClick(
+                clicked,
+                false,
+                today,
+                false,
+                false,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                undefined,
+                7
+            )
+        ).not.toBeNull()
+    })
+})
+
+describe('handleCustomRangeCalendarDateClick - minDate/maxDate/customDisableDates guards', () => {
+    const today = new Date('2026-06-15T12:00:00')
+
+    it('blocks clicks before minDate even with custom range config absent', () => {
+        const minDate = new Date('2026-06-10')
+        const before = new Date('2026-06-09')
+        const on = new Date('2026-06-10')
+
+        expect(
+            handleCustomRangeCalendarDateClick(
+                before,
+                false,
+                today,
+                false,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).toBeNull()
+
+        expect(
+            handleCustomRangeCalendarDateClick(
+                on,
+                false,
+                today,
+                false,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                false,
+                minDate
+            )
+        ).not.toBeNull()
+    })
+
+    it('blocks clicks when customDisableDates returns true', () => {
+        const disableSundays = (d: Date) => d.getDay() === 0
+        const sunday = new Date('2026-06-21')
+
+        expect(
+            handleCustomRangeCalendarDateClick(
+                sunday,
+                false,
+                today,
+                false,
+                false,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                false,
+                undefined,
+                undefined,
+                disableSundays
+            )
+        ).toBeNull()
+    })
+
+    it('maxRangeDays blocks clicks beyond start + maxRangeDays when half-selected', () => {
+        const start = new Date('2026-06-10')
+        const selectedRange: DateRange = { startDate: start }
+        const beyond = new Date('2026-06-25') // 15 days away
+
+        expect(
+            handleCustomRangeCalendarDateClick(
+                beyond,
+                false,
+                today,
+                false,
+                false,
+                undefined,
+                false,
+                undefined,
+                selectedRange,
+                false,
+                undefined,
+                undefined,
+                undefined,
+                7
+            )
+        ).toBeNull()
     })
 })

--- a/packages/blend/lib/components/DateRangePicker/CalendarGrid.tsx
+++ b/packages/blend/lib/components/DateRangePicker/CalendarGrid.tsx
@@ -9,7 +9,11 @@ import {
 } from 'react'
 import styled, { CSSObject } from 'styled-components'
 import { motion } from 'framer-motion'
-import { DateRange, CustomRangeConfig } from './types'
+import {
+    DateRange,
+    CustomRangeConfig,
+    CustomDateDisableFunction,
+} from './types'
 import { CalendarTokenType } from './dateRangePicker.tokens'
 import Block from '../Primitives/Block/Block'
 import Skeleton from '../Skeleton/Skeleton'
@@ -36,13 +40,16 @@ type CalendarGridProps = {
     disablePastDates?: boolean
     hideFutureDates?: boolean
     hidePastDates?: boolean
-    customDisableDates?: (date: Date) => boolean
+    customDisableDates?: CustomDateDisableFunction
     customRangeConfig?: CustomRangeConfig
     showDateTimePicker?: boolean
     resetScrollPosition?: number // Used to trigger scroll reset when popover reopens
     timezone?: string
     isSingleDatePicker?: boolean
     maxYearOffset?: number
+    minDate?: Date
+    maxDate?: Date
+    maxRangeDays?: number
 }
 
 const CONTAINER_HEIGHT = 340
@@ -239,6 +246,9 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
             timezone,
             isSingleDatePicker,
             maxYearOffset,
+            minDate,
+            maxDate,
+            maxRangeDays,
         },
         ref
     ) => {
@@ -379,7 +389,11 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                     isDoubleClick,
                     timezone,
                     selectedRange,
-                    isSingleDatePicker
+                    isSingleDatePicker,
+                    minDate,
+                    maxDate,
+                    customDisableDates,
+                    maxRangeDays
                 )
 
                 if (newRange) {
@@ -395,6 +409,10 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                 customRangeConfig,
                 onDateSelect,
                 timezone,
+                minDate,
+                maxDate,
+                customDisableDates,
+                maxRangeDays,
             ]
         )
 
@@ -474,8 +492,14 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                 e: React.KeyboardEvent<HTMLElement>,
                 year: number,
                 month: number,
-                day: number
+                day: number,
+                isDisabled: boolean = false
             ) => {
+                if (isDisabled && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault()
+                    return
+                }
+
                 if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault()
                     handleDateClick(year, month, day, false)
@@ -657,7 +681,10 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                                                         calendarToken,
                                                         customDisableDates,
                                                         timezone,
-                                                        isSingleDatePicker
+                                                        isSingleDatePicker,
+                                                        minDate,
+                                                        maxDate,
+                                                        maxRangeDays
                                                     )
 
                                                 const isSelected =
@@ -800,6 +827,7 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                                                             isDisabled
                                                         }
                                                         onClick={() =>
+                                                            !isDisabled &&
                                                             handleDateClick(
                                                                 year,
                                                                 month,
@@ -808,6 +836,7 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                                                             )
                                                         }
                                                         onDoubleClick={() =>
+                                                            !isDisabled &&
                                                             handleDateClick(
                                                                 year,
                                                                 month,
@@ -820,7 +849,8 @@ const CalendarGrid = forwardRef<HTMLDivElement, CalendarGridProps>(
                                                                 e,
                                                                 year,
                                                                 month,
-                                                                day
+                                                                day,
+                                                                isDisabled
                                                             )
                                                         }
                                                         data-element="days"

--- a/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -264,13 +264,16 @@ type CalendarSectionProps = {
     disablePastDates: boolean
     hideFutureDates: boolean
     hidePastDates: boolean
-    customDisableDates?: (date: Date) => boolean
+    customDisableDates?: (date: Date, currentRange?: DateRange) => boolean
     customRangeConfig?: import('./types').CustomRangeConfig
     onDateSelect: (range: DateRange) => void
     showDateTimePicker: boolean
     timezone?: string
     isSingleDatePicker?: boolean
     maxYearOffset?: number
+    minDate?: Date
+    maxDate?: Date
+    maxRangeDays?: number
 }
 
 const CalendarSection: React.FC<
@@ -291,6 +294,9 @@ const CalendarSection: React.FC<
     timezone,
     isSingleDatePicker,
     maxYearOffset,
+    minDate,
+    maxDate,
+    maxRangeDays,
 }) => (
     <Block flexGrow={1} minHeight={0} overflow="auto">
         <CalendarGrid
@@ -309,6 +315,9 @@ const CalendarSection: React.FC<
             timezone={timezone}
             isSingleDatePicker={isSingleDatePicker}
             maxYearOffset={maxYearOffset}
+            minDate={minDate}
+            maxDate={maxDate}
+            maxRangeDays={maxRangeDays}
         />
     </Block>
 )
@@ -386,6 +395,9 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
             hidePastDates = false,
             customDisableDates,
             customRangeConfig,
+            minDate,
+            maxDate,
+            maxRangeDays,
             triggerElement = null,
             useDrawerOnMobile = true,
             skipQuickFiltersOnMobile = false,
@@ -1283,6 +1295,9 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                             timezone={timezone}
                             isSingleDatePicker={isSingleDatePicker}
                             maxYearOffset={maxYearOffset}
+                            minDate={minDate}
+                            maxDate={maxDate}
+                            maxRangeDays={maxRangeDays}
                         />
 
                         <FooterControls

--- a/packages/blend/lib/components/DateRangePicker/types.ts
+++ b/packages/blend/lib/components/DateRangePicker/types.ts
@@ -207,9 +207,13 @@ export type PresetsConfig = (
 /**
  * Function type for custom date disabling logic
  * @param date The date to check
+ * @param currentRange The current in-progress selected range (if any)
  * @returns true if the date should be disabled, false otherwise
  */
-export type CustomDateDisableFunction = (date: Date) => boolean
+export type CustomDateDisableFunction = (
+    date: Date,
+    currentRange?: DateRange
+) => boolean
 
 /**
  * Function type for custom range calculation
@@ -317,6 +321,7 @@ export type DateRangePickerProps = {
     icon?: ReactNode
     minDate?: Date
     maxDate?: Date
+    maxRangeDays?: number
     dateFormat?: string
     allowSingleDateSelection?: boolean
     isSingleDatePicker?: boolean

--- a/packages/blend/lib/components/DateRangePicker/utils.ts
+++ b/packages/blend/lib/components/DateRangePicker/utils.ts
@@ -1040,6 +1040,10 @@ export const createSingleDateRange = (
     return { startDate, endDate }
 }
 
+/** Normalizes a date to midnight so comparisons only consider the calendar day. */
+const startOfDay = (date: Date): Date =>
+    new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
 /**
  * Creates a date at start of day (00:00:00)
  */
@@ -1129,9 +1133,9 @@ export const handleCalendarDateClick = (
         return null
     }
 
-    // minDate / maxDate hard bounds
-    if (minDate && clickedDate < minDate) return null
-    if (maxDate && clickedDate > maxDate) return null
+    // minDate / maxDate hard bounds (day-level comparison)
+    if (minDate && startOfDay(clickedDate) < startOfDay(minDate)) return null
+    if (maxDate && startOfDay(clickedDate) > startOfDay(maxDate)) return null
     // customDisableDates honoured in the click path
     if (customDisableDates && customDisableDates(clickedDate, selectedRange))
         return null
@@ -1139,7 +1143,8 @@ export const handleCalendarDateClick = (
     if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
         const diffDays = Math.abs(
             Math.floor(
-                (clickedDate.getTime() - selectedRange.startDate.getTime()) /
+                (startOfDay(clickedDate).getTime() -
+                    startOfDay(selectedRange.startDate).getTime()) /
                     (1000 * 60 * 60 * 24)
             )
         )
@@ -1540,7 +1545,7 @@ export const getDateCellStates = (
     let isBeyondMaxRange = false
     if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
         const start = selectedRange.startDate
-        const diffMs = date.getTime() - start.getTime()
+        const diffMs = startOfDay(date).getTime() - startOfDay(start).getTime()
         const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
         isBeyondMaxRange = Math.abs(diffDays) > maxRangeDays
     }
@@ -1548,8 +1553,8 @@ export const getDateCellStates = (
     const isDisabled = Boolean(
         (disableFutureDates && date > today) ||
         (disablePastDates && date < today) ||
-        (minDate && date < minDate) ||
-        (maxDate && date > maxDate) ||
+        (minDate && startOfDay(date) < startOfDay(minDate)) ||
+        (maxDate && startOfDay(date) > startOfDay(maxDate)) ||
         (customDisableDates && customDisableDates(date, selectedRange)) ||
         isBeyondMaxRange
     )
@@ -3656,9 +3661,9 @@ export const handleCustomRangeCalendarDateClick = (
         return null
     }
 
-    // minDate / maxDate hard bounds
-    if (minDate && clickedDate < minDate) return null
-    if (maxDate && clickedDate > maxDate) return null
+    // minDate / maxDate hard bounds (day-level comparison)
+    if (minDate && startOfDay(clickedDate) < startOfDay(minDate)) return null
+    if (maxDate && startOfDay(clickedDate) > startOfDay(maxDate)) return null
     // customDisableDates honoured in the click path
     if (customDisableDates && customDisableDates(clickedDate, selectedRange))
         return null
@@ -3666,7 +3671,8 @@ export const handleCustomRangeCalendarDateClick = (
     if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
         const diffDays = Math.abs(
             Math.floor(
-                (clickedDate.getTime() - selectedRange.startDate.getTime()) /
+                (startOfDay(clickedDate).getTime() -
+                    startOfDay(selectedRange.startDate).getTime()) /
                     (1000 * 60 * 60 * 24)
             )
         )

--- a/packages/blend/lib/components/DateRangePicker/utils.ts
+++ b/packages/blend/lib/components/DateRangePicker/utils.ts
@@ -1115,7 +1115,11 @@ export const handleCalendarDateClick = (
     isDoubleClick: boolean = false,
     timezone?: string,
     selectedRange?: DateRange,
-    isSingleDatePicker?: boolean
+    isSingleDatePicker?: boolean,
+    minDate?: Date,
+    maxDate?: Date,
+    customDisableDates?: (date: Date, currentRange?: DateRange) => boolean,
+    maxRangeDays?: number
 ): DateRange | null => {
     // Validate date is not disabled
     if (
@@ -1123,6 +1127,23 @@ export const handleCalendarDateClick = (
         (disablePastDates && clickedDate < today)
     ) {
         return null
+    }
+
+    // minDate / maxDate hard bounds
+    if (minDate && clickedDate < minDate) return null
+    if (maxDate && clickedDate > maxDate) return null
+    // customDisableDates honoured in the click path
+    if (customDisableDates && customDisableDates(clickedDate, selectedRange))
+        return null
+    // maxRangeDays: block clicks on days beyond start + maxRangeDays
+    if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
+        const diffDays = Math.abs(
+            Math.floor(
+                (clickedDate.getTime() - selectedRange.startDate.getTime()) /
+                    (1000 * 60 * 60 * 24)
+            )
+        )
+        if (diffDays > maxRangeDays) return null
     }
 
     // Create clean date without time components for comparison
@@ -1504,15 +1525,33 @@ export const getDateCellStates = (
     today: Date,
     disableFutureDates: boolean = false,
     disablePastDates: boolean = false,
-    customDisableDates?: (date: Date) => boolean,
+    customDisableDates?: (date: Date, currentRange?: DateRange) => boolean,
     timezone?: string,
-    isSingleDatePicker?: boolean
+    isSingleDatePicker?: boolean,
+    minDate?: Date,
+    maxDate?: Date,
+    maxRangeDays?: number
 ) => {
     const isTodayDay = isDateToday(date, today)
+
+    // maxRangeDays: only active while a range is half-selected (start picked,
+    // end not yet chosen). Once both start and end are set, a new click resets
+    // to a fresh start, so capping is not needed there.
+    let isBeyondMaxRange = false
+    if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
+        const start = selectedRange.startDate
+        const diffMs = date.getTime() - start.getTime()
+        const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+        isBeyondMaxRange = Math.abs(diffDays) > maxRangeDays
+    }
+
     const isDisabled = Boolean(
         (disableFutureDates && date > today) ||
         (disablePastDates && date < today) ||
-        (customDisableDates && customDisableDates(date))
+        (minDate && date < minDate) ||
+        (maxDate && date > maxDate) ||
+        (customDisableDates && customDisableDates(date, selectedRange)) ||
+        isBeyondMaxRange
     )
 
     if (!selectedRange) {
@@ -2249,9 +2288,12 @@ export const calculateDayCellProps = (
     disableFutureDates: boolean,
     disablePastDates: boolean,
     calendarToken: CalendarTokenType,
-    customDisableDates?: (date: Date) => boolean,
+    customDisableDates?: (date: Date, currentRange?: DateRange) => boolean,
     timezone?: string,
-    isSingleDatePicker?: boolean
+    isSingleDatePicker?: boolean,
+    minDate?: Date,
+    maxDate?: Date,
+    maxRangeDays?: number
 ): {
     dateStates: ReturnType<typeof getDateCellStates>
     styles: Record<string, unknown>
@@ -2266,7 +2308,10 @@ export const calculateDayCellProps = (
         disablePastDates,
         customDisableDates,
         timezone,
-        isSingleDatePicker
+        isSingleDatePicker,
+        minDate,
+        maxDate,
+        maxRangeDays
     )
 
     const getCellStyles = () => {
@@ -3597,7 +3642,11 @@ export const handleCustomRangeCalendarDateClick = (
     isDoubleClick: boolean = false,
     timezone?: string,
     selectedRange?: DateRange,
-    isSingleDatePicker?: boolean
+    isSingleDatePicker?: boolean,
+    minDate?: Date,
+    maxDate?: Date,
+    customDisableDates?: (date: Date, currentRange?: DateRange) => boolean,
+    maxRangeDays?: number
 ): DateRange | null => {
     // Validate date is not disabled
     if (
@@ -3605,6 +3654,23 @@ export const handleCustomRangeCalendarDateClick = (
         (disablePastDates && clickedDate < today)
     ) {
         return null
+    }
+
+    // minDate / maxDate hard bounds
+    if (minDate && clickedDate < minDate) return null
+    if (maxDate && clickedDate > maxDate) return null
+    // customDisableDates honoured in the click path
+    if (customDisableDates && customDisableDates(clickedDate, selectedRange))
+        return null
+    // maxRangeDays: block clicks on days beyond start + maxRangeDays
+    if (maxRangeDays && selectedRange?.startDate && !selectedRange.endDate) {
+        const diffDays = Math.abs(
+            Math.floor(
+                (clickedDate.getTime() - selectedRange.startDate.getTime()) /
+                    (1000 * 60 * 60 * 24)
+            )
+        )
+        if (diffDays > maxRangeDays) return null
     }
 
     // If no custom range config, use standard logic
@@ -3618,7 +3684,11 @@ export const handleCustomRangeCalendarDateClick = (
             isDoubleClick,
             timezone,
             selectedRange,
-            isSingleDatePicker
+            isSingleDatePicker,
+            minDate,
+            maxDate,
+            customDisableDates,
+            maxRangeDays
         )
     }
 
@@ -3666,7 +3736,11 @@ export const handleCustomRangeCalendarDateClick = (
                 isDoubleClick,
                 timezone,
                 selectedRange,
-                isSingleDatePicker
+                isSingleDatePicker,
+                minDate,
+                maxDate,
+                customDisableDates,
+                maxRangeDays
             )
         }
         endDate = calculatedDate
@@ -3681,7 +3755,11 @@ export const handleCustomRangeCalendarDateClick = (
             isDoubleClick,
             timezone,
             selectedRange,
-            isSingleDatePicker
+            isSingleDatePicker,
+            minDate,
+            maxDate,
+            customDisableDates,
+            maxRangeDays
         )
     }
 


### PR DESCRIPTION
### Summary

fix (DateRangePicker) : wire up minDate/maxDate, enforce customDisableDates on click, add maxRangeDays,
The DateRangePicker exposed minDate/maxDate in its public props but never threaded them into the calendar logic  they were dead code. customDisableDates only styled cells as disabled (via pointerEvents: 'none') but the click/keyboard handlers did not consult it, so Enter/Space on a "disabled" cell could still select it. There was also no way to cap the length of an in-progress range. 

### Issue Ticket

Closes #1596 or Related to #1596

### video

https://github.com/user-attachments/assets/e486776b-1f3e-4ce1-b2e1-3cd034062fa9


