### PR TITLE
feat(Directory): key items by optional id instead of label path

### DIFF
--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -53,6 +53,50 @@ describe('Directory', () => {
         ).toHaveLength(2)
     })
 
+    it('keys expansion by item id when provided, so duplicate sibling labels stay independent', async () => {
+        const onExpandedItemsChange = vi.fn()
+        const duplicateLabelData: DirectoryData[] = [
+            {
+                label: 'Merchants',
+                isCollapsible: false,
+                items: [
+                    {
+                        id: 'mid_001',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_1', label: 'Store 1' }],
+                    },
+                    {
+                        id: 'mid_002',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_2', label: 'Store 2' }],
+                    },
+                ],
+            },
+        ]
+        const { user } = render(
+            <Directory
+                directoryData={duplicateLabelData}
+                enableVirtualization
+                virtualization={{
+                    threshold: 0,
+                    rowHeight: 32,
+                    viewportHeight: 320,
+                    overscan: 2,
+                }}
+                expandedItems={[]}
+                onExpandedItemsChange={onExpandedItemsChange}
+            />
+        )
+
+        const [firstDuplicate] = screen.getAllByRole('button', {
+            name: 'sanavi S',
+        })
+        await user.click(firstDuplicate)
+
+        // the id — not the shared label — identifies the expanded item
+        expect(onExpandedItemsChange).toHaveBeenCalledWith(['mid_001'])
+    })
+
     it('supports controlled expanded items in virtualized mode', async () => {
         const onExpandedItemsChange = vi.fn()
         const { user } = render(

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -13,7 +13,7 @@ import Block from '../Primitives/Block/Block'
 import styled from 'styled-components'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { DirectoryTokenType } from './directory.tokens'
-import { handleKeyDown } from './utils'
+import { getItemPathSegment, handleKeyDown } from './utils'
 import { TooltipV2 } from '../TooltipV2/TooltipV2'
 import { TooltipV2Side } from '../TooltipV2/tooltipV2.types'
 import { TruncatedTextWithTooltipV2 } from '../common/TruncatedTextWithTooltipV2'
@@ -286,7 +286,7 @@ const NavItem = ({
     item,
     index,
     onNavigate,
-    itemPath = item.label,
+    itemPath = getItemPathSegment(item),
     iconOnlyMode = false,
     showHierarchyLines = false,
     hierarchyLineBorderRadius = 0,
@@ -498,7 +498,7 @@ const NavItem = ({
                 hasChildren && !iconOnlyMode ? isExpanded : undefined
             }
             data-element="sidebar-sub-section"
-            data-id={item.label}
+            data-id={item.id ?? item.label}
             data-status={isActive ? 'selected' : 'not selected'}
         >
             {renderContent()}
@@ -544,7 +544,7 @@ const NavItem = ({
                                     key={childIdx}
                                     item={childItem}
                                     index={childIdx}
-                                    itemPath={`${itemPath}/${childItem.label}`}
+                                    itemPath={`${itemPath}/${getItemPathSegment(childItem)}`}
                                     iconOnlyMode={iconOnlyMode}
                                     showHierarchyLines={showHierarchyLines}
                                     hierarchyLineBorderRadius={

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -516,7 +516,7 @@ const VirtualizedDirectory = ({
                     aria-expanded={hasChildren ? isExpanded : undefined}
                     aria-label={row.item.label}
                     data-element="sidebar-sub-section"
-                    data-id={row.item.label}
+                    data-id={row.item.id ?? row.item.label}
                     data-status={isActive ? 'selected' : 'not selected'}
                     data-directory-row-index={rowIndex}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -37,6 +37,13 @@ export type DirectoryData = {
 }
 
 export type NavbarItem = {
+    /**
+     * Stable unique identity for the item among its siblings. When present it
+     * is used (instead of `label`) to build the item's path — the value that
+     * keys expansion state, virtualized row keys and `onItemExpand`. Provide it
+     * whenever sibling labels can repeat.
+     */
+    id?: string
     label: string
     items?: NavbarItem[]
     leftSlot?: ReactNode

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -14,8 +14,13 @@ export const normalizeExpandedItems = (
 ): Set<string> =>
     expandedItems ? new Set(Array.from(expandedItems)) : new Set<string>()
 
+export const getItemPathSegment = (item: NavbarItem): string =>
+    item.id ?? item.label
+
 const getItemPath = (parentPath: string, item: NavbarItem): string =>
-    parentPath ? `${parentPath}/${item.label}` : item.label
+    parentPath
+        ? `${parentPath}/${getItemPathSegment(item)}`
+        : getItemPathSegment(item)
 
 const flattenDirectoryItems = (
     items: NavbarItem[],


### PR DESCRIPTION
Fixes #1614

## Problem

`Directory` identifies items purely by their **label path** (`parent/child` join of `label`s). That single value keys:

- controlled/uncontrolled **expansion state** (`expandedItems` set),
- `onItemExpand` / `onExpandedItemsChange` payloads,
- the virtualizer's **`getItemKey`** (React row keys),
- the `data-id` attribute.

Two siblings sharing a label therefore share expansion state and produce duplicate React keys — the virtualized tree visibly glitches. Real-world directories can't guarantee unique sibling labels (we hit this with several merchants sharing one display name).

## Change

- `NavbarItem` gains an optional **`id?: string`** (doc-commented).
- New `getItemPathSegment(item) = item.id ?? item.label` in `utils.ts`; `getItemPath` uses it, so the virtualized flatten (expansion keys, `getItemKey`, `onItemExpand` paths) is id-aware from one place.
- Non-virtualized `NavItem` uses the same segment for its default `itemPath` and child paths.
- `data-id` prefers `id` in both renderers.
- **No behaviour change without `id`** — label fallback everywhere.

## Tests

- Added: duplicate sibling labels with distinct ids — expanding the first fires `onExpandedItemsChange(['mid_001'])` (the id, not the shared label), independent of its twin.
- Existing Directory suite passes (5/5); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
