### PR TITLE
fix(Directory): hierarchy-line elbow, label alignment, id-based identity, lazy-loading APIs

### DIFF
--- a/apps/site/src/demos/DirectoryDemo.tsx
+++ b/apps/site/src/demos/DirectoryDemo.tsx
@@ -286,6 +286,89 @@ const longNameDirectoryData: DirectoryData[] = [
     },
 ]
 
+const LAZY_PAGE_SIZE = 25
+const LAZY_MAX_ROWS = 150
+
+const LazyLoadSection = () => {
+    const [rowCount, setRowCount] = useState(LAZY_PAGE_SIZE)
+    const [isLoading, setIsLoading] = useState(false)
+    const [events, setEvents] = useState<string[]>([])
+
+    const logEvent = (message: string) => {
+        console.log(`[Directory onEndReached] ${message}`)
+        setEvents((prev) => [...prev.slice(-5), message])
+    }
+
+    const handleEndReached = () => {
+        if (isLoading) return
+        if (rowCount >= LAZY_MAX_ROWS) {
+            logEvent(`end reached at ${rowCount} rows — no more data`)
+            return
+        }
+        logEvent(
+            `end reached at ${rowCount} rows — fetching ${LAZY_PAGE_SIZE} more…`
+        )
+        setIsLoading(true)
+        window.setTimeout(() => {
+            setRowCount((prev) =>
+                Math.min(prev + LAZY_PAGE_SIZE, LAZY_MAX_ROWS)
+            )
+            setIsLoading(false)
+        }, 600)
+    }
+
+    const lazyDirectoryData: DirectoryData[] = useMemo(
+        () => [
+            {
+                label: `Lazy merchants (${rowCount} loaded)`,
+                isCollapsible: false,
+                items: Array.from({ length: rowCount }, (_, index) => ({
+                    id: `lazy-${index}`,
+                    label: `Merchant ${String(index + 1).padStart(3, '0')}`,
+                    leftSlot: <Store style={iconStyle} />,
+                })),
+            },
+        ],
+        [rowCount]
+    )
+
+    return (
+        <section className="space-y-3">
+            <h2 className="text-xl font-semibold">
+                Lazy loading (onEndReached)
+            </h2>
+            <div className="grid gap-6 lg:grid-cols-2">
+                <div className="h-72 w-full max-w-md rounded-lg border border-gray-200 bg-white p-3">
+                    <Directory
+                        directoryData={lazyDirectoryData}
+                        onEndReached={handleEndReached}
+                        endReachedThreshold={80}
+                    />
+                </div>
+                <div className="w-full max-w-md space-y-2">
+                    <p className="text-xs text-gray-500">
+                        Scroll the list to the bottom — each time the viewport
+                        gets within 80px of the end, onEndReached fires (also
+                        printed to the browser console), a fetch is simulated
+                        for 600ms, and {LAZY_PAGE_SIZE} more rows are appended
+                        (up to {LAZY_MAX_ROWS}).
+                    </p>
+                    {isLoading && (
+                        <p className="text-xs font-medium text-blue-600">
+                            loading more…
+                        </p>
+                    )}
+                    <pre className="whitespace-pre-wrap rounded bg-gray-50 p-2 text-xs text-gray-700">
+                        {events.length
+                            ? events.join('\n')
+                            : 'no onEndReached events yet'}
+                    </pre>
+                </div>
+            </div>
+        </section>
+    )
+}
+
 const DirectoryDemo = () => {
     const [showHierarchyLines, setShowHierarchyLines] = useState(true)
     const [hierarchyLineBorderRadius, setHierarchyLineBorderRadius] =
@@ -532,6 +615,8 @@ const DirectoryDemo = () => {
                     merchant rows. Only visible rows plus overscan are mounted.
                 </p>
             </section>
+
+            <LazyLoadSection />
         </div>
     )
 }

--- a/apps/site/src/demos/DirectoryDemo.tsx
+++ b/apps/site/src/demos/DirectoryDemo.tsx
@@ -503,6 +503,7 @@ const DirectoryDemo = () => {
                                 onActiveItemChange={setActiveItem}
                                 showHierarchyLines={showHierarchyLines}
                                 hierarchyLineBorderRadius={`${hierarchyLineBorderRadius}px`}
+                                enableParentSelection
                             />
                         </div>
                         <p className="text-xs text-gray-500">

--- a/apps/site/src/demos/DirectoryDemo.tsx
+++ b/apps/site/src/demos/DirectoryDemo.tsx
@@ -373,9 +373,7 @@ const DirectoryDemo = () => {
     const [showHierarchyLines, setShowHierarchyLines] = useState(true)
     const [hierarchyLineBorderRadius, setHierarchyLineBorderRadius] =
         useState(0)
-    const [activeItem, setActiveItem] = useState<string | null>(
-        'Acme Commerce Group/Helix Network/Orbit Pharma'
-    )
+    const [activeItem, setActiveItem] = useState<string | null>(null)
     const virtualizedExpandedItems = useMemo(
         () => [
             'Merchant Directory',

--- a/apps/site/src/demos/DirectoryDemo.tsx
+++ b/apps/site/src/demos/DirectoryDemo.tsx
@@ -373,7 +373,9 @@ const DirectoryDemo = () => {
     const [showHierarchyLines, setShowHierarchyLines] = useState(true)
     const [hierarchyLineBorderRadius, setHierarchyLineBorderRadius] =
         useState(0)
-    const [activeItem, setActiveItem] = useState<string | null>(null)
+    const [activeItem, setActiveItem] = useState<string | null>(
+        'Acme Commerce Group/Helix Network/Orbit Pharma'
+    )
     const virtualizedExpandedItems = useMemo(
         () => [
             'Merchant Directory',

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -53,6 +53,98 @@ describe('Directory', () => {
         ).toHaveLength(2)
     })
 
+    it('keys expansion by item id when provided, so duplicate sibling labels stay independent', async () => {
+        const onExpandedItemsChange = vi.fn()
+        const duplicateLabelData: DirectoryData[] = [
+            {
+                label: 'Merchants',
+                isCollapsible: false,
+                items: [
+                    {
+                        id: 'mid_001',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_1', label: 'Store 1' }],
+                    },
+                    {
+                        id: 'mid_002',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_2', label: 'Store 2' }],
+                    },
+                ],
+            },
+        ]
+        const { user } = render(
+            <Directory
+                directoryData={duplicateLabelData}
+                enableVirtualization
+                virtualization={{
+                    threshold: 0,
+                    rowHeight: 32,
+                    viewportHeight: 320,
+                    overscan: 2,
+                }}
+                expandedItems={[]}
+                onExpandedItemsChange={onExpandedItemsChange}
+            />
+        )
+
+        const [firstDuplicate] = screen.getAllByRole('button', {
+            name: 'sanavi S',
+        })
+        await user.click(firstDuplicate)
+
+        // the id — not the shared label — identifies the expanded item
+        expect(onExpandedItemsChange).toHaveBeenCalledWith(['mid_001'])
+    })
+
+    it('honors controlled expansion props without virtualization', async () => {
+        const onExpandedItemsChange = vi.fn()
+        const onItemExpand = vi.fn()
+        const { user } = render(
+            <Directory
+                directoryData={directoryData}
+                expandedItems={[]}
+                onExpandedItemsChange={onExpandedItemsChange}
+                onItemExpand={onItemExpand}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: /acme/i }))
+
+        expect(onExpandedItemsChange).toHaveBeenCalledWith([
+            'Acme Commerce Group',
+        ])
+        expect(onItemExpand).toHaveBeenCalledWith(
+            expect.objectContaining({ label: 'Acme Commerce Group' }),
+            'Acme Commerce Group'
+        )
+    })
+
+    it('fires onClick for parent rows when toggling expansion', async () => {
+        const onParentClick = vi.fn()
+        const parentClickData: DirectoryData[] = [
+            {
+                label: 'Organizations',
+                isCollapsible: false,
+                items: [
+                    {
+                        label: 'Acme Commerce Group',
+                        onClick: onParentClick,
+                        items: [{ label: 'Helix Network' }],
+                    },
+                ],
+            },
+        ]
+        const { user } = render(<Directory directoryData={parentClickData} />)
+
+        await user.click(screen.getByRole('button', { name: /acme/i }))
+
+        expect(onParentClick).toHaveBeenCalledTimes(1)
+        expect(
+            screen.getByRole('button', { name: /helix network/i })
+        ).toBeInTheDocument()
+    })
+
     it('supports controlled expanded items in virtualized mode', async () => {
         const onExpandedItemsChange = vi.fn()
         const { user } = render(

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -97,6 +97,53 @@ describe('Directory', () => {
         expect(onExpandedItemsChange).toHaveBeenCalledWith(['mid_001'])
     })
 
+    it('uses id-based paths in the non-virtualized renderer too', async () => {
+        const onExpandedItemsChange = vi.fn()
+        const onActiveItemChange = vi.fn()
+        const duplicateLabelData: DirectoryData[] = [
+            {
+                label: 'Merchants',
+                isCollapsible: false,
+                items: [
+                    {
+                        id: 'mid_001',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_1', label: 'Store 1' }],
+                    },
+                    {
+                        id: 'mid_002',
+                        label: 'sanavi S',
+                        items: [{ id: 'sub_2', label: 'Store 2' }],
+                    },
+                ],
+            },
+        ]
+        const { user } = render(
+            <Directory
+                directoryData={duplicateLabelData}
+                onExpandedItemsChange={onExpandedItemsChange}
+                onActiveItemChange={onActiveItemChange}
+            />
+        )
+
+        const [firstDuplicate] = screen.getAllByRole('button', {
+            name: 'sanavi S',
+        })
+        await user.click(firstDuplicate)
+
+        // same id-based identity as the virtualized renderer
+        expect(onExpandedItemsChange).toHaveBeenCalledWith(['mid_001'])
+        expect(
+            screen.getByRole('button', { name: 'Store 1' })
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByRole('button', { name: 'Store 2' })
+        ).not.toBeInTheDocument()
+
+        await user.click(screen.getByRole('button', { name: 'Store 1' }))
+        expect(onActiveItemChange).toHaveBeenCalledWith('mid_001/sub_1')
+    })
+
     it('honors controlled expansion props without virtualization', async () => {
         const onExpandedItemsChange = vi.fn()
         const onItemExpand = vi.fn()

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -182,6 +182,60 @@ describe('Directory', () => {
         ).toHaveAttribute('data-status', 'selected')
     })
 
+    it('does not refire onEndReached when re-rendered with fresh data references', () => {
+        const onEndReached = vi.fn()
+        const buildData = (): DirectoryData[] => [
+            {
+                label: 'Merchants',
+                isCollapsible: false,
+                items: [{ label: 'Store 1' }, { label: 'Store 2' }],
+            },
+        ]
+        // jsdom reports zero dimensions, so the viewport counts as "at the
+        // end" — the hook fires once on bind and must stay disarmed across
+        // re-renders that only change the data array's reference identity
+        const { rerender } = render(
+            <Directory
+                directoryData={buildData()}
+                onEndReached={onEndReached}
+            />
+        )
+        expect(onEndReached).toHaveBeenCalledTimes(1)
+
+        rerender(
+            <Directory
+                directoryData={buildData()}
+                onEndReached={onEndReached}
+            />
+        )
+        rerender(
+            <Directory
+                directoryData={buildData()}
+                onEndReached={onEndReached}
+            />
+        )
+        expect(onEndReached).toHaveBeenCalledTimes(1)
+
+        // an actual content change re-arms and fires again
+        rerender(
+            <Directory
+                directoryData={[
+                    {
+                        label: 'Merchants',
+                        isCollapsible: false,
+                        items: [
+                            { label: 'Store 1' },
+                            { label: 'Store 2' },
+                            { label: 'Store 3' },
+                        ],
+                    },
+                ]}
+                onEndReached={onEndReached}
+            />
+        )
+        expect(onEndReached).toHaveBeenCalledTimes(2)
+    })
+
     it('honors controlled expansion props without virtualization', async () => {
         const onExpandedItemsChange = vi.fn()
         const onItemExpand = vi.fn()

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -144,6 +144,44 @@ describe('Directory', () => {
         expect(onActiveItemChange).toHaveBeenCalledWith('mid_001/sub_1')
     })
 
+    it('does not co-select id-having duplicates via a bare-label activeItem', () => {
+        const duplicateLabelData: DirectoryData[] = [
+            {
+                label: 'Merchants',
+                isCollapsible: false,
+                items: [
+                    { id: 'mid_001', label: 'sanavi S' },
+                    { id: 'mid_002', label: 'sanavi S' },
+                    { label: 'Legacy Store' },
+                ],
+            },
+        ]
+        const { unmount } = render(
+            <Directory
+                directoryData={duplicateLabelData}
+                activeItem="sanavi S"
+            />
+        )
+
+        for (const duplicate of screen.getAllByRole('button', {
+            name: 'sanavi S',
+        })) {
+            expect(duplicate).toHaveAttribute('data-status', 'not selected')
+        }
+        unmount()
+
+        // id-less items keep the backward-compat bare-label matching
+        render(
+            <Directory
+                directoryData={duplicateLabelData}
+                activeItem="Legacy Store"
+            />
+        )
+        expect(
+            screen.getByRole('button', { name: 'Legacy Store' })
+        ).toHaveAttribute('data-status', 'selected')
+    })
+
     it('honors controlled expansion props without virtualization', async () => {
         const onExpandedItemsChange = vi.fn()
         const onItemExpand = vi.fn()

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -145,6 +145,45 @@ describe('Directory', () => {
         ).toBeInTheDocument()
     })
 
+    it('selects parent rows on click when enableParentSelection is set', async () => {
+        const onActiveItemChange = vi.fn()
+        const { user } = render(
+            <Directory
+                directoryData={directoryData}
+                enableParentSelection
+                onActiveItemChange={onActiveItemChange}
+            />
+        )
+
+        const parent = screen.getByRole('button', { name: /acme/i })
+        await user.click(parent)
+
+        expect(onActiveItemChange).toHaveBeenCalledWith('Acme Commerce Group')
+        expect(parent).toHaveAttribute('data-status', 'selected')
+
+        // selection moves to the leaf, then back to the parent on collapse
+        await user.click(screen.getByRole('button', { name: /helix network/i }))
+        expect(onActiveItemChange).toHaveBeenLastCalledWith(
+            'Acme Commerce Group/Helix Network'
+        )
+        expect(parent).toHaveAttribute('data-status', 'not selected')
+
+        await user.click(parent)
+        expect(onActiveItemChange).toHaveBeenLastCalledWith(
+            'Acme Commerce Group'
+        )
+        expect(parent).toHaveAttribute('data-status', 'selected')
+    })
+
+    it('keeps parent rows unselectable by default', async () => {
+        const { user } = render(<Directory directoryData={directoryData} />)
+
+        const parent = screen.getByRole('button', { name: /acme/i })
+        await user.click(parent)
+
+        expect(parent).toHaveAttribute('data-status', 'not selected')
+    })
+
     it('supports controlled expanded items in virtualized mode', async () => {
         const onExpandedItemsChange = vi.fn()
         const { user } = render(

--- a/packages/blend/lib/components/Directory/Directory.tsx
+++ b/packages/blend/lib/components/Directory/Directory.tsx
@@ -6,8 +6,13 @@ import type { DirectoryProps } from './types'
 import Section from './Section'
 import VirtualizedDirectory from './VirtualizedDirectory'
 import Block from '../Primitives/Block/Block'
-import { handleSectionNavigation, normalizeDirectoryData } from './utils'
-import { ActiveItemProvider } from './NavItem'
+import {
+    DEFAULT_END_REACHED_THRESHOLD,
+    handleSectionNavigation,
+    normalizeDirectoryData,
+    useDirectoryEndReached,
+} from './utils'
+import { ActiveItemProvider, ExpandedItemsProvider } from './NavItem'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { DirectoryTokenType } from './directory.tokens'
 
@@ -24,6 +29,8 @@ const Directory = ({
     defaultExpandedItems,
     onExpandedItemsChange,
     onItemExpand,
+    onEndReached,
+    endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
     enableVirtualization = false,
     virtualization,
 }: DirectoryProps) => {
@@ -31,6 +38,7 @@ const Directory = ({
     const sectionRefs = useRef<Array<React.RefObject<HTMLDivElement | null>>>(
         []
     )
+    const scrollRef = useRef<HTMLDivElement | null>(null)
 
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
     useEffect(() => {
@@ -38,6 +46,14 @@ const Directory = ({
             createRef<HTMLDivElement | null>()
         )
     }, [directoryData])
+
+    useDirectoryEndReached({
+        scrollRef,
+        onEndReached:
+            enableVirtualization && !iconOnlyMode ? undefined : onEndReached,
+        threshold: endReachedThreshold,
+        contentKey: directoryData,
+    })
 
     if (enableVirtualization && !iconOnlyMode) {
         return (
@@ -53,6 +69,8 @@ const Directory = ({
                 defaultExpandedItems={defaultExpandedItems}
                 onExpandedItemsChange={onExpandedItemsChange}
                 onItemExpand={onItemExpand}
+                onEndReached={onEndReached}
+                endReachedThreshold={endReachedThreshold}
                 enableVirtualization={enableVirtualization}
                 virtualization={virtualization}
             />
@@ -65,39 +83,52 @@ const Directory = ({
             onActiveItemChange={onActiveItemChange}
             defaultActiveItem={defaultActiveItem}
         >
-            <Block
-                as="nav"
-                width="100%"
-                height="100%"
-                flexGrow={1}
-                display="flex"
-                flexDirection="column"
-                alignItems="center"
-                overflow="auto"
-                aria-label="Directory navigation"
-                gap={iconOnlyMode ? '8px' : tokens.gap}
-                paddingX={iconOnlyMode ? '12px' : tokens.paddingX}
-                paddingY={tokens.paddingY}
+            <ExpandedItemsProvider
+                expandedItems={expandedItems}
+                defaultExpandedItems={defaultExpandedItems}
+                onExpandedItemsChange={onExpandedItemsChange}
+                onItemExpand={onItemExpand}
             >
-                {directoryData.map((section, sectionIndex) => (
-                    <Section
-                        key={sectionIndex}
-                        section={section}
-                        sectionIndex={sectionIndex}
-                        idPrefix={idPrefix}
-                        iconOnlyMode={iconOnlyMode}
-                        showHierarchyLines={showHierarchyLines}
-                        hierarchyLineBorderRadius={hierarchyLineBorderRadius}
-                        onNavigateBetweenSections={(direction, currentIndex) =>
-                            handleSectionNavigation(
+                <Block
+                    as="nav"
+                    ref={scrollRef}
+                    width="100%"
+                    height="100%"
+                    flexGrow={1}
+                    display="flex"
+                    flexDirection="column"
+                    alignItems="center"
+                    overflow="auto"
+                    aria-label="Directory navigation"
+                    gap={iconOnlyMode ? '8px' : tokens.gap}
+                    paddingX={iconOnlyMode ? '12px' : tokens.paddingX}
+                    paddingY={tokens.paddingY}
+                >
+                    {directoryData.map((section, sectionIndex) => (
+                        <Section
+                            key={sectionIndex}
+                            section={section}
+                            sectionIndex={sectionIndex}
+                            idPrefix={idPrefix}
+                            iconOnlyMode={iconOnlyMode}
+                            showHierarchyLines={showHierarchyLines}
+                            hierarchyLineBorderRadius={
+                                hierarchyLineBorderRadius
+                            }
+                            onNavigateBetweenSections={(
                                 direction,
-                                currentIndex,
-                                directoryData.length
-                            )
-                        }
-                    />
-                ))}
-            </Block>
+                                currentIndex
+                            ) =>
+                                handleSectionNavigation(
+                                    direction,
+                                    currentIndex,
+                                    directoryData.length
+                                )
+                            }
+                        />
+                    ))}
+                </Block>
+            </ExpandedItemsProvider>
         </ActiveItemProvider>
     )
 }

--- a/packages/blend/lib/components/Directory/Directory.tsx
+++ b/packages/blend/lib/components/Directory/Directory.tsx
@@ -31,6 +31,7 @@ const Directory = ({
     onItemExpand,
     onEndReached,
     endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
+    enableParentSelection = false,
     enableVirtualization = false,
     virtualization,
 }: DirectoryProps) => {
@@ -71,6 +72,7 @@ const Directory = ({
                 onItemExpand={onItemExpand}
                 onEndReached={onEndReached}
                 endReachedThreshold={endReachedThreshold}
+                enableParentSelection={enableParentSelection}
                 enableVirtualization={enableVirtualization}
                 virtualization={virtualization}
             />
@@ -115,6 +117,7 @@ const Directory = ({
                             hierarchyLineBorderRadius={
                                 hierarchyLineBorderRadius
                             }
+                            enableParentSelection={enableParentSelection}
                             onNavigateBetweenSections={(
                                 direction,
                                 currentIndex

--- a/packages/blend/lib/components/Directory/Directory.tsx
+++ b/packages/blend/lib/components/Directory/Directory.tsx
@@ -7,6 +7,7 @@ import Section from './Section'
 import VirtualizedDirectory from './VirtualizedDirectory'
 import Block from '../Primitives/Block/Block'
 import {
+    countDirectoryItems,
     DEFAULT_END_REACHED_THRESHOLD,
     handleSectionNavigation,
     normalizeDirectoryData,
@@ -53,7 +54,7 @@ const Directory = ({
         onEndReached:
             enableVirtualization && !iconOnlyMode ? undefined : onEndReached,
         threshold: endReachedThreshold,
-        contentKey: directoryData,
+        contentKey: countDirectoryItems(directoryData),
     })
 
     if (enableVirtualization && !iconOnlyMode) {

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -262,11 +262,11 @@ export const ActiveItemProvider: React.FC<ActiveItemProviderProps> = ({
 
     const setActiveItem = useCallback(
         (item: string | null) => {
-            if (isControlled) {
-                onActiveItemChange?.(item)
-            } else {
+            if (!isControlled) {
                 setInternalActiveItem(item)
             }
+            // fired in both modes, matching the virtualized renderer
+            onActiveItemChange?.(item)
         },
         [isControlled, onActiveItemChange]
     )
@@ -387,6 +387,7 @@ const NavItem = ({
     hierarchyLineBorderRadius = 0,
     isLast = false,
     isNested = false,
+    enableParentSelection = false,
 }: NavItemProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
     const { isItemExpanded, setItemExpanded } = useExpandedItemsContext()
@@ -395,10 +396,11 @@ const NavItem = ({
         setItemExpanded(item, itemPath, value)
     const { activeItem, setActiveItem } = useActiveItemContext()
     const hasChildren = item.items && item.items.length > 0
+    const isSelectable = enableParentSelection || !hasChildren
     const isActive =
         item.isSelected !== undefined
-            ? item.isSelected && !hasChildren
-            : !hasChildren &&
+            ? item.isSelected && isSelectable
+            : isSelectable &&
               (activeItem === itemPath || activeItem === item.label)
 
     const itemRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null)
@@ -428,6 +430,9 @@ const NavItem = ({
     const activateItem = () => {
         if (hasChildren && !iconOnlyMode) {
             setIsExpanded(!isExpanded)
+            if (enableParentSelection) {
+                setActiveItem(itemPath)
+            }
             item.onClick?.()
         } else {
             setActiveItem(itemPath)
@@ -654,6 +659,9 @@ const NavItem = ({
                                         (item.items?.length || 0) - 1
                                     }
                                     isNested
+                                    enableParentSelection={
+                                        enableParentSelection
+                                    }
                                     onNavigate={(direction, currentIndex) => {
                                         if (
                                             direction === 'up' &&

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -7,13 +7,17 @@ import React, {
     useRef,
     useLayoutEffect,
 } from 'react'
-import type { NavItemProps } from './types'
+import type { DirectoryExpandedItems, NavItemProps, NavbarItem } from './types'
 import { ChevronDown } from 'lucide-react'
 import Block from '../Primitives/Block/Block'
 import styled from 'styled-components'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { DirectoryTokenType } from './directory.tokens'
-import { handleKeyDown } from './utils'
+import {
+    getItemPathSegment,
+    handleKeyDown,
+    normalizeExpandedItems,
+} from './utils'
 import { TooltipV2 } from '../TooltipV2/TooltipV2'
 import { TooltipV2Side } from '../TooltipV2/tooltipV2.types'
 import { TruncatedTextWithTooltipV2 } from '../common/TruncatedTextWithTooltipV2'
@@ -67,6 +71,7 @@ const StyledElement = styled(Block)<{
     border-radius: ${({ $tokens }) =>
         $tokens.section.itemList.item.borderRadius};
     transition: ${({ $tokens }) => $tokens.section.itemList.item.transition};
+    text-align: left;
     user-select: none;
     cursor: pointer;
     overflow: hidden;
@@ -282,11 +287,101 @@ export const ActiveItemProvider: React.FC<ActiveItemProviderProps> = ({
     )
 }
 
+type ExpandedItemsContextValue = {
+    isItemExpanded: (itemPath: string) => boolean
+    setItemExpanded: (item: NavbarItem, itemPath: string, next: boolean) => void
+}
+
+const ExpandedItemsContext = createContext<ExpandedItemsContextValue | null>(
+    null
+)
+
+const useExpandedItemsContext = () => {
+    const context = useContext(ExpandedItemsContext)
+    if (!context) {
+        throw new Error(
+            'useExpandedItemsContext must be used within ExpandedItemsProvider'
+        )
+    }
+    return context
+}
+
+type ExpandedItemsProviderProps = {
+    children: React.ReactNode
+    /**
+     * Controlled mode: parent owns the expanded item paths.
+     * If provided, internal state is ignored.
+     */
+    expandedItems?: DirectoryExpandedItems
+    defaultExpandedItems?: DirectoryExpandedItems
+    onExpandedItemsChange?: (items: string[]) => void
+    onItemExpand?: (item: NavbarItem, itemPath: string) => void | Promise<void>
+}
+
+export const ExpandedItemsProvider: React.FC<ExpandedItemsProviderProps> = ({
+    children,
+    expandedItems,
+    defaultExpandedItems,
+    onExpandedItemsChange,
+    onItemExpand,
+}) => {
+    const isControlled = expandedItems !== undefined
+    const [internalExpandedItems, setInternalExpandedItems] = useState<
+        Set<string>
+    >(() => normalizeExpandedItems(defaultExpandedItems))
+    const currentExpandedItems = useMemo(
+        () =>
+            isControlled
+                ? normalizeExpandedItems(expandedItems)
+                : internalExpandedItems,
+        [expandedItems, internalExpandedItems, isControlled]
+    )
+
+    const setItemExpanded = useCallback(
+        (item: NavbarItem, itemPath: string, next: boolean) => {
+            const nextExpandedItems = new Set(currentExpandedItems)
+            if (next) {
+                nextExpandedItems.add(itemPath)
+                void onItemExpand?.(item, itemPath)
+            } else {
+                nextExpandedItems.delete(itemPath)
+            }
+
+            if (!isControlled) {
+                setInternalExpandedItems(nextExpandedItems)
+            }
+            onExpandedItemsChange?.(Array.from(nextExpandedItems))
+        },
+        [
+            currentExpandedItems,
+            isControlled,
+            onExpandedItemsChange,
+            onItemExpand,
+        ]
+    )
+
+    const isItemExpanded = useCallback(
+        (itemPath: string) => currentExpandedItems.has(itemPath),
+        [currentExpandedItems]
+    )
+
+    const contextValue = useMemo<ExpandedItemsContextValue>(
+        () => ({ isItemExpanded, setItemExpanded }),
+        [isItemExpanded, setItemExpanded]
+    )
+
+    return (
+        <ExpandedItemsContext.Provider value={contextValue}>
+            {children}
+        </ExpandedItemsContext.Provider>
+    )
+}
+
 const NavItem = ({
     item,
     index,
     onNavigate,
-    itemPath = item.label,
+    itemPath = getItemPathSegment(item),
     iconOnlyMode = false,
     showHierarchyLines = false,
     hierarchyLineBorderRadius = 0,
@@ -294,7 +389,10 @@ const NavItem = ({
     isNested = false,
 }: NavItemProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
-    const [isExpanded, setIsExpanded] = React.useState(false)
+    const { isItemExpanded, setItemExpanded } = useExpandedItemsContext()
+    const isExpanded = isItemExpanded(itemPath)
+    const setIsExpanded = (value: boolean) =>
+        setItemExpanded(item, itemPath, value)
     const { activeItem, setActiveItem } = useActiveItemContext()
     const hasChildren = item.items && item.items.length > 0
     const isActive =
@@ -330,6 +428,7 @@ const NavItem = ({
     const activateItem = () => {
         if (hasChildren && !iconOnlyMode) {
             setIsExpanded(!isExpanded)
+            item.onClick?.()
         } else {
             setActiveItem(itemPath)
             item.onClick?.()
@@ -544,7 +643,7 @@ const NavItem = ({
                                     key={childIdx}
                                     item={childItem}
                                     index={childIdx}
-                                    itemPath={`${itemPath}/${childItem.label}`}
+                                    itemPath={`${itemPath}/${getItemPathSegment(childItem)}`}
                                     iconOnlyMode={iconOnlyMode}
                                     showHierarchyLines={showHierarchyLines}
                                     hierarchyLineBorderRadius={

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -597,7 +597,7 @@ const NavItem = ({
                 hasChildren && !iconOnlyMode ? isExpanded : undefined
             }
             data-element="sidebar-sub-section"
-            data-id={item.label}
+            data-id={item.id ?? item.label}
             data-status={isActive ? 'selected' : 'not selected'}
         >
             {renderContent()}

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -397,11 +397,14 @@ const NavItem = ({
     const { activeItem, setActiveItem } = useActiveItemContext()
     const hasChildren = item.items && item.items.length > 0
     const isSelectable = enableParentSelection || !hasChildren
+    // bare-label matching is a backward-compat fallback for id-less items
+    // only, so a label-valued activeItem can't co-select id'd duplicates
     const isActive =
         item.isSelected !== undefined
             ? item.isSelected && isSelectable
             : isSelectable &&
-              (activeItem === itemPath || activeItem === item.label)
+              (activeItem === itemPath ||
+                  (!item.id && activeItem === item.label))
 
     const itemRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null)
     const nestedListRef = useRef<HTMLUListElement>(null)
@@ -602,7 +605,7 @@ const NavItem = ({
                 hasChildren && !iconOnlyMode ? isExpanded : undefined
             }
             data-element="sidebar-sub-section"
-            data-id={item.id ?? item.label}
+            data-id={getItemPathSegment(item)}
             data-status={isActive ? 'selected' : 'not selected'}
         >
             {renderContent()}

--- a/packages/blend/lib/components/Directory/Section.tsx
+++ b/packages/blend/lib/components/Directory/Section.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { DirectoryTokenType } from './directory.tokens'
 import { useSectionScroll } from '../../hooks/useSectionScroll'
+import { getItemPathSegment } from './utils'
 
 type SectionStateContextValue = {
     sectionStates: Map<number, boolean>
@@ -259,7 +260,7 @@ const Section = ({
                             key={itemIdx}
                             item={item}
                             index={itemIdx}
-                            itemPath={item.label}
+                            itemPath={getItemPathSegment(item)}
                             iconOnlyMode={iconOnlyMode}
                             showHierarchyLines={showHierarchyLines}
                             hierarchyLineBorderRadius={

--- a/packages/blend/lib/components/Directory/Section.tsx
+++ b/packages/blend/lib/components/Directory/Section.tsx
@@ -58,6 +58,7 @@ const Section = ({
     iconOnlyMode = false,
     showHierarchyLines = false,
     hierarchyLineBorderRadius = 0,
+    enableParentSelection = false,
 }: SectionProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
     const sectionStateContext = useSectionState()
@@ -269,6 +270,7 @@ const Section = ({
                             isLast={
                                 itemIdx === (section.items?.length || 0) - 1
                             }
+                            enableParentSelection={enableParentSelection}
                             onNavigate={handleItemNavigation}
                         />
                     ))}

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -10,10 +10,12 @@ import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { addPxToValue } from '../../global-utils/GlobalUtils'
 import { DirectoryTokenType } from './directory.tokens'
 import {
+    DEFAULT_END_REACHED_THRESHOLD,
     flattenDirectoryData,
     handleKeyDown,
     normalizeExpandedItems,
     normalizeDirectoryData,
+    useDirectoryEndReached,
 } from './utils'
 import type { DirectoryFlatRow, DirectoryProps, NavbarItem } from './types'
 
@@ -143,6 +145,7 @@ const ItemButton = styled(Block)<{
         addPxToValue($tokens.section.itemList.item.fontSize)};
     font-weight: ${({ $tokens }) => $tokens.section.itemList.item.fontWeight};
     overflow: hidden;
+    text-align: left;
     text-decoration: none;
     transition: ${({ $tokens }) => $tokens.section.itemList.item.transition};
 
@@ -242,6 +245,8 @@ const VirtualizedDirectory = ({
     defaultExpandedItems,
     onExpandedItemsChange,
     onItemExpand,
+    onEndReached,
+    endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
     virtualization,
 }: DirectoryProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
@@ -311,6 +316,13 @@ const VirtualizedDirectory = ({
             width: 0,
             height: viewportHeight,
         },
+    })
+    useDirectoryEndReached({
+        scrollRef,
+        externalRef: virtualization?.viewportRef,
+        onEndReached,
+        threshold: endReachedThreshold,
+        contentKey: rows.length,
     })
     const virtualRows = virtualizer.getVirtualItems()
     const fallbackRows =
@@ -468,6 +480,7 @@ const VirtualizedDirectory = ({
         const activateItem = () => {
             if (hasChildren) {
                 setExpanded(row.item, row.itemPath, !isExpanded)
+                row.item.onClick?.()
             } else {
                 setActiveItem(row.itemPath)
                 row.item.onClick?.()

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -12,6 +12,7 @@ import { DirectoryTokenType } from './directory.tokens'
 import {
     DEFAULT_END_REACHED_THRESHOLD,
     flattenDirectoryData,
+    getItemPathSegment,
     handleKeyDown,
     normalizeExpandedItems,
     normalizeDirectoryData,
@@ -459,11 +460,14 @@ const VirtualizedDirectory = ({
         const hasChildren = !!row.item.items?.length
         const isExpanded = currentExpandedItems.has(row.itemPath)
         const isSelectable = enableParentSelection || !hasChildren
+        // bare-label matching is a backward-compat fallback for id-less items
+        // only, so a label-valued activeItem can't co-select id'd duplicates
         const isActive =
             row.item.isSelected !== undefined
                 ? row.item.isSelected && isSelectable
                 : isSelectable &&
-                  (activeItem === row.itemPath || activeItem === row.item.label)
+                  (activeItem === row.itemPath ||
+                      (!row.item.id && activeItem === row.item.label))
 
         const Element = row.item.href ? 'a' : 'button'
         const elementProps = row.item.href
@@ -534,7 +538,7 @@ const VirtualizedDirectory = ({
                     aria-expanded={hasChildren ? isExpanded : undefined}
                     aria-label={row.item.label}
                     data-element="sidebar-sub-section"
-                    data-id={row.item.id ?? row.item.label}
+                    data-id={getItemPathSegment(row.item)}
                     data-status={isActive ? 'selected' : 'not selected'}
                     data-directory-row-index={rowIndex}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -529,7 +529,7 @@ const VirtualizedDirectory = ({
                     aria-expanded={hasChildren ? isExpanded : undefined}
                     aria-label={row.item.label}
                     data-element="sidebar-sub-section"
-                    data-id={row.item.label}
+                    data-id={row.item.id ?? row.item.label}
                     data-status={isActive ? 'selected' : 'not selected'}
                     data-directory-row-index={rowIndex}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -76,7 +76,7 @@ const ConnectorVerticalLine = styled.span<{
     top: 0;
     height: ${({ $tokens, $isCurrent, $isLast }) =>
         $isCurrent && $isLast
-            ? `calc(${$tokens.section.itemList.nested.connector.elbowTop} + ${$tokens.section.itemList.nested.connector.elbowHeight})`
+            ? $tokens.section.itemList.nested.connector.elbowTop
             : '100%'};
     border-left: ${({ $tokens }) =>
         `${$tokens.section.itemList.nested.border.width} solid ${$tokens.section.itemList.nested.border.color}`};

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -247,6 +247,7 @@ const VirtualizedDirectory = ({
     onItemExpand,
     onEndReached,
     endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
+    enableParentSelection = false,
     virtualization,
 }: DirectoryProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
@@ -457,10 +458,11 @@ const VirtualizedDirectory = ({
     ) => {
         const hasChildren = !!row.item.items?.length
         const isExpanded = currentExpandedItems.has(row.itemPath)
+        const isSelectable = enableParentSelection || !hasChildren
         const isActive =
             row.item.isSelected !== undefined
-                ? row.item.isSelected && !hasChildren
-                : !hasChildren &&
+                ? row.item.isSelected && isSelectable
+                : isSelectable &&
                   (activeItem === row.itemPath || activeItem === row.item.label)
 
         const Element = row.item.href ? 'a' : 'button'
@@ -480,6 +482,9 @@ const VirtualizedDirectory = ({
         const activateItem = () => {
             if (hasChildren) {
                 setExpanded(row.item, row.itemPath, !isExpanded)
+                if (enableParentSelection) {
+                    setActiveItem(row.itemPath)
+                }
                 row.item.onClick?.()
             } else {
                 setActiveItem(row.itemPath)

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -36,6 +36,13 @@ export type DirectoryProps = {
      * @default 200
      */
     endReachedThreshold?: number
+    /**
+     * When true, clicking a parent row selects it (updates activeItem) in
+     * addition to toggling expansion, and parent rows can render as
+     * selected. When false, only leaf rows can be selected.
+     * @default false
+     */
+    enableParentSelection?: boolean
     enableVirtualization?: boolean
     virtualization?: DirectoryVirtualizationConfig
 }
@@ -80,6 +87,7 @@ export type SectionProps = {
     iconOnlyMode?: boolean
     showHierarchyLines?: boolean
     hierarchyLineBorderRadius?: CSSObject['borderRadius']
+    enableParentSelection?: boolean
 }
 
 export type NavItemProps = {
@@ -92,6 +100,7 @@ export type NavItemProps = {
     hierarchyLineBorderRadius?: CSSObject['borderRadius']
     isLast?: boolean
     isNested?: boolean
+    enableParentSelection?: boolean
 }
 
 export type DirectoryFlatRow =

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -25,6 +25,17 @@ export type DirectoryProps = {
     defaultExpandedItems?: DirectoryExpandedItems
     onExpandedItemsChange?: (items: string[]) => void
     onItemExpand?: (item: NavbarItem, itemPath: string) => void | Promise<void>
+    /**
+     * Called when the viewport is scrolled within endReachedThreshold pixels
+     * of the bottom (and re-checked when the content grows), for paged /
+     * infinite loading.
+     */
+    onEndReached?: () => void | Promise<void>
+    /**
+     * Distance in pixels from the bottom at which onEndReached fires.
+     * @default 200
+     */
+    endReachedThreshold?: number
     enableVirtualization?: boolean
     virtualization?: DirectoryVirtualizationConfig
 }
@@ -38,6 +49,12 @@ export type DirectoryData = {
 
 export type NavbarItem = {
     label: string
+    /**
+     * Stable identifier used as this item's path segment (itemPath, expansion
+     * state, virtualizer keys). Falls back to label when omitted — provide it
+     * when sibling labels can collide.
+     */
+    id?: string
     items?: NavbarItem[]
     leftSlot?: ReactNode
     rightSlot?: ReactNode

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -4,6 +4,11 @@ import type { CSSObject } from 'styled-components'
 export type DirectoryExpandedItems = Set<string> | string[]
 
 export type DirectoryVirtualizationConfig = {
+    /**
+     * External scroll container. Must be mounted (ref.current set) by the
+     * time Directory mounts — onEndReached binds its scroll listener once
+     * and does not retry when the element appears later.
+     */
     viewportRef?: RefObject<HTMLElement | null>
     rowHeight?: number
     sectionHeight?: number

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -59,7 +59,10 @@ export type NavbarItem = {
     /**
      * Stable identifier used as this item's path segment (itemPath, expansion
      * state, virtualizer keys). Falls back to label when omitted — provide it
-     * when sibling labels can collide.
+     * when sibling labels can collide. Must be non-empty and must not contain
+     * "/" (the path separator). Note: active-state matching also accepts the
+     * raw label as a fallback, so a label-valued activeItem can match rows
+     * regardless of their id.
      */
     id?: string
     items?: NavbarItem[]

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -58,11 +58,11 @@ export type NavbarItem = {
     label: string
     /**
      * Stable identifier used as this item's path segment (itemPath, expansion
-     * state, virtualizer keys). Falls back to label when omitted — provide it
-     * when sibling labels can collide. Must be non-empty and must not contain
-     * "/" (the path separator). Note: active-state matching also accepts the
-     * raw label as a fallback, so a label-valued activeItem can match rows
-     * regardless of their id.
+     * state, virtualizer keys, data-id). Falls back to label when omitted or
+     * empty — provide it when sibling labels can collide. Must not contain
+     * "/" (the path separator). Items without an id also match a bare-label
+     * activeItem for backward compatibility; items with an id match only
+     * their id-based path.
      */
     id?: string
     items?: NavbarItem[]

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -1,9 +1,61 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
 import type {
     DirectoryData,
     DirectoryExpandedItems,
     DirectoryFlatRow,
     NavbarItem,
 } from './types'
+
+export const DEFAULT_END_REACHED_THRESHOLD = 200
+
+export const useDirectoryEndReached = ({
+    scrollRef,
+    externalRef,
+    onEndReached,
+    threshold,
+    contentKey,
+}: {
+    scrollRef: RefObject<HTMLElement | null>
+    externalRef?: RefObject<HTMLElement | null>
+    onEndReached?: () => void | Promise<void>
+    threshold: number
+    contentKey: unknown
+}) => {
+    // Latest-ref so an inline callback prop doesn't rebind (and re-arm) the
+    // effect on every render.
+    const onEndReachedRef = useRef(onEndReached)
+    useEffect(() => {
+        onEndReachedRef.current = onEndReached
+    })
+    const hasOnEndReached = !!onEndReached
+
+    useEffect(() => {
+        if (!hasOnEndReached) return
+        const element = externalRef?.current ?? scrollRef.current
+        if (!element) return
+
+        // Re-armed when the effect rebinds so content growth (contentKey) can
+        // trigger another fire while still within the threshold.
+        let armed = true
+        const check = () => {
+            const remaining =
+                element.scrollHeight - element.scrollTop - element.clientHeight
+            if (remaining <= threshold) {
+                if (armed) {
+                    armed = false
+                    void onEndReachedRef.current?.()
+                }
+            } else {
+                armed = true
+            }
+        }
+
+        check()
+        element.addEventListener('scroll', check, { passive: true })
+        return () => element.removeEventListener('scroll', check)
+    }, [hasOnEndReached, threshold, contentKey, externalRef, scrollRef])
+}
 
 export const normalizeDirectoryData = (
     directoryData: DirectoryData[] | null
@@ -14,8 +66,13 @@ export const normalizeExpandedItems = (
 ): Set<string> =>
     expandedItems ? new Set(Array.from(expandedItems)) : new Set<string>()
 
-const getItemPath = (parentPath: string, item: NavbarItem): string =>
-    parentPath ? `${parentPath}/${item.label}` : item.label
+export const getItemPathSegment = (item: NavbarItem): string =>
+    item.id ?? item.label
+
+const getItemPath = (parentPath: string, item: NavbarItem): string => {
+    const segment = getItemPathSegment(item)
+    return parentPath ? `${parentPath}/${segment}` : segment
+}
 
 const flattenDirectoryItems = (
     items: NavbarItem[],

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -66,8 +66,10 @@ export const normalizeExpandedItems = (
 ): Set<string> =>
     expandedItems ? new Set(Array.from(expandedItems)) : new Set<string>()
 
+// || (not ??) so an empty-string id falls back to the label instead of
+// silently producing colliding empty path segments
 export const getItemPathSegment = (item: NavbarItem): string =>
-    item.id ?? item.label
+    item.id || item.label
 
 const getItemPath = (parentPath: string, item: NavbarItem): string => {
     const segment = getItemPathSegment(item)

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -71,6 +71,18 @@ export const normalizeExpandedItems = (
 export const getItemPathSegment = (item: NavbarItem): string =>
     item.id || item.label
 
+const countItems = (items: NavbarItem[] | undefined): number =>
+    (items ?? []).reduce((total, item) => total + 1 + countItems(item.items), 0)
+
+// Stable end-reached contentKey: reference identity of directoryData is
+// useless here (inline arrays / null re-normalize to fresh references every
+// render), so key on the total item count like the virtualized rows.length.
+export const countDirectoryItems = (directoryData: DirectoryData[]): number =>
+    directoryData.reduce(
+        (total, section) => total + countItems(section.items),
+        0
+    )
+
 const getItemPath = (parentPath: string, item: NavbarItem): string => {
     const segment = getItemPathSegment(item)
     return parentPath ? `${parentPath}/${segment}` : segment


### PR DESCRIPTION
## Summary

Fixes four Directory component issues — #1612, #1613, #1614, #1615 — plus follow-up improvements found while verifying them. Supersedes #1616 (its test and data-id change are ported here).

### #1612 — last child's connector not rounded (virtualized)

With `showHierarchyLines` + `hierarchyLineBorderRadius`, the virtualized renderer painted the last child's vertical rail down to the elbow's bottom edge (`elbowTop + elbowHeight`), overdrawing the elbow's rounded corner so the connector looked square. The rail now stops at `elbowTop`, where the elbow's own `border-left` takes over — matching the non-virtualized `NavItem` geometry (`bottom: calc(100% - elbowTop)`).

Verified by measuring computed styles in the site demo: rail height went from 15px (overlapping the full 10px curve region) to 5px, and every last child now terminates in a rounded elbow identical to the plain renderer.

### #1613 — labels center-aligned in host apps

Rows render as `<button>` and never set `text-align`, so the UA's `button { text-align: center }` leaked into the label wrapper in host apps without a button reset. Added `text-align: left` to the row styled-components in both renderers.

### #1614 — label-path identity breaks with duplicate sibling labels

Added optional `NavbarItem.id`, used as the item's path segment (`parentPath/id`) with fallback to `label` for full backward compatibility. Applied consistently in `flattenDirectoryData`, `NavItem`, and `Section`, so duplicate sibling labels no longer share expansion state or produce duplicate virtualizer keys. `data-id` also prefers `id` in both renderers. Verified: three siblings labeled "sanavi S" with distinct ids expand independently in both renderers.

### #1615 — lazy-loading API gaps

- **Controlled expansion now works without virtualization**: the non-virtualized Directory honors `expandedItems` / `defaultExpandedItems` / `onExpandedItemsChange` / `onItemExpand` via a new `ExpandedItemsProvider` that mirrors the virtualized renderer's semantics (previously the props were silently ignored on that path).
- **`onEndReached?: () => void | Promise<void>`** + **`endReachedThreshold`** (default 200px) added on the scroll viewport of both renderers (including `virtualization.viewportRef`). It re-arms when content grows, so paged loading keeps filling; the callback is held in a ref so inline props can't rebind the listener and refire in a loop.
- **Parent rows now fire `item.onClick`** on expand/collapse toggle in both renderers (previously only leaf rows fired it).

## Additional changes

- **`enableParentSelection?: boolean`** (default `false`) — the second half of #1615's third ask ("parents can never render as selected"). When enabled, clicking a parent row selects it (updates `activeItem`) in addition to toggling expansion, so the highlight always follows the last-clicked row — including when collapsing a subtree whose leaf was selected. Default off preserves existing leaf-only selection for current consumers (Sidebar etc.).
- **`onActiveItemChange` consistency**: the non-virtualized path's `ActiveItemProvider` only fired the callback in controlled mode, while the virtualized renderer fires it in both modes. Aligned the plain path to fire in uncontrolled mode too.
- **Site demo** (`apps/site` Directory page):
  - New "Lazy loading (onEndReached)" section: scrollable list that logs each fire (panel + console), simulates a 600ms fetch, and appends 25 rows per page up to 150.
  - The controlled "Multiple parent hierarchy" panel no longer pre-seeds `activeItem` with Orbit Pharma's path (a row looked spuriously selected on first expansion) and now opts into `enableParentSelection`.

## Behavior changes (changelog-worthy)

Intentional, observable changes existing consumers should know about:

1. **Parent rows fire `item.onClick` on every expand/collapse toggle** (both renderers), regardless of `enableParentSelection`. Previously a parent's `onClick` never fired — this is #1615's explicit ask. Consumers who attached navigation handlers to parent items will now receive calls on both expand and collapse.
2. **`onActiveItemChange` fires in uncontrolled mode** in the non-virtualized renderer (previously controlled-mode only), matching the virtualized renderer.
3. **Expansion state survives subtree unmount/remount** in the non-virtualized renderer: expansion is now provider-owned (path-keyed) instead of per-item local state, so collapsing and re-expanding a parent restores its children's expansion — matching the virtualized renderer.
4. **Bare-label `activeItem` matching is scoped to id-less items**: rows carrying an `id` match only their id-based path, so a label-valued `activeItem` can no longer co-select duplicates that have distinct ids. Items without ids behave exactly as before.

## Tests

`packages/blend/__tests__/components/Directory/Directory.test.tsx` — 12 passing (4 existing + 8 new):

- duplicate sibling labels with distinct ids expand independently (ported from #1616)
- id-based paths in the non-virtualized renderer too (`onExpandedItemsChange`/`onActiveItemChange` payloads)
- bare-label `activeItem` does not co-select id'd duplicates; id-less items keep label matching
- `onEndReached` does not refire across re-renders with fresh data references; refires on real content growth
- controlled expansion props honored without virtualization
- parent rows fire `onClick` when toggling expansion
- `enableParentSelection` selects parents on click and moves selection on collapse
- parents stay unselectable by default

## Test plan

- `tsc --noEmit` passes; prettier pre-commit clean.
- Manually verified each fix in the `apps/site` Directory demo (plain + virtualized side by side): connector geometry measured before/after, computed `text-align`, independent duplicate expansion, controlled expansion on the plain path, single `onEndReached` fire per bottom-reach with re-arm on scroll-away and paging demo, parent `onClick` firing alongside expansion, and the full parent-selection click flow (select parent → child → leaf → re-click leaf → collapse moves selection to parent).

Fixes #1612, fixes #1613, fixes #1614, fixes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
