### PR TITLE
feat: add DataTable empty and error states

### DIFF
--- a/apps/ascent/app/docs/content/components/data-table.mdx
+++ b/apps/ascent/app/docs/content/components/data-table.mdx
@@ -795,6 +795,68 @@ function CompactTable() {
         ],
         [
             {
+                content: 'error',
+                hintText:
+                    'When true, replaces table rows with an error state while preserving the table header, toolbar, filters, and footer. Loading takes precedence when isLoading is also true. Defaults to false.',
+            },
+            {
+                content: 'boolean',
+                hintText:
+                    'true shows the error state, false shows normal content',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'renderErrorState',
+                hintText:
+                    'Optional renderer for custom error content in the table body area. Receives onRetry when one is provided.',
+            },
+            {
+                content: '(retry?: () => void) => ReactNode',
+                hintText: 'Function that returns custom error-state content',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'onRetry',
+                hintText:
+                    'Optional callback passed to renderErrorState and wired to the Retry button in the default error state.',
+            },
+            {
+                content: '() => void',
+                hintText:
+                    'Function called when the user retries the failed load',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'showEmptyState',
+                hintText:
+                    'When true, displays the default empty state when data has no rows and loading is complete. Defaults to false to preserve the legacy empty-body presentation.',
+            },
+            {
+                content: 'boolean',
+                hintText: 'true enables the default empty state',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'renderEmptyState',
+                hintText:
+                    'Optional renderer for custom empty content in the table body area. A custom renderer is used whenever data is empty and loading is complete, independently of showEmptyState.',
+            },
+            {
+                content: '() => ReactNode',
+                hintText: 'Function that returns custom empty-state content',
+            },
+            { content: '' },
+        ],
+        [
+            {
                 content: 'showSkeleton',
                 hintText:
                     'When true, displays skeleton loading placeholders in all table cells (including checkboxes and expansion buttons). Provides granular control over skeleton display separate from isLoading. Can be overridden at the column level via column.showSkeleton or at the row level via isRowLoading. Defaults to false.',

--- a/apps/storybook/stories/components/DataTable/v1/DataTable.stories.tsx
+++ b/apps/storybook/stories/components/DataTable/v1/DataTable.stories.tsx
@@ -84,7 +84,7 @@ const columns: ColumnDefinition<User>[] = [
 - Column management (show/hide columns)
 - Bulk actions support
 - Custom cell rendering
-- Loading states and empty states
+- Loading, empty, and error states
 - Multiple column types (Text, Number, Date, Avatar, Tag, Select, etc.)
 
 ## Accessibility
@@ -384,6 +384,50 @@ const columns: ColumnDefinition<User>[] = [
             table: {
                 type: { summary: 'boolean' },
                 defaultValue: { summary: 'false' },
+                category: 'UI State',
+            },
+        },
+        error: {
+            control: { type: 'boolean' },
+            description: 'Show an error state instead of table rows',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'UI State',
+            },
+        },
+        renderErrorState: {
+            control: false,
+            description: 'Custom renderer for the table error state',
+            table: {
+                type: {
+                    summary: '(retry?: () => void) => React.ReactNode',
+                },
+                category: 'UI State',
+            },
+        },
+        onRetry: {
+            action: 'retry',
+            description: 'Callback invoked by the default error Retry button',
+            table: {
+                type: { summary: '() => void' },
+                category: 'UI State',
+            },
+        },
+        showEmptyState: {
+            control: { type: 'boolean' },
+            description: 'Show the default empty state when there are no rows',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'UI State',
+            },
+        },
+        renderEmptyState: {
+            control: false,
+            description: 'Custom renderer used when there are no rows',
+            table: {
+                type: { summary: '() => React.ReactNode' },
                 category: 'UI State',
             },
         },
@@ -1123,11 +1167,64 @@ export const EmptyState: Story = {
         description: 'No users found',
         enableSearch: true,
         searchPlaceholder: 'Search users...',
+        showEmptyState: true,
     },
     parameters: {
         docs: {
             description: {
                 story: 'DataTable with no data showing empty state.',
+            },
+        },
+    },
+}
+
+export const CustomEmptyState: Story = {
+    args: {
+        data: [],
+        columns: userColumns as any[],
+        idField: 'id',
+        title: 'User Management',
+        enableSearch: true,
+        renderEmptyState: () => (
+            <div style={{ textAlign: 'center' }}>
+                <strong>No users match your filters</strong>
+                <p style={{ margin: '8px 0 0' }}>
+                    Try changing or clearing your search criteria.
+                </p>
+            </div>
+        ),
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'DataTable with custom content rendered in the empty body area.',
+            },
+        },
+    },
+}
+
+const ErrorStateDataTable: React.FC = () => {
+    const [hasError, setHasError] = useState(true)
+
+    return (
+        <DataTable
+            data={hasError ? [] : (sampleUsers.slice(0, 5) as any[])}
+            columns={userColumns as any[]}
+            idField="id"
+            title="User Management"
+            enableSearch
+            error={hasError}
+            onRetry={() => setHasError(false)}
+        />
+    )
+}
+
+export const ErrorState: Story = {
+    render: () => <ErrorStateDataTable />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'DataTable with the default error state and a working Retry action.',
             },
         },
     },

--- a/packages/blend/__tests__/components/DataTable/DataTable.states.test.tsx
+++ b/packages/blend/__tests__/components/DataTable/DataTable.states.test.tsx
@@ -1,0 +1,285 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '../../test-utils'
+import DataTable from '../../../lib/components/DataTable/DataTable'
+import {
+    ColumnDefinition,
+    ColumnType,
+} from '../../../lib/components/DataTable/types'
+import { getDataTableBodyState } from '../../../lib/components/DataTable/utils'
+
+type Row = { id: number; name: string }
+
+const columns: ColumnDefinition<Row>[] = [
+    {
+        field: 'name',
+        header: 'Name',
+        type: ColumnType.TEXT,
+        isSortable: false,
+    },
+]
+
+const rows: Row[] = [{ id: 1, name: 'Ada' }]
+
+const stateProps = {
+    columns,
+    idField: 'id' as const,
+    showFooter: false,
+    showEmptyState: true,
+    renderEmptyState: () => <div>Custom empty state</div>,
+    renderErrorState: () => <div>Custom error state</div>,
+}
+
+describe('getDataTableBodyState', () => {
+    it.each([
+        {
+            isLoading: true,
+            error: true,
+            hasRows: false,
+            expected: 'loading',
+        },
+        {
+            isLoading: true,
+            error: true,
+            hasRows: true,
+            expected: 'rows',
+        },
+        {
+            isLoading: false,
+            error: true,
+            hasRows: false,
+            expected: 'error',
+        },
+        {
+            isLoading: false,
+            error: false,
+            hasRows: false,
+            expected: 'empty',
+        },
+        {
+            isLoading: false,
+            error: false,
+            hasRows: true,
+            expected: 'rows',
+        },
+    ] as const)(
+        'returns $expected for loading=$isLoading, error=$error, rows=$hasRows',
+        ({ expected, ...state }) => {
+            expect(getDataTableBodyState(state)).toBe(expected)
+        }
+    )
+})
+
+describe('DataTable body states', () => {
+    it('applies loading > error > empty > rows precedence', () => {
+        const { rerender } = render(
+            <DataTable {...stateProps} data={[]} isLoading error />
+        )
+
+        expect(screen.getByText('Loading data...')).toBeInTheDocument()
+        expect(screen.queryByText('Custom error state')).not.toBeInTheDocument()
+        expect(screen.queryByText('Custom empty state')).not.toBeInTheDocument()
+
+        rerender(<DataTable {...stateProps} data={rows} isLoading error />)
+
+        expect(screen.getByText('Loading table data')).toBeInTheDocument()
+        expect(screen.queryByText('Custom error state')).not.toBeInTheDocument()
+        expect(screen.queryByText('Custom empty state')).not.toBeInTheDocument()
+        expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+
+        rerender(<DataTable {...stateProps} data={[]} error />)
+
+        expect(screen.getByText('Custom error state')).toBeInTheDocument()
+        expect(screen.queryByText('Custom empty state')).not.toBeInTheDocument()
+
+        rerender(<DataTable {...stateProps} data={rows} error />)
+
+        expect(screen.getByText('Custom error state')).toBeInTheDocument()
+        expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+
+        rerender(<DataTable {...stateProps} data={[]} />)
+
+        expect(screen.getByText('Custom empty state')).toBeInTheDocument()
+
+        rerender(<DataTable {...stateProps} data={rows} />)
+
+        expect(screen.getByText('Ada')).toBeInTheDocument()
+        expect(screen.queryByText('Custom empty state')).not.toBeInTheDocument()
+        expect(screen.queryByText('Custom error state')).not.toBeInTheDocument()
+    })
+
+    it('preserves the legacy empty body unless the new state is enabled', () => {
+        const { container } = render(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                showFooter={false}
+            />
+        )
+
+        expect(
+            container.querySelector('[data-table-body-state="empty"]')
+        ).toHaveTextContent('No data available')
+        expect(screen.queryByText('No data')).not.toBeInTheDocument()
+    })
+
+    it('renders the default empty state at tableBodyHeight', () => {
+        const { container } = render(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                showEmptyState
+                showFooter={false}
+                tableBodyHeight={240}
+            />
+        )
+
+        expect(screen.getByText('No data')).toBeInTheDocument()
+        expect(
+            container.querySelector('[data-table-body-state="empty"]')
+        ).toHaveStyle({ height: '240px', minHeight: '240px' })
+        expect(
+            screen.getByRole('columnheader', { name: 'Name' })
+        ).toBeInTheDocument()
+    })
+
+    it('keeps the header and footer around an error state', () => {
+        const { container } = render(
+            <DataTable
+                data={rows}
+                columns={columns}
+                idField="id"
+                error
+                tableBodyHeight={240}
+                pagination={{ currentPage: 1, pageSize: 10, totalRows: 1 }}
+            />
+        )
+
+        expect(
+            screen.getByRole('columnheader', { name: 'Name' })
+        ).toBeInTheDocument()
+        expect(
+            container.querySelector('[data-table-body-state="error"]')
+        ).toHaveStyle({ height: '240px', minHeight: '240px' })
+        expect(
+            screen.getByRole('button', { name: 'Previous page' })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('button', { name: 'Next page' })
+        ).toBeInTheDocument()
+    })
+
+    it('hides row-scoped controls while stale rows are replaced by an error', async () => {
+        const { user, rerender } = render(
+            <DataTable
+                data={rows}
+                columns={columns}
+                idField="id"
+                enableRowSelection
+                showFooter={false}
+            />
+        )
+
+        await user.click(screen.getAllByRole('checkbox')[1])
+        expect(
+            await screen.findByRole('region', { name: '1 row selected' })
+        ).toBeInTheDocument()
+
+        rerender(
+            <DataTable
+                data={rows}
+                columns={columns}
+                idField="id"
+                enableRowSelection
+                error
+                showFooter={false}
+            />
+        )
+
+        expect(screen.getByText('Unable to load data')).toBeInTheDocument()
+        expect(
+            screen.queryByRole('columnheader', { name: 'Select all rows' })
+        ).not.toBeInTheDocument()
+        expect(
+            screen.queryByRole('region', { name: '1 row selected' })
+        ).not.toBeInTheDocument()
+    })
+
+    it('passes onRetry to custom errors and wires the default Retry button', async () => {
+        const retry = vi.fn()
+        const customError = vi.fn((retryCallback?: () => void) => (
+            <button onClick={retryCallback}>Custom retry</button>
+        ))
+        const { container, user, rerender } = render(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                error
+                onRetry={retry}
+                renderErrorState={customError}
+                showFooter={false}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: 'Custom retry' }))
+        expect(customError).toHaveBeenCalledWith(retry)
+        expect(retry).toHaveBeenCalledTimes(1)
+
+        rerender(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                error
+                onRetry={retry}
+                showFooter={false}
+            />
+        )
+
+        await user.click(screen.getByRole('button', { name: 'Retry' }))
+        expect(retry).toHaveBeenCalledTimes(2)
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(container.querySelector('[id$="-status"]')).toHaveTextContent(
+            'Failed to load table data'
+        )
+    })
+})
+
+describe('DataTable body states Accessibility', () => {
+    it('hides decorative icons and exposes Retry by its accessible name', () => {
+        const { container, rerender } = render(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                showEmptyState
+                showFooter={false}
+            />
+        )
+
+        expect(container.querySelector('.lucide-inbox')).toHaveAttribute(
+            'aria-hidden',
+            'true'
+        )
+
+        rerender(
+            <DataTable
+                data={[]}
+                columns={columns}
+                idField="id"
+                error
+                onRetry={() => undefined}
+                showFooter={false}
+            />
+        )
+
+        expect(container.querySelector('.lucide-circle-alert')).toHaveAttribute(
+            'aria-hidden',
+            'true'
+        )
+        expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled()
+    })
+})

--- a/packages/blend/lib/components/DataTable/DataTable.tsx
+++ b/packages/blend/lib/components/DataTable/DataTable.tsx
@@ -47,6 +47,7 @@ import {
     clearAllFiltersAndSearch,
     getColumnStyles,
     haveSameFilterOptions,
+    getDataTableBodyState,
 } from './utils'
 import DataTableHeader from './DataTableHeader'
 import TableHeader from './TableHeader'
@@ -56,7 +57,7 @@ import BulkActionBar from './TableBody/BulkActionBar'
 import Block from '../Primitives/Block/Block'
 import Button from '../Button/Button'
 import { ButtonSize, ButtonType } from '../Button/types'
-import { Settings, Check, Loader2 } from 'lucide-react'
+import { Settings, Check, Loader2, Inbox, CircleAlert } from 'lucide-react'
 import Menu from '../Menu/Menu'
 import { MenuGroupType, MenuAlignment } from '../Menu/types'
 
@@ -84,6 +85,66 @@ const ScrollableContainer = styled(Block)`
     scrollbar-width: none;
 `
 
+const DefaultTableState = ({
+    state,
+    onRetry,
+}: {
+    state: 'empty' | 'error'
+    onRetry?: () => void
+}) => {
+    const isError = state === 'error'
+    const StateIcon = isError ? CircleAlert : Inbox
+
+    return (
+        <Block
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            gap={FOUNDATION_THEME.unit[12]}
+        >
+            <Block
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                style={{
+                    width: FOUNDATION_THEME.unit[40],
+                    height: FOUNDATION_THEME.unit[40],
+                    borderRadius: '50%',
+                    backgroundColor: isError
+                        ? FOUNDATION_THEME.colors.red[50]
+                        : FOUNDATION_THEME.colors.gray[100],
+                    color: isError
+                        ? FOUNDATION_THEME.colors.red[600]
+                        : FOUNDATION_THEME.colors.gray[500],
+                }}
+            >
+                <StateIcon
+                    size={FOUNDATION_THEME.unit[20]}
+                    aria-hidden="true"
+                />
+            </Block>
+            <PrimitiveText
+                style={{
+                    color: FOUNDATION_THEME.colors.gray[700],
+                    fontSize: FOUNDATION_THEME.font.size.body.md.fontSize,
+                    fontWeight: FOUNDATION_THEME.font.weight[500],
+                }}
+            >
+                {isError ? 'Unable to load data' : 'No data'}
+            </PrimitiveText>
+            {isError && onRetry && (
+                <Button
+                    buttonType={ButtonType.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    onClick={onRetry}
+                    text="Retry"
+                />
+            )}
+        </Block>
+    )
+}
+
 const DataTable = forwardRef(
     <T extends Record<string, unknown>>(
         {
@@ -106,6 +167,11 @@ const DataTable = forwardRef(
             serverSideFiltering = false,
             serverSidePagination = false,
             isLoading = false,
+            error = false,
+            renderErrorState,
+            onRetry,
+            showEmptyState = false,
+            renderEmptyState,
             enableColumnManager = true,
             enableColumnReordering = false,
             onColumnReorder,
@@ -475,15 +541,11 @@ const DataTable = forwardRef(
             ? mobileVisibleColumns
             : visibleColumns
 
-        // Calculate minimum height for empty state based on page size
-        // This ensures consistent height whether data is present or not
-        const emptyStateMinHeight = useMemo(() => {
-            if (tableBodyHeight) {
-                return '400px'
+        const stateAreaHeight = useMemo(() => {
+            if (tableBodyHeight !== undefined) {
+                return tableBodyHeight
             }
-            // Use fixed heights based on page size ranges
-            // 5 rows/page → 300px
-            // 10+ rows/page → 600px
+
             return pageSize <= 5 ? '300px' : '600px'
         }, [pageSize, tableBodyHeight])
 
@@ -666,6 +728,15 @@ const DataTable = forwardRef(
             pagination?.currentPage,
             pagination?.pageSize,
         ])
+        const isTableLoading =
+            isLoading || (serverSidePagination && internalLoading)
+        const bodyState = getDataTableBodyState({
+            isLoading: isTableLoading,
+            error,
+            hasRows: currentData.length > 0,
+        })
+        const isErrorState = bodyState === 'error'
+        const shouldRenderRows = bodyState === 'rows'
 
         // Stable row ID list for the current page. Used for selection state and
         // as a cheap signal to remount the tbody when results change (e.g. server-side search).
@@ -1592,7 +1663,7 @@ const DataTable = forwardRef(
                         overflow: 'auto',
                     }}
                 >
-                    {showBulkActionBar && (
+                    {showBulkActionBar && !isErrorState && (
                         <BulkActionBar
                             selectedCount={selectedCount}
                             onExport={exportToCSV}
@@ -1618,11 +1689,13 @@ const DataTable = forwardRef(
                             borderWidth: 0,
                         }}
                     >
-                        {isLoading
+                        {isTableLoading
                             ? 'Loading table data'
-                            : currentData.length === 0
-                              ? 'No data available'
-                              : `Showing ${currentData.length} of ${totalRows} rows`}
+                            : error
+                              ? 'Failed to load table data'
+                              : currentData.length === 0
+                                ? 'No data available'
+                                : `Showing ${currentData.length} of ${totalRows} rows`}
                     </Block>
 
                     <Block
@@ -1736,7 +1809,7 @@ const DataTable = forwardRef(
                                                 enableColumnReordering
                                             }
                                             showSkeleton={showSkeleton}
-                                            isLoading={isLoading}
+                                            isLoading={isTableLoading}
                                             onColumnReorder={(columns) => {
                                                 setVisibleColumns(
                                                     columns as ColumnDefinition<T>[]
@@ -1764,7 +1837,8 @@ const DataTable = forwardRef(
                                                 enableRowExpansion
                                             }
                                             enableRowSelection={
-                                                enableRowSelection
+                                                enableRowSelection &&
+                                                !isErrorState
                                             }
                                             rowActions={
                                                 rowActions as
@@ -1826,7 +1900,7 @@ const DataTable = forwardRef(
                                                 setMeasuredFrozenWidths
                                             }
                                         />
-                                        {currentData.length > 0 && (
+                                        {shouldRenderRows && (
                                             <TableBodyComponent
                                                 currentData={currentData}
                                                 dataVersion={tbodyDataVersion}
@@ -1993,11 +2067,7 @@ const DataTable = forwardRef(
                                                         | undefined
                                                 }
                                                 dateLabel={dateLabel}
-                                                isLoading={
-                                                    isLoading ||
-                                                    (serverSidePagination &&
-                                                        internalLoading)
-                                                }
+                                                isLoading={isTableLoading}
                                                 showSkeleton={showSkeleton}
                                                 skeletonVariant={
                                                     skeletonVariant
@@ -2073,13 +2143,18 @@ const DataTable = forwardRef(
                             </DragOverlay>
                         </DndContext>
 
-                        {currentData.length === 0 && (
+                        {bodyState !== 'rows' && (
                             <Block
                                 display="flex"
                                 alignItems="center"
                                 justifyContent="center"
+                                data-table-body-state={bodyState}
                                 style={{
-                                    minHeight: emptyStateMinHeight,
+                                    minHeight: stateAreaHeight,
+                                    height:
+                                        tableBodyHeight !== undefined
+                                            ? stateAreaHeight
+                                            : undefined,
                                     backgroundColor:
                                         FOUNDATION_THEME.colors.gray[0],
                                     color: tableToken.dataTable.table.body.cell
@@ -2087,9 +2162,10 @@ const DataTable = forwardRef(
                                     fontSize:
                                         tableToken.dataTable.table.body.cell
                                             .fontSize,
+                                    overflow: 'auto',
                                 }}
                             >
-                                {isLoading ? (
+                                {bodyState === 'loading' ? (
                                     <Block
                                         display="flex"
                                         alignItems="center"
@@ -2106,6 +2182,19 @@ const DataTable = forwardRef(
                                         />
                                         <span>Loading data...</span>
                                     </Block>
+                                ) : bodyState === 'error' ? (
+                                    renderErrorState ? (
+                                        renderErrorState(onRetry)
+                                    ) : (
+                                        <DefaultTableState
+                                            state="error"
+                                            onRetry={onRetry}
+                                        />
+                                    )
+                                ) : renderEmptyState ? (
+                                    renderEmptyState()
+                                ) : showEmptyState ? (
+                                    <DefaultTableState state="empty" />
                                 ) : (
                                     <span>No data available</span>
                                 )}
@@ -2120,7 +2209,7 @@ const DataTable = forwardRef(
                             pageSize={pageSize}
                             totalRows={totalRows}
                             visibleRows={currentData.length}
-                            isLoading={isLoading}
+                            isLoading={isTableLoading}
                             showSkeleton={showSkeleton}
                             hasData={currentData.length > 0}
                             isNarrowContainer={isNarrowContainer}

--- a/packages/blend/lib/components/DataTable/types.ts
+++ b/packages/blend/lib/components/DataTable/types.ts
@@ -476,6 +476,11 @@ export type DataTableProps<T extends Record<string, unknown>> = {
     onPageSizeChange?: (pageSize: number) => void
 
     isLoading?: boolean
+    error?: boolean
+    renderErrorState?: (retry?: () => void) => ReactNode
+    onRetry?: () => void
+    showEmptyState?: boolean
+    renderEmptyState?: () => ReactNode
     showSkeleton?: boolean
     skeletonVariant?: SkeletonVariant
     isRowLoading?: (row: T, index: number) => boolean

--- a/packages/blend/lib/components/DataTable/utils.ts
+++ b/packages/blend/lib/components/DataTable/utils.ts
@@ -20,6 +20,23 @@ import {
     DateRangeData,
 } from './columnTypes'
 
+export type DataTableBodyState = 'loading' | 'error' | 'empty' | 'rows'
+
+export const getDataTableBodyState = ({
+    isLoading,
+    error,
+    hasRows,
+}: {
+    isLoading: boolean
+    error: boolean
+    hasRows: boolean
+}): DataTableBodyState => {
+    if (isLoading && !hasRows) return 'loading'
+    if (error && !isLoading) return 'error'
+    if (!hasRows) return 'empty'
+    return 'rows'
+}
+
 /**
  * Compares filter option lists by content. Consumers commonly build `columns`
  * inline, so a new-but-equal array must not count as a change: that would sync


### PR DESCRIPTION
## Summary

- add backward-compatible DataTable empty and error body states while keeping the header, toolbar, filters, and footer mounted
- add token-styled defaults, custom renderers, retry handling, server-pagination loading integration, and stale-row control suppression
- document the new API and add default-empty, custom-empty, and retryable-error Storybook examples

## Test Coverage

Coverage gate: **PASS (90%)**. The state resolver and precedence logic are fully covered; three non-blocking component-contract gaps remain for toolbar interaction, CSS-string height, and custom-empty rendering without the flag.

```text
CODE PATHS                                                  USER FLOWS
[+] getDataTableBodyState()                                [+] State precedence
  ├── [★★★ TESTED] loading, no rows                           └── [★★★ TESTED] loading > error > empty > rows
  ├── [★★★ TESTED] loading with rows → rows
  ├── [★★★ TESTED] error                                  [+] Retry recovery
  ├── [★★★ TESTED] empty                                     ├── [★★★ TESTED] custom retry callback
  └── [★★★ TESTED] rows                                      └── [★★★ TESTED] default Retry button

[+] DataTable state integration                            [+] Chrome preservation
  ├── [★★★ TESTED] loading + empty                           ├── [★★★ TESTED] header/footer around error
  ├── [★★★ TESTED] loading + stale rows                      ├── [★★ TESTED] header around empty
  ├── [★★★ TESTED] error + empty                             └── [GAP] toolbar/search/filter interaction during states
  ├── [★★★ TESTED] error replaces stale rows
  ├── [★★★ TESTED] empty                                  [+] Stale-row safety
  └── [★★★ TESTED] rows return                               ├── [★★★ TESTED] rows hidden
                                                               ├── [★★★ TESTED] select-all hidden
[+] Empty-state rendering                                    └── [★★★ TESTED] bulk-action bar hidden
  ├── [★★ TESTED] custom renderer branch
  ├── [★★★ TESTED] token default enabled                  [+] Accessibility
  ├── [★★★ TESTED] legacy default-false fallback             ├── [★★★ TESTED] empty/error icons decorative
  └── [GAP] custom renderer with showEmptyState omitted      ├── [★★★ TESTED] Retry accessible name
                                                               └── [★★★ TESTED] single polite error status
[+] Error-state rendering
  ├── [★★ TESTED] default error without retry
  ├── [★★★ TESTED] custom error receives retry
  └── [★★★ TESTED] default error retry

[+] Body sizing
  ├── [★★★ TESTED] numeric height, empty
  ├── [★★★ TESTED] numeric height, error
  └── [GAP] string tableBodyHeight, e.g. "50vh"

COVERAGE: 27/30 paths tested (90%)  |  Helper/state logic: 11/11 (100%)
User/component flows: 16/19 (84%)   |  GAPS: 3 (all unit/component; no E2E/eval needed)
```

Test files: **174 → 175** (+1).

## Verification

- `DataTable.states.test.tsx`: 12/12 passed
- Blend TypeScript check: passed
- formatting check: passed
- circular-dependency check: passed
- production Blend build and dist validation: passed
- full suite: all 4,903 tests executed; only known/unrelated contention flakes failed, and each failing suite passed in isolation (`SingleSelectV2` 25/25, Button performance 15/15, `SnackbarV2` persistence 24/24)

## Pre-Landing Review

- clean after fixing stale row-selection/bulk-action controls and duplicate live announcements
- no SQL, trust-boundary, conditional-side-effect, token, overflow, or layout findings
- scope drift: clean
- no prompt/eval files changed

## Plan Completion

- 20/20 items addressed: 15 implemented as planned, 5 equivalent requirement-driven changes, 0 deferred
- loading > error > empty > rows precedence is centralized and includes server-side internal loading
- no version, changelog, changeset, or package-version change

## Documentation

Documentation audit found no gaps: the API reference covers all five props, defaults, retry behavior, and loading precedence; Storybook covers default empty, custom empty, and error with retry. No architecture, TODO, or contributor docs are affected.

## Manual Test Plan

- [ ] verify the default and custom empty stories keep table chrome visible
- [ ] activate Retry in the error story and confirm rows recover
- [ ] verify loading supersedes error for both empty and stale-row data
- [ ] verify error suppresses stale select-all and bulk-action controls
- [ ] verify numeric and CSS-string body heights preserve header/footer layout

🤖 Generated with OpenAI Codex
