### PR TITLE
feat(date-picker): add month and year granularity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ breakpoints/    only two: { sm: 320, lg: 1024 }
 main.ts node.ts token-engine.ts token-engine-server.ts   ← the four build entries
 ```
 
-`components/shared/` holds cross-component internals, not components. `shared/datetime/` is the date+time layer: `timeCore.ts` (pure time math — parsing, clamping, `minuteStep` snapping, 12h/24h formatting) and `PickerTrigger.tsx` (the shared trigger button) back `DateRangePicker`, `SingleDatePicker` and `TimePicker`. A change there hits all three, so test all three.
+`components/shared/` holds cross-component internals, not components. `shared/datetime/` is the date+time layer: `timeCore.ts` (pure time math — parsing, clamping, `minuteStep` snapping, 12h/24h formatting), `granularity.ts` (period normalization), `MonthYearGrid.tsx` (month/year selection), and `PickerTrigger.tsx` (the shared trigger button) back `DateRangePicker`, `SingleDatePicker` and `TimePicker`. A change there hits all three, so test all three.
 
 Tests live **outside** `lib/`, in `packages/blend/__tests__/`, mirroring the component tree. `packages/blend/rfcs/` holds the authoritative standards docs (0002 testing, 0003 accessibility, 0005 token naming, 0007 refactoring).
 

--- a/apps/ascent/app/docs/content/components/daterangepicker.mdx
+++ b/apps/ascent/app/docs/content/components/daterangepicker.mdx
@@ -1,6 +1,6 @@
 ---
 title: DateRangePicker
-description: The DateRangePicker component provides a comprehensive date and time selection interface with calendar grid, preset options, mobile drawer support, and flexible configuration for single or range date selection with time picker integration.
+description: The DateRangePicker component provides a comprehensive date, month, and time selection interface with calendar grids, preset options, mobile drawer support, and flexible configuration for single or range selection.
 category: Selection
 tags:
     - daterangepicker
@@ -46,6 +46,11 @@ function MyComponent() {
     )
 }
 ```
+
+For month ranges, set `granularity="month"`. The selected `startDate` is
+normalized to the first day of the start month and `endDate` to the last day
+of the end month; day-only presets, date/time inputs, and the mobile drawer
+are not shown in this mode.
 
 ## API Reference
 
@@ -167,6 +172,18 @@ function MyComponent() {
                     'Date format string using format tokens (dd, MM, yyyy, etc.)',
             },
             { content: '' },
+        ],
+        [
+            {
+                content: 'granularity',
+                hintText:
+                    'Controls the selection resolution. Defaults to day. Set to month to display a month grid and select a month range; the returned startDate is the first day of the start month and endDate is the last day of the end month. Month mode suppresses day-only presets, date/time inputs, and the mobile drawer.',
+            },
+            {
+                content: "'day' | 'month'",
+                hintText: 'Selection resolution for day or month ranges',
+            },
+            { content: "'day', 'month'" },
         ],
         [
             {

--- a/apps/storybook/stories/components/DateRangePicker/v1/DateRangePicker.stories.tsx
+++ b/apps/storybook/stories/components/DateRangePicker/v1/DateRangePicker.stories.tsx
@@ -238,6 +238,17 @@ const [dateRange, setDateRange] = useState({
                 category: 'Date Configuration',
             },
         },
+        granularity: {
+            control: { type: 'select' },
+            options: ['day', 'month'],
+            description:
+                "`'month'` swaps the day calendar for a month grid and selects a month range: `startDate` becomes the first day of the start month and `endDate` the last day of the end month. Month mode suppresses `showPresets`, the DD/MM/YYYY text inputs, and the mobile drawer (`useDrawerOnMobile`).",
+            table: {
+                type: { summary: "'day' | 'month'" },
+                defaultValue: { summary: 'day' },
+                category: 'Date Configuration',
+            },
+        },
 
         // Preset Props
         showPresets: {
@@ -1259,6 +1270,46 @@ export const CustomFormatting: Story = {
         docs: {
             description: {
                 story: 'DateRangePicker with different date formatting options: US format, ISO format, and custom format.',
+            },
+        },
+    },
+}
+
+// Month granularity range selection
+export const MonthRange: Story = {
+    render: function MonthRange() {
+        const [monthRange, setMonthRange] = useState<DateRange>({
+            startDate: new Date(),
+            endDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        })
+
+        return (
+            <div className="w-100">
+                <h4 className="text-sm font-semibold mb-3">
+                    Month Range Selection
+                </h4>
+                <DateRangePicker
+                    value={monthRange}
+                    onChange={setMonthRange}
+                    granularity="month"
+                />
+                <div className="mt-3 text-xs text-gray-500">
+                    <div>
+                        <strong>Start:</strong>{' '}
+                        {monthRange.startDate.toDateString()}
+                    </div>
+                    <div>
+                        <strong>End:</strong>{' '}
+                        {monthRange.endDate?.toDateString() ?? 'Not selected'}
+                    </div>
+                </div>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'DateRangePicker with `granularity="month"`, selecting a month range instead of individual days. `startDate` is normalised to the first day of the start month and `endDate` to the last day of the end month; presets, the DD/MM/YYYY text inputs, and the mobile drawer are suppressed in this mode.',
             },
         },
     },

--- a/apps/storybook/stories/components/SingleDatePicker/SingleDatePicker.stories.tsx
+++ b/apps/storybook/stories/components/SingleDatePicker/SingleDatePicker.stories.tsx
@@ -136,6 +136,17 @@ const [date, setDate] = useState<Date | undefined>(new Date());
                 category: 'Date Configuration',
             },
         },
+        granularity: {
+            control: { type: 'select' },
+            options: ['day', 'month', 'year'],
+            description:
+                "`'month'` swaps the day calendar for a 12-cell month grid and returns the first day of the selected month; `'year'` renders a year grid and returns 1 January of the selected year. `minDate`/`maxDate` are compared at the same resolution, and `dateFormat`/`placeholder` pick granularity-appropriate defaults unless set explicitly.",
+            table: {
+                type: { summary: "'day' | 'month' | 'year'" },
+                defaultValue: { summary: 'day' },
+                category: 'Date Configuration',
+            },
+        },
 
         // Time Configuration
         showTime: {
@@ -600,6 +611,60 @@ export const Sizes: Story = {
         docs: {
             description: {
                 story: 'SingleDatePicker rendered at all three size variants: small, medium, and large.',
+            },
+        },
+    },
+}
+
+// Month granularity
+export const MonthPicker: Story = {
+    render: function MonthPicker() {
+        const [date, setDate] = useState<Date | undefined>(new Date())
+
+        return (
+            <div className="w-100">
+                <SingleDatePicker
+                    value={date}
+                    onChange={setDate}
+                    granularity="month"
+                />
+                <p className="mt-3 text-xs text-gray-500">
+                    Returned date: {date?.toDateString() ?? 'none'}
+                </p>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'SingleDatePicker with `granularity="month"`, rendering a 12-cell month grid with year navigation. The returned value is always the first day of the selected month.',
+            },
+        },
+    },
+}
+
+// Year granularity
+export const YearPicker: Story = {
+    render: function YearPicker() {
+        const [date, setDate] = useState<Date | undefined>(new Date())
+
+        return (
+            <div className="w-100">
+                <SingleDatePicker
+                    value={date}
+                    onChange={setDate}
+                    granularity="year"
+                />
+                <p className="mt-3 text-xs text-gray-500">
+                    Returned date: {date?.toDateString() ?? 'none'}
+                </p>
+            </div>
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'SingleDatePicker with `granularity="year"`, rendering a year grid. The returned value is always 1 January of the selected year.',
             },
         },
     },

--- a/packages/blend/README.md
+++ b/packages/blend/README.md
@@ -90,8 +90,8 @@ export default App
 ### Layout
 
 - **Accordion** - Collapsible content sections
-- **DateRangePicker** - Date range selection
-- **SingleDatePicker** - Single date selection, with optional time
+- **DateRangePicker** - Day or month range selection
+- **SingleDatePicker** - Day, month, or year selection, with optional time for day selection
 - **TimePicker** - Time-of-day selection, 12h or 24h display
 
 ## 🎨 Design Tokens

--- a/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.granularity.test.tsx
+++ b/packages/blend/__tests__/components/DateRangePicker/DateRangePicker.granularity.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../../test-utils'
+import DateRangePicker from '../../../lib/components/DateRangePicker/DateRangePicker'
+import type { DateRange } from '../../../lib/components/DateRangePicker/types'
+
+if (typeof PointerEvent === 'undefined') {
+    // @ts-expect-error - PointerEvent is not available in jsdom test environment
+    global.PointerEvent = class PointerEvent extends Event {
+        pointerId: number
+        bubbles: boolean
+        cancelable: boolean
+        pointerType: string
+        constructor(
+            type: string,
+            eventInitDict?: {
+                pointerId?: number
+                bubbles?: boolean
+                cancelable?: boolean
+                pointerType?: string
+            }
+        ) {
+            super(type, eventInitDict)
+            this.pointerId = eventInitDict?.pointerId ?? 0
+            this.bubbles = eventInitDict?.bubbles ?? false
+            this.cancelable = eventInitDict?.cancelable ?? false
+            this.pointerType = eventInitDict?.pointerType ?? 'mouse'
+        }
+    } as unknown
+}
+
+// A complete initial range anchors the month grid's view year at 2025 (via
+// MonthYearGrid's anchorYear derivation) without leaving a half-open pending
+// selection: `nextMonthRange` treats a range that already has an `endDate` as
+// complete and starts fresh on the very first click, so this seed value never
+// leaks into the assertions below.
+const JUNE_2025_RANGE: DateRange = {
+    startDate: new Date(2025, 5, 10),
+    endDate: new Date(2025, 5, 20),
+}
+
+const getTrigger = () =>
+    screen.getByRole('button', { name: /^Date range picker,/ })
+
+const getMonthCells = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll('[data-element="months"]'))
+
+const getMonthCell = (year: number, monthIndex: number): HTMLElement => {
+    const cell = document.querySelector(
+        `[data-element="months"][data-id="${year}-${monthIndex}"]`
+    )
+    if (!cell) throw new Error(`No month cell found for ${year}-${monthIndex}`)
+    return cell as HTMLElement
+}
+
+const waitForMonthGrid = async () =>
+    waitFor(() => expect(getMonthCells().length).toBeGreaterThan(0))
+
+const openPicker = async (user: ReturnType<typeof render>['user']) => {
+    await user.click(getTrigger())
+    await waitForMonthGrid()
+}
+
+const applyPicker = async (user: ReturnType<typeof render>['user']) => {
+    await user.click(screen.getByRole('button', { name: /apply/i }))
+}
+
+describe('DateRangePicker granularity', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('month granularity', () => {
+        it('commits startDate as the first day and endDate as the last day of the clicked months', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    value={JUNE_2025_RANGE}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+
+            await user.click(getMonthCell(2025, 8)) // September
+            await user.click(getMonthCell(2025, 10)) // November
+            await applyPicker(user)
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            const committed = onChange.mock.calls[0][0] as DateRange
+            expect(committed.startDate).toEqual(new Date(2025, 8, 1))
+            expect(committed.endDate).toEqual(new Date(2025, 10, 30))
+        })
+
+        it('gives a same-month range when the same month is clicked twice', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    value={JUNE_2025_RANGE}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+
+            await user.click(getMonthCell(2025, 8)) // September
+            await user.click(getMonthCell(2025, 8)) // September again
+            await applyPicker(user)
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            const committed = onChange.mock.calls[0][0] as DateRange
+            expect(committed.startDate).toEqual(new Date(2025, 8, 1))
+            expect(committed.endDate).toEqual(new Date(2025, 8, 30))
+        })
+
+        it('keeps the internal single-date mode single when month granularity is used', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    isSingleDatePicker
+                    value={{ startDate: new Date(2025, 5, 10) }}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+
+            await user.click(getMonthCell(2025, 8)) // September
+            await user.click(getMonthCell(2025, 10)) // October
+            await applyPicker(user)
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange.mock.calls[0][0]).toEqual({
+                startDate: new Date(2025, 10, 1),
+            })
+        })
+
+        it('restarts the range at an earlier month clicked while half-open', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    value={JUNE_2025_RANGE}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+
+            await user.click(getMonthCell(2025, 8)) // September — pending start
+            await user.click(getMonthCell(2025, 5)) // June — earlier, restarts
+            await user.click(getMonthCell(2025, 10)) // November — closes the range
+            await applyPicker(user)
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            const committed = onChange.mock.calls[0][0] as DateRange
+            // Had the restart not happened, the range would have stayed
+            // anchored at September (startDate 1 Sep). Anchored at June
+            // instead proves the earlier click restarted the range.
+            expect(committed.startDate).toEqual(new Date(2025, 5, 1))
+            expect(committed.endDate).toEqual(new Date(2025, 10, 30))
+        })
+
+        it('hides the DD/MM/YYYY text inputs and the preset quick-selector', async () => {
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    value={JUNE_2025_RANGE}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+
+            expect(screen.queryAllByPlaceholderText('DD/MM/YYYY')).toHaveLength(
+                0
+            )
+            expect(
+                document.querySelector('[data-element="preset-selector"]')
+            ).toBeNull()
+        })
+    })
+
+    // The trigger always renders from the committed `value` prop, not the
+    // in-popover draft (see `renderTrigger`'s `displayRange = value`), so
+    // these branches are exercised directly through `value` rather than by
+    // clicking through the calendar and Apply — Apply only calls `onChange`,
+    // it never updates `value` itself.
+    describe('trigger text (formatMonthRangeDisplay)', () => {
+        it('shows "Select month range" when nothing is committed', () => {
+            render(
+                <DateRangePicker
+                    granularity="month"
+                    value={undefined}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Select month range')
+        })
+
+        it('shows a single formatted month when only startDate is committed (no endDate)', () => {
+            render(
+                <DateRangePicker
+                    granularity="month"
+                    value={{ startDate: new Date(2025, 8, 1) }}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Sep 2025')
+        })
+
+        it('shows a single string, not a dashed range, when startDate and endDate fall in the same month', () => {
+            render(
+                <DateRangePicker
+                    granularity="month"
+                    value={{
+                        startDate: new Date(2025, 8, 1),
+                        endDate: new Date(2025, 8, 30),
+                    }}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Sep 2025')
+            expect(getTrigger().textContent).not.toContain(' - ')
+        })
+
+        it('shows "MMM yyyy - MMM yyyy" when startDate and endDate fall in different months', () => {
+            render(
+                <DateRangePicker
+                    granularity="month"
+                    value={{
+                        startDate: new Date(2025, 8, 1),
+                        endDate: new Date(2025, 10, 30),
+                    }}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Sep 2025 - Nov 2025')
+        })
+    })
+
+    describe('Apply button state (month mode)', () => {
+        it('disables Apply with nothing selected, and keeps it disabled after only a start month is picked', async () => {
+            const { user } = render(
+                <DateRangePicker
+                    granularity="month"
+                    value={undefined}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+
+            expect(
+                screen.getByRole('button', { name: /apply/i })
+            ).toBeDisabled()
+
+            // No committed value means the grid anchors on whatever year the
+            // component resolves as "today" — read it back from the view
+            // label instead of constructing a Date, so this stays
+            // independent of the real current date.
+            const viewYear = Number(
+                (
+                    document.querySelector(
+                        '[data-element="month-year"]'
+                    ) as HTMLElement
+                ).textContent
+            )
+            await user.click(getMonthCell(viewYear, 0)) // a start month only, no end yet
+
+            expect(
+                screen.getByRole('button', { name: /apply/i })
+            ).toBeDisabled()
+        })
+    })
+
+    describe('day granularity (default)', () => {
+        it('still renders the DD/MM/YYYY text inputs', async () => {
+            const { user } = render(
+                <DateRangePicker value={JUNE_2025_RANGE} onChange={vi.fn()} />
+            )
+
+            await user.click(getTrigger())
+
+            await waitFor(() => {
+                expect(
+                    screen.getAllByPlaceholderText('DD/MM/YYYY').length
+                ).toBeGreaterThan(0)
+            })
+        })
+    })
+})

--- a/packages/blend/__tests__/components/SingleDatePicker/SingleDatePicker.granularity.test.tsx
+++ b/packages/blend/__tests__/components/SingleDatePicker/SingleDatePicker.granularity.test.tsx
@@ -1,0 +1,568 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../../test-utils'
+import SingleDatePicker from '../../../lib/components/SingleDatePicker/SingleDatePicker'
+
+if (typeof PointerEvent === 'undefined') {
+    // @ts-expect-error - PointerEvent is not available in jsdom test environment
+    global.PointerEvent = class PointerEvent extends Event {
+        pointerId: number
+        bubbles: boolean
+        cancelable: boolean
+        pointerType: string
+        constructor(
+            type: string,
+            eventInitDict?: {
+                pointerId?: number
+                bubbles?: boolean
+                cancelable?: boolean
+                pointerType?: string
+            }
+        ) {
+            super(type, eventInitDict)
+            this.pointerId = eventInitDict?.pointerId ?? 0
+            this.bubbles = eventInitDict?.bubbles ?? false
+            this.cancelable = eventInitDict?.cancelable ?? false
+            this.pointerType = eventInitDict?.pointerType ?? 'mouse'
+        }
+    } as unknown
+}
+
+// Fixed dates only — the year grid depends on "today" for its upper bound
+// (1940..currentYear+10), so pick target years well inside that range.
+const JUN_10_2025 = new Date(2025, 5, 10)
+const SEP_15_2025 = new Date(2025, 8, 15)
+
+const getTrigger = () => screen.getByRole('button', { name: /^Date picker,/ })
+
+const getMonthCells = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll('[data-element="months"]'))
+
+const getYearCells = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll('[data-element="years"]'))
+
+const getMonthCell = (year: number, monthIndex: number): HTMLElement => {
+    const cell = document.querySelector(
+        `[data-element="months"][data-id="${year}-${monthIndex}"]`
+    )
+    if (!cell) throw new Error(`No month cell found for ${year}-${monthIndex}`)
+    return cell as HTMLElement
+}
+
+const getYearCell = (year: number): HTMLElement => {
+    const cell = document.querySelector(
+        `[data-element="years"][data-id="${year}"]`
+    )
+    if (!cell) throw new Error(`No year cell found for ${year}`)
+    return cell as HTMLElement
+}
+
+const getMonthYearLabel = () =>
+    document.querySelector('[data-element="month-year"]') as HTMLElement
+
+const waitForMonthGrid = async () =>
+    waitFor(() => expect(getMonthCells().length).toBeGreaterThan(0))
+
+const waitForYearGrid = async () =>
+    waitFor(() => expect(getYearCells().length).toBeGreaterThan(0))
+
+const openPicker = async (user: ReturnType<typeof render>['user']) => {
+    await user.click(getTrigger())
+}
+
+describe('SingleDatePicker granularity', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('month granularity', () => {
+        it('calls onChange with the first day of the clicked month on Apply', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={JUN_10_2025}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            await user.click(getMonthCell(2025, 8))
+            await user.click(screen.getByRole('button', { name: /apply/i }))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith(new Date(2025, 8, 1))
+        })
+
+        it('highlights the month of a mid-month value as selected', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            const septemberCell = getMonthCell(2025, 8)
+            expect(septemberCell).toHaveAttribute('data-state', 'selected')
+        })
+
+        it('advances the view year and re-renders month cells on Next year', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={JUN_10_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(getMonthYearLabel()).toHaveTextContent('2025')
+            expect(
+                document.querySelector(
+                    '[data-element="months"][data-id="2026-0"]'
+                )
+            ).toBeNull()
+
+            await user.click(screen.getByRole('button', { name: 'Next year' }))
+
+            await waitFor(() => {
+                expect(getMonthYearLabel()).toHaveTextContent('2026')
+            })
+            expect(getMonthCell(2026, 0)).toBeInTheDocument()
+        })
+
+        it('compares minDate at month resolution, leaving the boundary month enabled', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                    minDate={new Date(2025, 8, 15)}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(getMonthCell(2025, 8)).toHaveAttribute(
+                'data-status',
+                'enabled'
+            )
+            expect(getMonthCell(2025, 7)).toHaveAttribute(
+                'data-status',
+                'disabled'
+            )
+        })
+
+        it('compares maxDate at month resolution, leaving the boundary month enabled', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                    maxDate={new Date(2025, 8, 15)}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(getMonthCell(2025, 8)).toHaveAttribute(
+                'data-status',
+                'enabled'
+            )
+            expect(getMonthCell(2025, 9)).toHaveAttribute(
+                'data-status',
+                'disabled'
+            )
+        })
+
+        it('calls customDisableDates with the period first day, not an arbitrary day, and disables the matched month', async () => {
+            const customDisableDates = vi.fn(
+                (date: Date) =>
+                    date.getTime() === new Date(2025, 9, 1).getTime()
+            )
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                    disableDates={customDisableDates}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(getMonthCell(2025, 9)).toHaveAttribute(
+                'data-status',
+                'disabled'
+            )
+            expect(
+                customDisableDates.mock.calls.some(
+                    ([date]) =>
+                        date.getTime() === new Date(2025, 9, 1).getTime()
+                )
+            ).toBe(true)
+        })
+    })
+
+    describe('keyboard navigation (month mode)', () => {
+        it('moves focus between month cells with arrow keys', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            const septemberCell = getMonthCell(2025, 8)
+            septemberCell.focus()
+            expect(document.activeElement).toBe(septemberCell)
+
+            await user.keyboard('{ArrowLeft}')
+            const augustCell = getMonthCell(2025, 7)
+            expect(document.activeElement).toBe(augustCell)
+
+            await user.keyboard('{ArrowUp}')
+            const aprilCell = getMonthCell(2025, 3)
+            expect(document.activeElement).toBe(aprilCell)
+
+            await user.keyboard('{ArrowDown}')
+            expect(document.activeElement).toBe(augustCell)
+
+            await user.keyboard('{ArrowRight}')
+            expect(document.activeElement).toBe(septemberCell)
+        })
+
+        it('does not move focus onto a disabled month', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    minDate={new Date(2025, 8, 1)}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            const septemberCell = getMonthCell(2025, 8)
+            septemberCell.focus()
+            await user.keyboard('{ArrowLeft}')
+
+            expect(document.activeElement).toBe(septemberCell)
+            expect(getMonthCell(2025, 7)).toHaveAttribute(
+                'aria-disabled',
+                'true'
+            )
+        })
+
+        it('selects the focused cell on Enter and commits it on Apply', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            getMonthCell(2025, 8).focus()
+            await user.keyboard('{ArrowRight}') // focus October
+            await user.keyboard('{Enter}')
+
+            await user.click(screen.getByRole('button', { name: /apply/i }))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith(new Date(2025, 9, 1))
+        })
+
+        it('selects the focused cell on Space and commits it on Apply', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            getMonthCell(2025, 8).focus()
+            await user.keyboard('{ArrowLeft}') // focus August
+            await user.keyboard(' ')
+
+            await user.click(screen.getByRole('button', { name: /apply/i }))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith(new Date(2025, 7, 1))
+        })
+    })
+
+    describe('empty picker keyboard entry', () => {
+        it('gives an empty month picker a keyboard-reachable cell', async () => {
+            const { user } = render(
+                <SingleDatePicker granularity="month" onChange={vi.fn()} />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(
+                getMonthCells().some(
+                    (cell) => cell.getAttribute('tabindex') === '0'
+                )
+            ).toBe(true)
+        })
+
+        it('starts an empty year picker at the current year for keyboard users', async () => {
+            const { user } = render(
+                <SingleDatePicker granularity="year" onChange={vi.fn()} />
+            )
+
+            await openPicker(user)
+            await waitForYearGrid()
+
+            expect(getYearCell(new Date().getFullYear())).toHaveAttribute(
+                'tabindex',
+                '0'
+            )
+        })
+    })
+
+    describe('cancel discards in-progress selection (month mode)', () => {
+        it('discards a clicked month on Cancel and reopens showing the previously committed value', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            await user.click(getMonthCell(2025, 10)) // November — draft only
+            await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+            expect(onChange).not.toHaveBeenCalled()
+            expect(getTrigger()).toHaveTextContent('09/2025')
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(getMonthCell(2025, 8)).toHaveAttribute(
+                'data-state',
+                'selected'
+            )
+            expect(getMonthCell(2025, 10)).toHaveAttribute(
+                'data-state',
+                'not selected'
+            )
+        })
+
+        it('discards a clicked month on Cancel and reopens to the placeholder when there was no committed value', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={undefined}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            await user.click(getMonthCells()[0]) // any month — draft only, nothing committed
+            await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+            expect(onChange).not.toHaveBeenCalled()
+            expect(getTrigger()).toHaveTextContent('Select month')
+        })
+    })
+
+    describe('showTime combined with month/year granularity', () => {
+        it('suppresses time controls and commits the month at local midnight', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="month"
+                    showTime
+                    value={new Date(2025, 8, 15, 14, 30)}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForMonthGrid()
+
+            expect(
+                document.querySelector('[data-element="time-columns"]')
+            ).not.toBeInTheDocument()
+            expect(getMonthCells().length).toBeGreaterThan(0)
+
+            await user.click(getMonthCell(2025, 9)) // October
+            await user.click(screen.getByRole('button', { name: /apply/i }))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith(new Date(2025, 9, 1))
+        })
+
+        it('suppresses time controls in year mode without crashing', async () => {
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="year"
+                    showTime
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            await openPicker(user)
+            await waitForYearGrid()
+
+            expect(
+                document.querySelector('[data-element="time-columns"]')
+            ).not.toBeInTheDocument()
+            expect(getYearCells().length).toBeGreaterThan(0)
+        })
+    })
+
+    describe('year granularity', () => {
+        it('calls onChange with 1 January of the clicked year on Apply', async () => {
+            const onChange = vi.fn()
+            const { user } = render(
+                <SingleDatePicker
+                    granularity="year"
+                    value={JUN_10_2025}
+                    onChange={onChange}
+                />
+            )
+
+            await openPicker(user)
+            await waitForYearGrid()
+
+            await user.click(getYearCell(2027))
+            await user.click(screen.getByRole('button', { name: /apply/i }))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith(new Date(2027, 0, 1))
+        })
+    })
+
+    describe('default formatting', () => {
+        it('formats the trigger as MM/yyyy in month mode', () => {
+            render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('09/2025')
+        })
+
+        it('formats the trigger as yyyy in year mode', () => {
+            render(
+                <SingleDatePicker
+                    granularity="year"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('2025')
+        })
+
+        it('lets an explicit dateFormat override the month-mode default', () => {
+            render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={SEP_15_2025}
+                    onChange={vi.fn()}
+                    dateFormat="yyyy-MM"
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('2025-09')
+        })
+    })
+
+    describe('default placeholder', () => {
+        it('uses "Select month" in month mode without a value', () => {
+            render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={undefined}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Select month')
+        })
+
+        it('uses "Select year" in year mode without a value', () => {
+            render(
+                <SingleDatePicker
+                    granularity="year"
+                    value={undefined}
+                    onChange={vi.fn()}
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Select year')
+        })
+
+        it('lets an explicit placeholder override the month-mode default', () => {
+            render(
+                <SingleDatePicker
+                    granularity="month"
+                    value={undefined}
+                    onChange={vi.fn()}
+                    placeholder="Pick a month"
+                />
+            )
+
+            expect(getTrigger()).toHaveTextContent('Pick a month')
+        })
+    })
+
+    describe('day granularity (default)', () => {
+        it('renders day cells and no month cells when granularity is omitted', async () => {
+            const { user } = render(
+                <SingleDatePicker value={SEP_15_2025} onChange={vi.fn()} />
+            )
+
+            await openPicker(user)
+            await waitFor(() => {
+                expect(
+                    document.querySelectorAll('[data-element="days"]').length
+                ).toBeGreaterThan(0)
+            })
+
+            expect(getMonthCells()).toHaveLength(0)
+        })
+    })
+})

--- a/packages/blend/__tests__/components/shared/datetime/MonthYearGrid.accessibility.test.tsx
+++ b/packages/blend/__tests__/components/shared/datetime/MonthYearGrid.accessibility.test.tsx
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../../../test-utils'
+import { axe } from 'jest-axe'
+import SingleDatePicker from '../../../../lib/components/SingleDatePicker/SingleDatePicker'
+import DateRangePicker from '../../../../lib/components/DateRangePicker/DateRangePicker'
+import type { DateRange } from '../../../../lib/components/DateRangePicker/types'
+
+if (typeof PointerEvent === 'undefined') {
+    // @ts-expect-error - PointerEvent is not available in jsdom test environment
+    global.PointerEvent = class PointerEvent extends Event {
+        pointerId: number
+        bubbles: boolean
+        cancelable: boolean
+        pointerType: string
+        constructor(
+            type: string,
+            eventInitDict?: {
+                pointerId?: number
+                bubbles?: boolean
+                cancelable?: boolean
+                pointerType?: string
+            }
+        ) {
+            super(type, eventInitDict)
+            this.pointerId = eventInitDict?.pointerId ?? 0
+            this.bubbles = eventInitDict?.bubbles ?? false
+            this.cancelable = eventInitDict?.cancelable ?? false
+            this.pointerType = eventInitDict?.pointerType ?? 'mouse'
+        }
+    } as unknown
+}
+
+const SEP_15_2025 = new Date(2025, 8, 15)
+const JUNE_2025_RANGE: DateRange = {
+    startDate: new Date(2025, 5, 10),
+    endDate: new Date(2025, 5, 20),
+}
+
+const getSingleTrigger = () =>
+    screen.getByRole('button', { name: /^Date picker,/ })
+
+const getRangeTrigger = () =>
+    screen.getByRole('button', { name: /^Date range picker,/ })
+
+const getMonthCells = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll('[data-element="months"]'))
+
+const getYearCells = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll('[data-element="years"]'))
+
+const getMonthCell = (year: number, monthIndex: number): HTMLElement => {
+    const cell = document.querySelector(
+        `[data-element="months"][data-id="${year}-${monthIndex}"]`
+    )
+    if (!cell) throw new Error(`No month cell found for ${year}-${monthIndex}`)
+    return cell as HTMLElement
+}
+
+const waitForMonthGrid = async () =>
+    waitFor(() => expect(getMonthCells().length).toBeGreaterThan(0))
+
+const waitForYearGrid = async () =>
+    waitFor(() => expect(getYearCells().length).toBeGreaterThan(0))
+
+describe('MonthYearGrid Accessibility (via SingleDatePicker, month mode)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('has no axe violations when the month grid is open', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="month"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForMonthGrid()
+
+        // The popover renders in a portal, so scope axe to the whole body.
+        const results = await axe(document.body)
+        expect(results).toHaveNoViolations()
+    }, 20000)
+
+    it('exposes the grid container with role="grid" and an accessible name', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="month"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForMonthGrid()
+
+        expect(
+            screen.getByRole('grid', { name: 'Select month' })
+        ).toBeInTheDocument()
+    })
+
+    it('labels each month cell with the full month and year, marking the selection', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="month"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForMonthGrid()
+
+        expect(getMonthCell(2025, 8)).toHaveAttribute(
+            'aria-label',
+            'September 2025, selected'
+        )
+        expect(getMonthCell(2025, 9)).toHaveAttribute(
+            'aria-label',
+            'October 2025'
+        )
+    })
+
+    it('gives the year navigation buttons their exact accessible names and keeps them focusable', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="month"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForMonthGrid()
+
+        const prevYear = screen.getByRole('button', { name: 'Previous year' })
+        const nextYear = screen.getByRole('button', { name: 'Next year' })
+        expect(prevYear).toBeInTheDocument()
+        expect(nextYear).toBeInTheDocument()
+        expect(prevYear).not.toHaveAttribute('tabIndex', '-1')
+        expect(nextYear).not.toHaveAttribute('tabIndex', '-1')
+    })
+
+    it('marks a month disabled by minDate with aria-disabled="true"', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="month"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+                minDate={new Date(2025, 8, 1)}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForMonthGrid()
+
+        expect(getMonthCell(2025, 7)).toHaveAttribute('aria-disabled', 'true')
+        expect(getMonthCell(2025, 8)).toHaveAttribute('aria-disabled', 'false')
+    })
+})
+
+describe('MonthYearGrid Accessibility (via SingleDatePicker, year mode)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('has no axe violations when the year grid is open', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="year"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForYearGrid()
+
+        const results = await axe(document.body)
+        expect(results).toHaveNoViolations()
+    }, 20000)
+
+    it('exposes the grid container with role="grid" and an accessible name', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="year"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForYearGrid()
+
+        expect(
+            screen.getByRole('grid', { name: 'Select year' })
+        ).toBeInTheDocument()
+    })
+
+    it('labels each year cell with the year text, marking the selection', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="year"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForYearGrid()
+
+        const selectedCell = document.querySelector(
+            '[data-element="years"][data-id="2025"]'
+        ) as HTMLElement
+        expect(selectedCell).toHaveAttribute('aria-label', '2025, selected')
+
+        const otherCell = document.querySelector(
+            '[data-element="years"][data-id="2027"]'
+        ) as HTMLElement
+        expect(otherCell).toHaveAttribute('aria-label', '2027')
+    })
+
+    it('marks a year disabled by maxDate with aria-disabled="true"', async () => {
+        const { user } = render(
+            <SingleDatePicker
+                granularity="year"
+                value={SEP_15_2025}
+                onChange={vi.fn()}
+                maxDate={new Date(2025, 8, 15)}
+            />
+        )
+
+        await user.click(getSingleTrigger())
+        await waitForYearGrid()
+
+        const futureCell = document.querySelector(
+            '[data-element="years"][data-id="2026"]'
+        ) as HTMLElement
+        expect(futureCell).toHaveAttribute('aria-disabled', 'true')
+
+        const currentCell = document.querySelector(
+            '[data-element="years"][data-id="2025"]'
+        ) as HTMLElement
+        expect(currentCell).toHaveAttribute('aria-disabled', 'false')
+    })
+})
+
+describe('MonthYearGrid Accessibility (via DateRangePicker, month mode)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('has no axe violations when the month grid is open', async () => {
+        const { user } = render(
+            <DateRangePicker
+                granularity="month"
+                value={JUNE_2025_RANGE}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getRangeTrigger())
+        await waitForMonthGrid()
+
+        const results = await axe(document.body)
+        expect(results).toHaveNoViolations()
+    }, 20000)
+
+    it('exposes the grid container with role="grid" and an accessible name', async () => {
+        const { user } = render(
+            <DateRangePicker
+                granularity="month"
+                value={JUNE_2025_RANGE}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getRangeTrigger())
+        await waitForMonthGrid()
+
+        expect(
+            screen.getByRole('grid', { name: 'Select month' })
+        ).toBeInTheDocument()
+    })
+
+    it('labels each month cell with the full month and year, marking the selection', async () => {
+        const { user } = render(
+            <DateRangePicker
+                granularity="month"
+                value={JUNE_2025_RANGE}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getRangeTrigger())
+        await waitForMonthGrid()
+
+        expect(getMonthCell(2025, 5)).toHaveAttribute(
+            'aria-label',
+            'June 2025, selected'
+        )
+        expect(getMonthCell(2025, 6)).toHaveAttribute('aria-label', 'July 2025')
+    })
+
+    it('gives the year navigation buttons their exact accessible names and keeps them focusable', async () => {
+        const { user } = render(
+            <DateRangePicker
+                granularity="month"
+                value={JUNE_2025_RANGE}
+                onChange={vi.fn()}
+            />
+        )
+
+        await user.click(getRangeTrigger())
+        await waitForMonthGrid()
+
+        const prevYear = screen.getByRole('button', { name: 'Previous year' })
+        const nextYear = screen.getByRole('button', { name: 'Next year' })
+        expect(prevYear).toBeInTheDocument()
+        expect(nextYear).toBeInTheDocument()
+        expect(prevYear).not.toHaveAttribute('tabIndex', '-1')
+        expect(nextYear).not.toHaveAttribute('tabIndex', '-1')
+    })
+
+    it('marks a month disabled by minDate with aria-disabled="true"', async () => {
+        const { user } = render(
+            <DateRangePicker
+                granularity="month"
+                value={JUNE_2025_RANGE}
+                onChange={vi.fn()}
+                minDate={new Date(2025, 5, 1)}
+            />
+        )
+
+        await user.click(getRangeTrigger())
+        await waitForMonthGrid()
+
+        expect(getMonthCell(2025, 4)).toHaveAttribute('aria-disabled', 'true')
+        expect(getMonthCell(2025, 5)).toHaveAttribute('aria-disabled', 'false')
+    })
+})

--- a/packages/blend/__tests__/components/shared/datetime/granularity.test.ts
+++ b/packages/blend/__tests__/components/shared/datetime/granularity.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import {
+    startOfMonth,
+    endOfMonth,
+    startOfYear,
+    startOfPeriod,
+    normalizeRangeToPeriodStarts,
+    nextMonthRange,
+} from '../../../../lib/components/shared/datetime/granularity'
+import type { DateRange } from '../../../../lib/components/DateRangePicker/types'
+
+describe('granularity', () => {
+    describe('endOfMonth', () => {
+        it('rolls December into 31 December of the same year', () => {
+            const result = endOfMonth(new Date(2025, 11, 15))
+            expect(result).toEqual(new Date(2025, 11, 31))
+        })
+
+        it('resolves February to the 29th in a leap year', () => {
+            const result = endOfMonth(new Date(2024, 1, 10))
+            expect(result).toEqual(new Date(2024, 1, 29))
+        })
+
+        it('resolves February to the 28th in a non-leap year', () => {
+            const result = endOfMonth(new Date(2025, 1, 10))
+            expect(result).toEqual(new Date(2025, 1, 28))
+        })
+
+        it('resolves a 30-day month correctly', () => {
+            const result = endOfMonth(new Date(2025, 3, 5))
+            expect(result).toEqual(new Date(2025, 3, 30))
+        })
+    })
+
+    describe('startOfMonth / startOfYear', () => {
+        it('startOfMonth returns local midnight on the 1st of the month', () => {
+            const result = startOfMonth(new Date(2025, 8, 20, 14, 30, 15))
+            expect(result).toEqual(new Date(2025, 8, 1))
+            expect(result.getHours()).toBe(0)
+            expect(result.getMinutes()).toBe(0)
+            expect(result.getSeconds()).toBe(0)
+            expect(result.getMilliseconds()).toBe(0)
+        })
+
+        it('startOfYear returns local midnight on 1 January', () => {
+            const result = startOfYear(new Date(2025, 8, 20, 14, 30, 15))
+            expect(result).toEqual(new Date(2025, 0, 1))
+            expect(result.getHours()).toBe(0)
+            expect(result.getMinutes()).toBe(0)
+            expect(result.getSeconds()).toBe(0)
+            expect(result.getMilliseconds()).toBe(0)
+        })
+    })
+
+    describe('startOfPeriod', () => {
+        it('returns the same Date reference, unchanged, for day granularity', () => {
+            const date = new Date(2025, 8, 20, 14, 30)
+            const result = startOfPeriod(date, 'day')
+            expect(result).toBe(date)
+        })
+
+        it('collapses to the start of the month for month granularity', () => {
+            const result = startOfPeriod(new Date(2025, 8, 20), 'month')
+            expect(result).toEqual(new Date(2025, 8, 1))
+        })
+
+        it('collapses to the start of the year for year granularity', () => {
+            const result = startOfPeriod(new Date(2025, 8, 20), 'year')
+            expect(result).toEqual(new Date(2025, 0, 1))
+        })
+    })
+
+    describe('normalizeRangeToPeriodStarts', () => {
+        it('returns the range untouched for day granularity', () => {
+            const range: DateRange = {
+                startDate: new Date(2025, 8, 15),
+                endDate: new Date(2025, 8, 20),
+            }
+            expect(normalizeRangeToPeriodStarts(range, 'day')).toBe(range)
+        })
+
+        it('returns undefined when the range is undefined', () => {
+            expect(
+                normalizeRangeToPeriodStarts(undefined, 'month')
+            ).toBeUndefined()
+        })
+
+        it('collapses both ends onto their period starts for month granularity', () => {
+            const range: DateRange = {
+                startDate: new Date(2025, 8, 15),
+                endDate: new Date(2025, 10, 20),
+            }
+            expect(normalizeRangeToPeriodStarts(range, 'month')).toEqual({
+                startDate: new Date(2025, 8, 1),
+                endDate: new Date(2025, 10, 1),
+            })
+        })
+
+        it('collapses both ends onto their period starts for year granularity', () => {
+            const range: DateRange = {
+                startDate: new Date(2025, 8, 15),
+                endDate: new Date(2027, 10, 20),
+            }
+            expect(normalizeRangeToPeriodStarts(range, 'year')).toEqual({
+                startDate: new Date(2025, 0, 1),
+                endDate: new Date(2027, 0, 1),
+            })
+        })
+
+        it('handles a range with no endDate', () => {
+            const range: DateRange = { startDate: new Date(2025, 8, 15) }
+            expect(normalizeRangeToPeriodStarts(range, 'month')).toEqual({
+                startDate: new Date(2025, 8, 1),
+                endDate: undefined,
+            })
+        })
+    })
+
+    describe('nextMonthRange', () => {
+        it('starts fresh when current is undefined', () => {
+            const result = nextMonthRange(undefined, new Date(2025, 8, 15))
+            expect(result).toEqual({ startDate: new Date(2025, 8, 1) })
+        })
+
+        it('starts fresh when current already has an endDate (complete range)', () => {
+            const current: DateRange = {
+                startDate: new Date(2025, 5, 1),
+                endDate: new Date(2025, 6, 31),
+            }
+            const result = nextMonthRange(current, new Date(2025, 8, 15))
+            expect(result).toEqual({ startDate: new Date(2025, 8, 1) })
+        })
+
+        it('closes the range when the picked month is later than the pending start', () => {
+            const current: DateRange = { startDate: new Date(2025, 8, 1) }
+            const result = nextMonthRange(current, new Date(2025, 10, 15))
+            expect(result).toEqual({
+                startDate: new Date(2025, 8, 1),
+                endDate: new Date(2025, 10, 30),
+            })
+        })
+
+        it('normalises a mid-month pending start when closing the range', () => {
+            // A caller can seed `value` with a half-open, mid-month range;
+            // closing against it must still commit a whole-month range.
+            const current: DateRange = { startDate: new Date(2025, 8, 10) }
+            const result = nextMonthRange(current, new Date(2025, 10, 15))
+            expect(result).toEqual({
+                startDate: new Date(2025, 8, 1),
+                endDate: new Date(2025, 10, 30),
+            })
+        })
+
+        it('restarts the range when the picked month is earlier than the pending start', () => {
+            const current: DateRange = { startDate: new Date(2025, 8, 1) }
+            const result = nextMonthRange(current, new Date(2025, 5, 15))
+            expect(result).toEqual({ startDate: new Date(2025, 5, 1) })
+        })
+
+        it('closes the range onto the same month when picked twice', () => {
+            const current: DateRange = { startDate: new Date(2025, 8, 1) }
+            const result = nextMonthRange(current, new Date(2025, 8, 20))
+            expect(result).toEqual({
+                startDate: new Date(2025, 8, 1),
+                endDate: new Date(2025, 8, 30),
+            })
+        })
+    })
+
+    describe('invalid Date input', () => {
+        it('yields an invalid Date rather than throwing', () => {
+            const invalid = new Date(NaN)
+
+            expect(() => startOfMonth(invalid)).not.toThrow()
+            expect(Number.isNaN(startOfMonth(invalid).getTime())).toBe(true)
+
+            expect(() => endOfMonth(invalid)).not.toThrow()
+            expect(Number.isNaN(endOfMonth(invalid).getTime())).toBe(true)
+
+            expect(() => startOfYear(invalid)).not.toThrow()
+            expect(Number.isNaN(startOfYear(invalid).getTime())).toBe(true)
+        })
+    })
+})

--- a/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -42,6 +42,8 @@ import { useBreakpoints } from '../../hooks/useBreakPoints'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { useTheme } from '../../context'
 import { renderPickerTrigger } from '../shared/datetime/PickerTrigger'
+import MonthYearGrid from '../shared/datetime/MonthYearGrid'
+import { nextMonthRange } from '../shared/datetime/granularity'
 
 type DateInputsSectionProps = {
     startDate?: string
@@ -269,6 +271,7 @@ type CalendarSectionProps = {
     minDate?: Date
     maxDate?: Date
     maxRangeDays?: number
+    granularity?: 'day' | 'month'
 }
 
 const CalendarSection: React.FC<
@@ -292,30 +295,62 @@ const CalendarSection: React.FC<
     minDate,
     maxDate,
     maxRangeDays,
-}) => (
-    <Block flexGrow={1} minHeight={0} overflow="auto">
-        <CalendarGrid
-            selectedRange={selectedRange}
-            onDateSelect={onDateSelect}
-            today={today}
-            allowSingleDateSelection={allowSingleDateSelection}
-            disableFutureDates={disableFutureDates}
-            disablePastDates={disablePastDates}
-            hideFutureDates={hideFutureDates}
-            hidePastDates={hidePastDates}
-            customDisableDates={customDisableDates}
-            customRangeConfig={customRangeConfig}
-            showDateTimePicker={showDateTimePicker}
-            resetScrollPosition={resetScrollPosition}
-            timezone={timezone}
-            isSingleDatePicker={isSingleDatePicker}
-            maxYearOffset={maxYearOffset}
-            minDate={minDate}
-            maxDate={maxDate}
-            maxRangeDays={maxRangeDays}
-        />
-    </Block>
-)
+    granularity = 'day',
+}) =>
+    granularity === 'month' ? (
+        <Block flexGrow={1} minHeight={0} overflow="auto">
+            <MonthYearGrid
+                granularity="month"
+                selectedRange={selectedRange}
+                // The grid only knows which month was clicked; turning that
+                // into a start-or-end decision is range bookkeeping, and
+                // `nextMonthRange` applies the same rules the day calendar
+                // uses (later click closes the range, earlier click restarts).
+                onSelect={(periodStart) =>
+                    onDateSelect(
+                        isSingleDatePicker
+                            ? { startDate: periodStart }
+                            : nextMonthRange(selectedRange, periodStart)
+                    )
+                }
+                today={today}
+                isRange={!isSingleDatePicker}
+                timezone={timezone}
+                disableFutureDates={disableFutureDates}
+                disablePastDates={disablePastDates}
+                hideFutureDates={hideFutureDates}
+                hidePastDates={hidePastDates}
+                customDisableDates={customDisableDates}
+                resetScrollPosition={resetScrollPosition}
+                maxYearOffset={maxYearOffset}
+                minDate={minDate}
+                maxDate={maxDate}
+            />
+        </Block>
+    ) : (
+        <Block flexGrow={1} minHeight={0} overflow="auto">
+            <CalendarGrid
+                selectedRange={selectedRange}
+                onDateSelect={onDateSelect}
+                today={today}
+                allowSingleDateSelection={allowSingleDateSelection}
+                disableFutureDates={disableFutureDates}
+                disablePastDates={disablePastDates}
+                hideFutureDates={hideFutureDates}
+                hidePastDates={hidePastDates}
+                customDisableDates={customDisableDates}
+                customRangeConfig={customRangeConfig}
+                showDateTimePicker={showDateTimePicker}
+                resetScrollPosition={resetScrollPosition}
+                timezone={timezone}
+                isSingleDatePicker={isSingleDatePicker}
+                maxYearOffset={maxYearOffset}
+                minDate={minDate}
+                maxDate={maxDate}
+                maxRangeDays={maxRangeDays}
+            />
+        </Block>
+    )
 
 type FooterControlsProps = {
     onCancel: () => void
@@ -382,6 +417,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
             customPresets,
             isDisabled = false,
             dateFormat = 'dd/MM/yyyy',
+            granularity = 'day',
             allowSingleDateSelection = false,
             isSingleDatePicker = false,
             disableFutureDates = false,
@@ -415,7 +451,18 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
         const { foundationTokens } = useTheme()
         const { innerWidth } = useBreakpoints()
         const isMobile = innerWidth < 1024
-        const showPresets = shouldShowPresets && !isSingleDatePicker
+
+        // Month mode turns off the three surfaces that only make sense for
+        // days: the presets are all day ranges, the DD/MM/YYYY text inputs
+        // would let a keystroke produce a range that starts mid-month, and the
+        // mobile drawer's scroll wheel has no month-range mode at all — so
+        // mobile falls through to the same popover desktop uses. See the
+        // `granularity` docs on `DateRangePickerProps`.
+        const isMonthGranularity = granularity === 'month'
+        const showPresets =
+            shouldShowPresets && !isSingleDatePicker && !isMonthGranularity
+        const showDateInputs = showDateInput && !isMonthGranularity
+        const useDrawer = useDrawerOnMobile && !isMonthGranularity
 
         const [selectedRange, setSelectedRange] = useState<
             DateRange | undefined
@@ -901,6 +948,34 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                 !triggerConfig?.renderTrigger &&
                 Boolean(triggerConfig?.element || triggerElement)
 
+            // A month range is two month names, not two timestamps:
+            // `formatDateDisplay` would render "Sep 1, 2025, 12:00 AM - Sep 30,
+            // 2025, 12:00 AM" for what the user picked as "September".
+            const formatMonthRangeDisplay = (
+                range: DateRange | undefined
+            ): string => {
+                if (!range?.startDate) return 'Select month range'
+
+                const options: Intl.DateTimeFormatOptions = {
+                    month: 'short',
+                    year: 'numeric',
+                    ...(timezone && { timeZone: timezone }),
+                }
+                const startStr = range.startDate.toLocaleDateString(
+                    'en-US',
+                    options
+                )
+                if (!range.endDate) return startStr
+
+                const endStr = range.endDate.toLocaleDateString(
+                    'en-US',
+                    options
+                )
+                return startStr === endStr
+                    ? startStr
+                    : `${startStr} - ${endStr}`
+            }
+
             const displayText = usesCustomElement
                 ? ''
                 : formatConfig
@@ -911,12 +986,14 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                         triggerConfig?.placeholder,
                         timezone
                     )
-                  : formatDateDisplay(
-                        displayRange,
-                        allowSingleDateSelection,
-                        timezone,
-                        isSingleDatePicker
-                    )
+                  : isMonthGranularity
+                    ? formatMonthRangeDisplay(displayRange)
+                    : formatDateDisplay(
+                          displayRange,
+                          allowSingleDateSelection,
+                          timezone,
+                          isSingleDatePicker
+                      )
 
             const formatMobileDateRange = (
                 range: DateRange | undefined
@@ -961,7 +1038,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
             return renderPickerTrigger({
                 displayText,
                 mobileText:
-                    isMobile && useDrawerOnMobile
+                    isMobile && useDrawer
                         ? formatMobileDateRange(displayRange)
                         : undefined,
                 displayRange,
@@ -973,7 +1050,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                 hasQuickSelector: showPresets,
                 triggerConfig,
                 triggerElement,
-                isMobileDrawer: isMobile && useDrawerOnMobile,
+                isMobileDrawer: isMobile && useDrawer,
                 onToggle: () => setIsOpen(!isOpen),
                 onMobileOpen: () => setDrawerOpen(true),
                 ariaLabel: `Date range picker, ${displayText || 'Select date range'}`,
@@ -981,7 +1058,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
             })
         }
 
-        if (isMobile && useDrawerOnMobile) {
+        if (isMobile && useDrawer) {
             const getMobilePresets = () => {
                 const presetsWithCustom = [...availablePresets]
                 if (!presetsWithCustom.includes(DateRangePreset.CUSTOM)) {
@@ -1101,6 +1178,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                     }
                     sideOffset={popoverConfig?.sideOffset ?? 4}
                     shadow="sm"
+                    useDrawerOnMobile={useDrawer}
                 >
                     <Block
                         style={{
@@ -1111,7 +1189,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                         flexDirection="column"
                         overflow="hidden"
                     >
-                        {showDateInput && (
+                        {showDateInputs && (
                             <DateInputsSection
                                 startDate={startDate}
                                 endDate={endDate}
@@ -1160,6 +1238,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                             minDate={minDate}
                             maxDate={maxDate}
                             maxRangeDays={maxRangeDays}
+                            granularity={granularity}
                         />
 
                         <FooterControls

--- a/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/blend/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -1163,7 +1163,6 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>(
                 <PopoverV2
                     key={popoverKey}
                     open={isOpen}
-                    useDrawerOnMobile={useDrawerOnMobile}
                     onOpenChange={(open) => {
                         setIsOpen(open)
                     }}

--- a/packages/blend/lib/components/DateRangePicker/types.ts
+++ b/packages/blend/lib/components/DateRangePicker/types.ts
@@ -323,6 +323,27 @@ export type DateRangePickerProps = {
     maxDate?: Date
     maxRangeDays?: number
     dateFormat?: string
+    /**
+     * Selection resolution. `'day'` (the default) is the original behaviour and
+     * is untouched by this prop's existence.
+     *
+     * `'month'` swaps the day calendar for a month grid with year navigation
+     * and selects a **month range**: `startDate` becomes the first day of the
+     * start month and `endDate` the last day of the end month, both at local
+     * midnight — the same midnight convention a day-granularity range uses.
+     * `minDate` / `maxDate` are compared at month resolution, so a `minDate`
+     * half-way through September still leaves September selectable.
+     *
+     * Month mode also suppresses three surfaces that only have day semantics,
+     * regardless of what you pass: the preset quick-selector (`showPresets`),
+     * the free-text DD/MM/YYYY start/end inputs (`showDateInput`) and the
+     * mobile drawer (`useDrawerOnMobile`), whose scroll-wheel picker has no
+     * month-range mode. The desktop popover renders on mobile instead.
+     *
+     * Mirrors `SingleDatePicker`'s `granularity`, which additionally supports
+     * `'year'`; a year *range* has no consumer and is deliberately absent here.
+     */
+    granularity?: 'day' | 'month'
     allowSingleDateSelection?: boolean
     isSingleDatePicker?: boolean
     disableFutureDates?: boolean

--- a/packages/blend/lib/components/SingleDatePicker/SingleDatePicker.tsx
+++ b/packages/blend/lib/components/SingleDatePicker/SingleDatePicker.tsx
@@ -15,6 +15,8 @@ import Popover from '../Popover/Popover'
 import Button from '../Button/Button'
 import { ButtonSize, ButtonType } from '../Button/types'
 import CalendarGrid from '../DateRangePicker/CalendarGrid'
+import MonthYearGrid from '../shared/datetime/MonthYearGrid'
+import { startOfPeriod } from '../shared/datetime/granularity'
 import { DateRangePickerSize, type DateRange } from '../DateRangePicker/types'
 import type { CalendarTokenType } from '../DateRangePicker/dateRangePicker.tokens'
 import {
@@ -65,7 +67,40 @@ import type { SingleDatePickerProps } from './singleDatePicker.types'
  * time section *and the error message* come from `TIME_PICKER`, shared with
  * `TimePicker` — overriding that slot restyles this component's error text and
  * time columns too. There is deliberately no `SINGLE_DATE_PICKER` slot.
+ *
+ * `granularity` swaps only the selection surface: `'month'` and `'year'` render
+ * `MonthYearGrid` in place of `CalendarGrid` and normalise the committed value
+ * to the period's first day. Everything else — the draft/Apply model, the
+ * trigger, the optional time section, clearing — is shared with day mode, and
+ * day mode itself takes no new branches.
  */
+/**
+ * Day granularity keeps every historical default verbatim. The coarser modes
+ * pick a pattern `formatDate` can actually render — it substitutes `dd`, `MM`,
+ * `yyyy`, `HH` and `mm` and has no month-name token — plus a matching
+ * placeholder and in-popover label.
+ */
+const GRANULARITY_DEFAULTS = {
+    day: {
+        dateFormat: 'dd/MM/yyyy',
+        placeholder: 'Select date',
+        label: 'Date',
+        ariaLabel: 'Choose date',
+    },
+    month: {
+        dateFormat: 'MM/yyyy',
+        placeholder: 'Select month',
+        label: 'Month',
+        ariaLabel: 'Choose month',
+    },
+    year: {
+        dateFormat: 'yyyy',
+        placeholder: 'Select year',
+        label: 'Year',
+        ariaLabel: 'Choose year',
+    },
+} as const
+
 const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
     (
         {
@@ -73,14 +108,15 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
             onChange,
             minDate,
             maxDate,
+            granularity = 'day',
             disableDates,
             showTime = false,
             timeFormat = '12h',
             showSeconds = false,
             timezone,
-            dateFormat = 'dd/MM/yyyy',
+            dateFormat,
             formatConfig,
-            placeholder = 'Select date',
+            placeholder,
             disabled = false,
             error = false,
             errorMessage,
@@ -95,6 +131,13 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
         const { foundationTokens } = useTheme()
         const timePickerToken =
             useResponsiveTokens<TimePickerTokensType>('TIME_PICKER')
+
+        const granularityDefaults = GRANULARITY_DEFAULTS[granularity]
+        const isDayGranularity = granularity === 'day'
+        const showTimeForGranularity = showTime && isDayGranularity
+        const resolvedDateFormat = dateFormat ?? granularityDefaults.dateFormat
+        const resolvedPlaceholder =
+            placeholder ?? granularityDefaults.placeholder
 
         const [isOpen, setIsOpen] = useState(false)
         // Bumped on every close so `CalendarGrid` re-derives its scroll offset
@@ -168,10 +211,12 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
             () =>
                 formatConfig && {
                     ...formatConfig,
-                    includeTime: formatConfig.includeTime ?? showTime,
+                    includeTime:
+                        isDayGranularity &&
+                        (formatConfig.includeTime ?? showTime),
                     timeFormat: formatConfig.timeFormat ?? timeFormat,
                 },
-            [formatConfig, showTime, timeFormat]
+            [formatConfig, isDayGranularity, showTime, timeFormat]
         )
 
         // Without a `formatConfig` the trigger uses the same `dateFormat` as
@@ -182,12 +227,12 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                   displayRange,
                   resolvedFormatConfig,
                   true,
-                  placeholder,
+                  resolvedPlaceholder,
                   timezone
               )
             : committedDate
-              ? `${formatDate(committedDate, dateFormat, timezone)}${
-                    showTime
+              ? `${formatDate(committedDate, resolvedDateFormat, timezone)}${
+                    showTimeForGranularity
                         ? ` ${formatTimeValue(
                               timeValueFromDate(committedDate, timezone),
                               {
@@ -197,7 +242,7 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                           )}`
                         : ''
                 }`
-              : placeholder
+              : resolvedPlaceholder
 
         // `minDate` / `maxDate` bound the *day* in the calendar; on the boundary
         // day they also bound the selectable time, otherwise the time columns
@@ -220,9 +265,17 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
 
         const handleDateSelect = useCallback(
             (range: DateRange) => {
-                const picked = range.startDate
+                // A no-op for day granularity; for month/year it is what makes
+                // the committed value the period's first day rather than
+                // whatever day the grid happened to build its cell from.
+                const picked = startOfPeriod(range.startDate, granularity)
 
-                if (!showTime) {
+                if (!showTimeForGranularity) {
+                    if (!isDayGranularity) {
+                        setDraftDate(picked)
+                        return
+                    }
+
                     // CalendarGrid returns start-of-day. When minDate/maxDate
                     // carry a time-of-day on this same day, midnight would sit
                     // outside the caller's range, so clamp here as well.
@@ -257,7 +310,14 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                     )
                 )
             },
-            [showTime, draftDate, timeBoundsFor, timezone]
+            [
+                showTimeForGranularity,
+                isDayGranularity,
+                draftDate,
+                timeBoundsFor,
+                timezone,
+                granularity,
+            ]
         )
 
         const handleTimeChange = useCallback(
@@ -298,10 +358,21 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
 
         const handleApply = useCallback(() => {
             if (!draftDate) return
-            if (!isControlled) setInternalDate(draftDate)
-            onChange?.(draftDate)
-            closeAndReset(isControlled ? committedDate : draftDate)
-        }, [draftDate, isControlled, committedDate, onChange, closeAndReset])
+            const valueToApply = isDayGranularity
+                ? draftDate
+                : startOfPeriod(draftDate, granularity)
+            if (!isControlled) setInternalDate(valueToApply)
+            onChange?.(valueToApply)
+            closeAndReset(isControlled ? committedDate : valueToApply)
+        }, [
+            draftDate,
+            granularity,
+            isDayGranularity,
+            isControlled,
+            committedDate,
+            onChange,
+            closeAndReset,
+        ])
 
         const handleCancel = useCallback(() => {
             closeAndReset(committedDate)
@@ -395,7 +466,7 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                          */}
                         <Block
                             role="group"
-                            aria-label="Choose date"
+                            aria-label={granularityDefaults.ariaLabel}
                             style={{ ...calendarToken.calendar }}
                             maxHeight="var(--radix-popper-available-height)"
                             display="flex"
@@ -431,7 +502,7 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                                             ?.dateInput?.label?.fontWeight
                                     }
                                 >
-                                    Date
+                                    {granularityDefaults.label}
                                 </PrimitiveText>
                                 <PrimitiveText
                                     as="span"
@@ -448,29 +519,49 @@ const SingleDatePicker = forwardRef<HTMLDivElement, SingleDatePickerProps>(
                                     {draftDate
                                         ? formatDate(
                                               draftDate,
-                                              dateFormat,
+                                              resolvedDateFormat,
                                               timezone
                                           )
-                                        : placeholder}
+                                        : resolvedPlaceholder}
                                 </PrimitiveText>
                             </Block>
 
                             <Block flexGrow={1} minHeight={0} overflow="auto">
-                                <CalendarGrid
-                                    selectedRange={draftRange}
-                                    onDateSelect={handleDateSelect}
-                                    today={today}
-                                    customDisableDates={disableDates}
-                                    showDateTimePicker={showTime}
-                                    resetScrollPosition={popoverKey}
-                                    timezone={timezone}
-                                    isSingleDatePicker
-                                    minDate={minDate}
-                                    maxDate={maxDate}
-                                />
+                                {granularity === 'day' ? (
+                                    <CalendarGrid
+                                        selectedRange={draftRange}
+                                        onDateSelect={handleDateSelect}
+                                        today={today}
+                                        customDisableDates={disableDates}
+                                        showDateTimePicker={
+                                            showTimeForGranularity
+                                        }
+                                        resetScrollPosition={popoverKey}
+                                        timezone={timezone}
+                                        isSingleDatePicker
+                                        minDate={minDate}
+                                        maxDate={maxDate}
+                                    />
+                                ) : (
+                                    <MonthYearGrid
+                                        granularity={granularity}
+                                        selectedRange={draftRange}
+                                        onSelect={(periodStart) =>
+                                            handleDateSelect({
+                                                startDate: periodStart,
+                                            })
+                                        }
+                                        today={today}
+                                        timezone={timezone}
+                                        customDisableDates={disableDates}
+                                        resetScrollPosition={popoverKey}
+                                        minDate={minDate}
+                                        maxDate={maxDate}
+                                    />
+                                )}
                             </Block>
 
-                            {showTime && (
+                            {showTimeForGranularity && (
                                 <Block
                                     display="flex"
                                     flexDirection="column"

--- a/packages/blend/lib/components/SingleDatePicker/singleDatePicker.types.ts
+++ b/packages/blend/lib/components/SingleDatePicker/singleDatePicker.types.ts
@@ -4,6 +4,14 @@ import type {
     DateRangePickerSize,
     TriggerConfig,
 } from '../DateRangePicker/types'
+import type { PickerGranularity } from '../shared/datetime/granularity'
+
+// Re-exported the way `timePicker.types.ts` re-exports `TimeValue`, so a
+// consumer can name the type of the `granularity` prop they are passing.
+export type {
+    PickerGranularity,
+    RangePickerGranularity,
+} from '../shared/datetime/granularity'
 
 /**
  * Props for `SingleDatePicker`.
@@ -27,9 +35,26 @@ export type SingleDatePickerProps = {
     onChange?: (date: Date | undefined) => void
     minDate?: Date
     maxDate?: Date
+    /**
+     * Selection resolution. `'day'` (the default) is the original behaviour and
+     * is untouched by this prop's existence.
+     *
+     * `'month'` swaps the day calendar for a 12-cell month grid with year
+     * navigation and returns the **first day of the selected month** at local
+     * midnight; `'year'` renders a year grid and returns **1 January** of the
+     * selected year. `minDate` / `maxDate` are compared at the same resolution,
+     * so a `minDate` half-way through September still leaves September (or
+     * 2025) selectable.
+     *
+     * `dateFormat` and `placeholder` pick granularity-appropriate defaults
+     * (`'MM/yyyy'` / "Select month", `'yyyy'` / "Select year") unless you set
+     * them. `disableDates` is called with the period's first day, not with
+     * every day inside it.
+     */
+    granularity?: PickerGranularity
     /** Per-date predicate; disabled days are unclickable in the calendar. */
     disableDates?: (date: Date) => boolean
-    /** Renders a time selector below the calendar. */
+    /** Renders a time selector below the day calendar; ignored for month/year. */
     showTime?: boolean
     /** Display-only; the stored value is always a 24-hour `Date`. */
     timeFormat?: '12h' | '24h'
@@ -39,11 +64,12 @@ export type SingleDatePickerProps = {
      * "today" and the trigger's formatting.
      */
     timezone?: string
+    /** Defaults to `'dd/MM/yyyy'`, or a granularity-appropriate pattern. */
     dateFormat?: string
     /**
      * Richer trigger formatting, replacing `dateFormat`.
      *
-     * Precedence: the component-level time props seed it, and anything set
+     * Precedence: in day mode, the component-level time props seed it, and anything set
      * explicitly on the config wins — `includeTime` defaults to `showTime` and
      * `timeFormat` defaults to the `timeFormat` prop, so a picker with
      * `showTime` shows that time in the trigger without restating it here.

--- a/packages/blend/lib/components/shared/datetime/MonthYearGrid.tsx
+++ b/packages/blend/lib/components/shared/datetime/MonthYearGrid.tsx
@@ -1,0 +1,568 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import styled, { CSSObject } from 'styled-components'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import Block from '../../Primitives/Block/Block'
+import PrimitiveButton from '../../Primitives/PrimitiveButton/PrimitiveButton'
+import type { CalendarTokenType } from '../../DateRangePicker/dateRangePicker.tokens'
+import type {
+    CustomDateDisableFunction,
+    DateRange,
+} from '../../DateRangePicker/types'
+import {
+    calculateDayCellProps,
+    getMonthName,
+} from '../../DateRangePicker/utils'
+import { DATE_RANGE_PICKER_CONSTANTS } from '../../DateRangePicker/constants'
+import { useResponsiveTokens } from '../../../hooks/useResponsiveTokens'
+import { FOUNDATION_THEME } from '../../../tokens'
+import {
+    normalizeRangeToPeriodStarts,
+    startOfPeriod,
+    type PickerGranularity,
+} from './granularity'
+
+/**
+ * The month and year selection surfaces behind `granularity="month"` and
+ * `granularity="year"`.
+ *
+ * Note on the brief this was built from: the repo had **no** existing month or
+ * year grid to promote. `CalendarGrid` is a continuously scrolling, virtualised
+ * list of months whose month headers are static text with no click target, and
+ * the only month/year *selection* UI anywhere was `ScrollablePicker`, a
+ * mobile-only scroll wheel. So this grid is new — but it is not a fork: every
+ * cell's state and styling comes from `calculateDayCellProps`, the same
+ * function that styles `CalendarGrid`'s day cells, fed period-start dates. A
+ * selected month therefore renders with the identical pill, an interior month
+ * of a range with the identical range fill, and the current month with the
+ * identical today dot.
+ *
+ * Day granularity never reaches this file.
+ */
+export type MonthYearGridProps = {
+    /** `'month'` renders 12 month cells plus year navigation; `'year'` a year grid. */
+    granularity: Exclude<PickerGranularity, 'day'>
+    /**
+     * The draft selection. Both ends are collapsed onto their period starts
+     * before matching, so a month range committed as 1 Sep → 30 Sep still
+     * highlights September as a single cell.
+     */
+    selectedRange: DateRange | undefined
+    /** Receives the first day of the clicked period, at local midnight. */
+    onSelect: (periodStart: Date) => void
+    today: Date
+    /**
+     * Range mode draws start/end caps and an interior fill; otherwise a single
+     * selected cell is drawn as a pill.
+     */
+    isRange?: boolean
+    /**
+     * Bounds are compared at period resolution, so a `minDate` of 15 Sep leaves
+     * September selectable in month mode — the useful reading for billing
+     * periods, where the month containing the boundary is still a valid month.
+     */
+    minDate?: Date
+    maxDate?: Date
+    timezone?: string
+    disableFutureDates?: boolean
+    disablePastDates?: boolean
+    hideFutureDates?: boolean
+    hidePastDates?: boolean
+    /** Called with the period's first day, not with every day inside it. */
+    customDisableDates?: CustomDateDisableFunction
+    /** Bumped by the pickers on close so the view re-derives from the selection. */
+    resetScrollPosition?: number
+    maxYearOffset?: number
+}
+
+const COLUMNS = 4
+const CONTAINER_HEIGHT = DATE_RANGE_PICKER_CONSTANTS.CALENDAR_CONTAINER_HEIGHT
+
+/**
+ * Mirrors `CalendarGrid`'s `StyledDayCell` so hover and focus rings match the
+ * day grid exactly. `$cellStyles` is whatever `calculateDayCellProps` returned.
+ */
+const StyledPeriodCell = styled(Block)<{
+    $cellStyles: CSSObject
+    $textColor: string
+    $isDisabled: boolean
+    $calendarToken: CalendarTokenType
+}>`
+    ${(props) => props.$cellStyles}
+    color: ${(props) => props.$textColor};
+    cursor: ${(props) => (props.$isDisabled ? 'not-allowed' : 'pointer')};
+    position: relative;
+
+    ${(props) =>
+        !props.$isDisabled &&
+        `
+    &:hover:not(:focus-visible) {
+      outline: ${props.$calendarToken.calendar.calendarGrid.day.cell.border.hover};
+      outline-offset: -1px;
+      border-radius: ${props.$calendarToken.calendar.calendarGrid.day.cell.borderRadius};
+      z-index: 1;
+    }
+  `}
+
+    ${(props) =>
+        !props.$isDisabled &&
+        `
+    &:focus-visible {
+      outline: 1px solid ${FOUNDATION_THEME.colors.primary[500]};
+      border-radius: ${props.$calendarToken.calendar.calendarGrid.day.cell.borderRadius};
+    }
+  `}
+`
+
+const NavButton = styled(PrimitiveButton)<{ $color: string }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: ${FOUNDATION_THEME.border.radius[4]};
+    width: ${FOUNDATION_THEME.unit[32]};
+    height: ${FOUNDATION_THEME.unit[32]};
+    padding: ${FOUNDATION_THEME.unit[8]};
+    color: ${(props) => props.$color};
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+        background: ${FOUNDATION_THEME.colors.gray[50]};
+    }
+
+    &:active:not(:disabled) {
+        background: ${FOUNDATION_THEME.colors.gray[100]};
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: ${FOUNDATION_THEME.shadows.focusPrimary};
+    }
+`
+
+const MonthYearGrid = ({
+    granularity,
+    selectedRange,
+    onSelect,
+    today,
+    isRange = false,
+    minDate,
+    maxDate,
+    timezone,
+    disableFutureDates = false,
+    disablePastDates = false,
+    hideFutureDates = false,
+    hidePastDates = false,
+    customDisableDates,
+    resetScrollPosition,
+    maxYearOffset,
+}: MonthYearGridProps) => {
+    const calendarToken = useResponsiveTokens<CalendarTokenType>('CALENDAR')
+    const cellsRef = useRef<HTMLDivElement[]>([])
+    const selectedCellRef = useRef<HTMLDivElement | null>(null)
+
+    const minYear = DATE_RANGE_PICKER_CONSTANTS.MIN_YEAR
+    const maxYear =
+        today.getFullYear() +
+        (maxYearOffset !== undefined && maxYearOffset >= 0
+            ? maxYearOffset
+            : DATE_RANGE_PICKER_CONSTANTS.MAX_YEAR_OFFSET)
+
+    // Every date the grid compares against is collapsed to the same resolution
+    // as the cells themselves, so `calculateDayCellProps` — which compares
+    // whole days — answers month and year questions correctly.
+    const displayRange = useMemo(
+        () => normalizeRangeToPeriodStarts(selectedRange, granularity),
+        [selectedRange, granularity]
+    )
+    const periodToday = useMemo(
+        () => startOfPeriod(today, granularity),
+        [today, granularity]
+    )
+    const periodMinDate = useMemo(
+        () => (minDate ? startOfPeriod(minDate, granularity) : undefined),
+        [minDate, granularity]
+    )
+    const periodMaxDate = useMemo(
+        () => (maxDate ? startOfPeriod(maxDate, granularity) : undefined),
+        [maxDate, granularity]
+    )
+
+    const anchorYear = (displayRange?.startDate ?? today).getFullYear()
+    const [viewYear, setViewYear] = useState(anchorYear)
+
+    // Reopening the popover must show the year the current selection lives in,
+    // not wherever the user browsed to before closing — same contract as
+    // `CalendarGrid`'s scroll reset.
+    useEffect(() => {
+        setViewYear(anchorYear)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [resetScrollPosition])
+
+    const cells = useMemo(() => {
+        if (granularity === 'month') {
+            return Array.from({ length: 12 }, (_, month) => ({
+                date: new Date(viewYear, month, 1),
+                label: getMonthName(month).slice(0, 3),
+                fullLabel: `${getMonthName(month)} ${viewYear}`,
+                id: `${viewYear}-${month}`,
+            }))
+        }
+        return Array.from({ length: maxYear - minYear + 1 }, (_, index) => {
+            const year = minYear + index
+            return {
+                date: new Date(year, 0, 1),
+                label: String(year),
+                fullLabel: String(year),
+                id: String(year),
+            }
+        })
+    }, [granularity, viewYear, minYear, maxYear])
+
+    const visibleCells = useMemo(
+        () =>
+            cells.filter(({ date }) => {
+                const period = startOfPeriod(date, granularity)
+                return (
+                    !(hideFutureDates && period > periodToday) &&
+                    !(hidePastDates && period < periodToday)
+                )
+            }),
+        [cells, granularity, hideFutureDates, hidePastDates, periodToday]
+    )
+
+    useEffect(() => {
+        cellsRef.current = cellsRef.current.slice(0, visibleCells.length)
+    }, [visibleCells.length])
+
+    // The year grid spans ~a century, so bring the selection into view the way
+    // `CalendarGrid` scrolls to the selected month.
+    useEffect(() => {
+        const cell = selectedCellRef.current
+        if (granularity !== 'year' || !cell) return
+        if (typeof cell.scrollIntoView !== 'function') return
+        cell.scrollIntoView({ block: 'center' })
+    }, [granularity, resetScrollPosition])
+
+    const handleKeyDown = useCallback(
+        (
+            e: React.KeyboardEvent<HTMLElement>,
+            index: number,
+            date: Date,
+            isDisabled: boolean
+        ) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                if (!isDisabled) onSelect(date)
+                return
+            }
+
+            const step: Record<string, number> = {
+                ArrowLeft: -1,
+                ArrowRight: 1,
+                ArrowUp: -COLUMNS,
+                ArrowDown: COLUMNS,
+            }
+            const delta = step[e.key]
+            if (delta === undefined) return
+
+            e.preventDefault()
+            e.stopPropagation()
+            const next = cellsRef.current[index + delta]
+            if (next && next.getAttribute('aria-disabled') !== 'true') {
+                next.focus()
+            }
+        },
+        [onSelect]
+    )
+
+    const navigationMinYear = Math.max(
+        minYear,
+        hidePastDates ? today.getFullYear() : minYear
+    )
+    const navigationMaxYear = Math.min(
+        maxYear,
+        hideFutureDates ? today.getFullYear() : maxYear
+    )
+    const canGoPrevYear = viewYear > navigationMinYear
+    const canGoNextYear = viewYear < navigationMaxYear
+
+    const cellEntries = visibleCells.map((cell) => {
+        const cellProps = calculateDayCellProps(
+            cell.date,
+            displayRange,
+            periodToday,
+            disableFutureDates,
+            disablePastDates,
+            calendarToken,
+            customDisableDates,
+            timezone,
+            !isRange,
+            periodMinDate,
+            periodMaxDate
+        )
+        const isSelected =
+            cellProps.dateStates.isStart ||
+            cellProps.dateStates.isEnd ||
+            cellProps.dateStates.isSingleDate
+        const isDisabled = cellProps.dateStates.isDisabled
+
+        return {
+            cell,
+            cellProps,
+            isSelected,
+            isDisabled,
+            isYearAnchor:
+                granularity === 'year' &&
+                !displayRange &&
+                !isDisabled &&
+                cell.date.getFullYear() === periodToday.getFullYear(),
+        }
+    })
+
+    const selectedIndex = cellEntries.findIndex(
+        (entry) => entry.isSelected && !entry.isDisabled
+    )
+    const anchorIndex = cellEntries.findIndex((entry) => entry.isYearAnchor)
+    const firstEnabledIndex = cellEntries.findIndex(
+        (entry) => !entry.isDisabled
+    )
+    const focusableIndex =
+        selectedIndex >= 0
+            ? selectedIndex
+            : anchorIndex >= 0
+              ? anchorIndex
+              : firstEnabledIndex
+
+    return (
+        <Block
+            display="flex"
+            flexDirection="column"
+            data-element={granularity === 'month' ? 'month-grid' : 'year-grid'}
+        >
+            {granularity === 'month' && (
+                <Block
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    paddingX={
+                        calendarToken.calendar.calendarGrid.week.padding.x
+                    }
+                    paddingY={
+                        calendarToken.calendar.calendarGrid.month.header.padding
+                            .y
+                    }
+                >
+                    <NavButton
+                        type="button"
+                        aria-label="Previous year"
+                        disabled={!canGoPrevYear}
+                        onClick={() =>
+                            canGoPrevYear && setViewYear(viewYear - 1)
+                        }
+                        $color={
+                            calendarToken.calendar.calendarGrid.month.header
+                                .color as string
+                        }
+                    >
+                        <ChevronLeft size={16} />
+                    </NavButton>
+                    <Block
+                        aria-live="polite"
+                        data-element="month-year"
+                        data-id={String(viewYear)}
+                        style={{
+                            fontSize:
+                                calendarToken.calendar.calendarGrid.month.header
+                                    .fontSize,
+                            fontWeight:
+                                calendarToken.calendar.calendarGrid.month.header
+                                    .fontWeight,
+                            color: calendarToken.calendar.calendarGrid.month
+                                .header.color,
+                        }}
+                    >
+                        {viewYear}
+                    </Block>
+                    <NavButton
+                        type="button"
+                        aria-label="Next year"
+                        disabled={!canGoNextYear}
+                        onClick={() =>
+                            canGoNextYear && setViewYear(viewYear + 1)
+                        }
+                        $color={
+                            calendarToken.calendar.calendarGrid.month.header
+                                .color as string
+                        }
+                    >
+                        <ChevronRight size={16} />
+                    </NavButton>
+                </Block>
+            )}
+
+            <Block
+                role="grid"
+                aria-label={
+                    granularity === 'month' ? 'Select month' : 'Select year'
+                }
+                style={{
+                    display: 'grid',
+                    rowGap: calendarToken.calendar.calendarGrid.week.gap,
+                    padding: `${calendarToken.calendar.calendarGrid.week.padding.y} ${calendarToken.calendar.calendarGrid.week.padding.x}`,
+                    maxHeight: CONTAINER_HEIGHT,
+                    overflowY: granularity === 'year' ? 'auto' : 'visible',
+                }}
+            >
+                {Array.from(
+                    { length: Math.ceil(cellEntries.length / COLUMNS) },
+                    (_, rowIndex) => (
+                        <Block
+                            key={`row-${rowIndex}`}
+                            role="row"
+                            style={{
+                                display: 'grid',
+                                gridTemplateColumns: `repeat(${COLUMNS}, 1fr)`,
+                                gap: calendarToken.calendar.calendarGrid.week
+                                    .row.gap,
+                            }}
+                        >
+                            {cellEntries
+                                .slice(
+                                    rowIndex * COLUMNS,
+                                    (rowIndex + 1) * COLUMNS
+                                )
+                                .map((entry, rowCellIndex) => {
+                                    const index =
+                                        rowIndex * COLUMNS + rowCellIndex
+                                    const {
+                                        cell,
+                                        cellProps,
+                                        isSelected,
+                                        isDisabled,
+                                        isYearAnchor,
+                                    } = entry
+
+                                    return (
+                                        <StyledPeriodCell
+                                            key={cell.id}
+                                            ref={(
+                                                el: HTMLDivElement | null
+                                            ) => {
+                                                if (!el) return
+                                                cellsRef.current[index] = el
+                                                if (
+                                                    (isSelected &&
+                                                        !isDisabled) ||
+                                                    isYearAnchor
+                                                ) {
+                                                    selectedCellRef.current = el
+                                                }
+                                            }}
+                                            $cellStyles={
+                                                cellProps.styles as CSSObject
+                                            }
+                                            $textColor={String(
+                                                cellProps.textColor || ''
+                                            )}
+                                            $isDisabled={isDisabled}
+                                            $calendarToken={calendarToken}
+                                            role="gridcell"
+                                            tabIndex={
+                                                isDisabled
+                                                    ? -1
+                                                    : index === focusableIndex
+                                                      ? 0
+                                                      : -1
+                                            }
+                                            aria-label={`${cell.fullLabel}${isSelected ? ', selected' : ''}${cellProps.dateStates.isTodayDay ? ', today' : ''}${isDisabled ? ', disabled' : ''}`}
+                                            aria-selected={isSelected}
+                                            aria-disabled={isDisabled}
+                                            onClick={() =>
+                                                !isDisabled &&
+                                                onSelect(cell.date)
+                                            }
+                                            onKeyDown={(
+                                                e: React.KeyboardEvent<HTMLElement>
+                                            ) =>
+                                                handleKeyDown(
+                                                    e,
+                                                    index,
+                                                    cell.date,
+                                                    isDisabled
+                                                )
+                                            }
+                                            data-element={
+                                                granularity === 'month'
+                                                    ? 'months'
+                                                    : 'years'
+                                            }
+                                            data-id={cell.id}
+                                            data-state={
+                                                isSelected
+                                                    ? 'selected'
+                                                    : 'not selected'
+                                            }
+                                            data-status={
+                                                isDisabled
+                                                    ? 'disabled'
+                                                    : 'enabled'
+                                            }
+                                        >
+                                            <span
+                                                style={{
+                                                    display: 'inline-block',
+                                                    textAlign: 'center',
+                                                }}
+                                            >
+                                                {cell.label}
+                                            </span>
+                                            {cellProps.showTodayIndicator && (
+                                                <Block
+                                                    style={{
+                                                        width: calendarToken
+                                                            .calendar
+                                                            .calendarGrid.day
+                                                            .todayIndicator
+                                                            .width,
+                                                        height: calendarToken
+                                                            .calendar
+                                                            .calendarGrid.day
+                                                            .todayIndicator
+                                                            .width,
+                                                        backgroundColor:
+                                                            calendarToken
+                                                                .calendar
+                                                                .calendarGrid
+                                                                .day
+                                                                .todayIndicator
+                                                                .backgroundColor,
+                                                        borderRadius: '50%',
+                                                        position: 'absolute',
+                                                        bottom: FOUNDATION_THEME
+                                                            .unit[2],
+                                                        left: '50%',
+                                                        transform:
+                                                            'translateX(-50%)',
+                                                    }}
+                                                />
+                                            )}
+                                        </StyledPeriodCell>
+                                    )
+                                })}
+                        </Block>
+                    )
+                )}
+            </Block>
+        </Block>
+    )
+}
+
+MonthYearGrid.displayName = 'MonthYearGrid'
+
+export default MonthYearGrid

--- a/packages/blend/lib/components/shared/datetime/granularity.ts
+++ b/packages/blend/lib/components/shared/datetime/granularity.ts
@@ -1,0 +1,122 @@
+import type { DateRange } from '../../DateRangePicker/types'
+
+/**
+ * Selection granularity shared by `SingleDatePicker` and `DateRangePicker`.
+ *
+ * `'day'` is the historical behaviour and the default everywhere: nothing in
+ * this module runs for it, so day pickers keep returning exactly the `Date`
+ * `CalendarGrid` produced. The coarser modes normalise the returned `Date` to
+ * the *start of the selected period* (and, for a range's end, to the last day
+ * of the end period) so consumers never have to guess which day inside a month
+ * a "September 2025" selection stands for.
+ *
+ * All arithmetic is local-time, matching `CalendarGrid`, which builds its day
+ * cells with `new Date(year, month, day)`. Timezone only ever affects
+ * *display* in these components, never the constructed calendar date.
+ */
+export type PickerGranularity = 'day' | 'month' | 'year'
+
+/** `DateRangePicker` supports month ranges; a "year range" has no consumer. */
+export type RangePickerGranularity = 'day' | 'month'
+
+const isUsableDate = (date: Date | undefined): date is Date =>
+    date instanceof Date && !Number.isNaN(date.getTime())
+
+/** First day of `date`'s month, at local midnight. */
+export const startOfMonth = (date: Date): Date =>
+    isUsableDate(date)
+        ? new Date(date.getFullYear(), date.getMonth(), 1)
+        : new Date(NaN)
+
+/**
+ * Last day of `date`'s month, at local midnight.
+ *
+ * Day 0 of the following month is the previous month's last day, which also
+ * gives December the right answer (Dec → month index 12 rolls into January of
+ * the next year, day 0 walks back to Dec 31) and handles leap Februaries.
+ *
+ * Midnight, not 23:59:59, so a month range's end matches what a day-granularity
+ * range returns when the same last day is clicked in the calendar.
+ */
+export const endOfMonth = (date: Date): Date =>
+    isUsableDate(date)
+        ? new Date(date.getFullYear(), date.getMonth() + 1, 0)
+        : new Date(NaN)
+
+/** 1 January of `date`'s year, at local midnight. */
+export const startOfYear = (date: Date): Date =>
+    isUsableDate(date) ? new Date(date.getFullYear(), 0, 1) : new Date(NaN)
+
+/**
+ * The canonical `Date` for the period `date` falls in.
+ *
+ * This is the value the pickers hand back to `onChange` in the coarser modes,
+ * and also what the grid uses to decide whether a cell is selected — feeding
+ * both from one function is what keeps "what you clicked" and "what you get"
+ * in sync.
+ */
+export const startOfPeriod = (
+    date: Date,
+    granularity: PickerGranularity
+): Date => {
+    switch (granularity) {
+        case 'month':
+            return startOfMonth(date)
+        case 'year':
+            return startOfYear(date)
+        default:
+            return date
+    }
+}
+
+/**
+ * Collapses both ends of a range onto their period starts.
+ *
+ * Used for *rendering only*. A committed month range ends on the last day of
+ * its end month, but the grid draws one cell per month, so the end cap has to
+ * be matched against that month's first day or it would render as an interior
+ * range cell instead of an end cap.
+ */
+export const normalizeRangeToPeriodStarts = (
+    range: DateRange | undefined,
+    granularity: PickerGranularity
+): DateRange | undefined => {
+    if (!range || granularity === 'day') return range
+    return {
+        ...range,
+        startDate: startOfPeriod(range.startDate, granularity),
+        endDate: range.endDate
+            ? startOfPeriod(range.endDate, granularity)
+            : undefined,
+    }
+}
+
+/**
+ * Range accumulation for month granularity, mirroring the day-mode rules in
+ * `handleCalendarDateClick`: a click with no pending selection (or with a
+ * complete range) starts a new one, a later click closes it, and a click
+ * *before* the pending start restarts rather than swapping.
+ *
+ * `picked` is any date inside the clicked month.
+ */
+export const nextMonthRange = (
+    current: DateRange | undefined,
+    picked: Date
+): DateRange => {
+    const start = startOfMonth(picked)
+
+    if (!current || !current.startDate || current.endDate) {
+        return { startDate: start }
+    }
+
+    const pendingStart = startOfMonth(current.startDate)
+
+    if (start.getTime() < pendingStart.getTime()) {
+        return { startDate: start }
+    }
+
+    // `pendingStart`, not `current.startDate`: a caller can seed `value` with a
+    // half-open range whose start sits mid-month, and closing the range against
+    // it verbatim would commit a month range starting on the 10th.
+    return { startDate: pendingStart, endDate: endOfMonth(picked) }
+}


### PR DESCRIPTION
## Summary

- Add `granularity="month" | "year"` to `SingleDatePicker`, with month and year grids and period-start normalization.
- Add `granularity="month"` to `DateRangePicker`, returning the first day of the start month and last day of the end month.
- Add shared period math, accessible month/year grid keyboard navigation, stories, regression tests, and picker documentation.
- Preserve the existing day-granularity `CalendarGrid` path and day-only time behavior.

## Test Coverage

- Focused granularity suites: 4 files, 70 tests passed.
- Full Blend suite: 188 files passed, 16 skipped; 4,879 tests passed, 604 skipped.
- Accessibility suite: 91 files passed, 113 skipped; 2,581 tests passed, 2,902 skipped.

## Pre-Landing Review

Adversarial and design reviews found no unresolved P0/P1 issues. The review findings around timezone forwarding, empty-grid keyboard entry, disabled-cell focus, valid ARIA grid semantics, mobile routing, hidden date flags, non-day `showTime`, and current-period announcements were addressed before commit.

## Design Review

Design review complete: no unresolved medium or high findings. Navigation controls use the existing focus and interaction treatment, and the new grid reuses the established date-cell styling.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope check: CLEAN. The documentation-sync step added only picker documentation and the related repository guidance updates.

## Plan Completion

The requested picker granularity scope is complete. The older design plan’s intentionally deferred items are named-format token expansion (`MMMM`/`MMM`), new calendar token keys, a dedicated SingleDatePicker MDX page (which did not exist), planned named-format tests, and the repository-wide strict lint gate, which has unrelated existing failures.

## Verification Results

- `pnpm format:check` — passed.
- `pnpm build:blend` — passed; package lint reported 0 errors and `check:dist` passed.
- `pnpm check:circular` — passed.
- Repository-wide `pnpm lint` remains red on 258 unrelated errors and 73 warnings outside this diff.

## TODOS

No TODO items completed in this PR.

## Documentation

Date picker granularity

Updated `daterangepicker.mdx`, `packages/blend/README.md`, and `CLAUDE.md` to document the new picker capabilities and shared datetime internals.

## Test plan

- [x] Granularity unit and integration tests pass
- [x] Accessibility and axe checks pass
- [x] Full Blend test suite passes
- [x] Package build, formatting, and circular-dependency checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
