### PR TITLE
feat(charts): add funnel chart and tooltip formatters

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,19 @@
 # TODOS
 
+## Ship
+
+### Fix Button hover transition performance regression
+
+**What:** Investigate and fix the failing `Button Performance > Animation Performance > hover transitions are smooth` test.
+
+**Why:** The full Blend suite reports an intermittent performance regression, so the repository's performance baseline is not reliable.
+
+**Context:** `/ship` observed this pre-existing failure on branch `funnel-chart-and-tooltips` on 2026-08-06: `Performance test failed: 14.04ms > 14ms` in `packages/blend/__tests__/components/Button/Button.performance.test.tsx`. A later full run passed but still emitted performance-regression warnings for the same test. The branch does not modify the Button test or implementation; reproduce with `pnpm run test:run` from `packages/blend` and check the local performance baseline before changing code.
+
+**Effort:** M
+**Priority:** P0
+**Depends on:** None
+
 ## MultiSelect
 
 ### Remove legacy per-item selection callbacks

--- a/apps/storybook/stories/components/Charts/v1/Charts.stories.tsx
+++ b/apps/storybook/stories/components/Charts/v1/Charts.stories.tsx
@@ -140,11 +140,11 @@ const data = [
 \`\`\`
 
 ## Features
-- Multiple chart types (Line, Bar, Pie)
+- Multiple chart types (Line, Bar, Pie, Funnel)
 - Interactive legends with hover and click functionality
 - Customizable colors and styling
 - Flexible data structure supporting nested data points
-- Custom tooltips with detailed information
+- Custom tooltips with detailed information and formatter callbacks
 - Header slots for additional content
 - Responsive design with container queries
 - Legend positioning options (top, right)
@@ -446,6 +446,33 @@ const generateCategoryData = (): NewNestedDataPoint[] => [
     },
 ]
 
+const generateFunnelData = (): NewNestedDataPoint[] => [
+    {
+        name: 'Visited landing page',
+        data: {
+            visitors: { primary: { label: 'Visitors', val: 10000 } },
+        },
+    },
+    {
+        name: 'Started checkout',
+        data: {
+            visitors: { primary: { label: 'Visitors', val: 6200 } },
+        },
+    },
+    {
+        name: 'Entered payment details',
+        data: {
+            visitors: { primary: { label: 'Visitors', val: 4100 } },
+        },
+    },
+    {
+        name: 'Completed purchase',
+        data: {
+            visitors: { primary: { label: 'Visitors', val: 2750 } },
+        },
+    },
+]
+
 // Default story
 export const Default: Story = {
     render: () => (
@@ -617,6 +644,109 @@ export const PieChartExample: Story = {
         docs: {
             description: {
                 story: 'Pie chart showing proportional data distribution.',
+            },
+        },
+    },
+}
+
+// Funnel charts
+export const FunnelChartPreviousBase: Story = {
+    render: () => (
+        <div className="w-200 h-135">
+            <Charts
+                chartType={ChartType.FUNNEL}
+                data={generateFunnelData()}
+                funnelConfig={{ percentageBase: 'previous' }}
+                colors={[
+                    { key: 'Visited landing page', color: '#00C951' },
+                    { key: 'Started checkout', color: '#2B7FFF' },
+                    { key: 'Entered payment details', color: '#FF8904' },
+                    { key: 'Completed purchase', color: '#AD46FF' },
+                ]}
+                chartHeaderSlot={
+                    <span className="text-lg font-bold">
+                        Conversion Funnel · Previous Stage
+                    </span>
+                }
+            />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Conversion funnel with each stage showing drop-off relative to the immediately previous stage.',
+            },
+        },
+    },
+}
+
+export const FunnelChartFirstBase: Story = {
+    render: () => (
+        <div className="w-200 h-135">
+            <Charts
+                chartType={ChartType.FUNNEL}
+                data={generateFunnelData()}
+                funnelConfig={{ percentageBase: 'first' }}
+                colors={[
+                    { key: 'Visited landing page', color: '#00C951' },
+                    { key: 'Started checkout', color: '#2B7FFF' },
+                    { key: 'Entered payment details', color: '#FF8904' },
+                    { key: 'Completed purchase', color: '#AD46FF' },
+                ]}
+                chartHeaderSlot={
+                    <span className="text-lg font-bold">
+                        Conversion Funnel · First Stage
+                    </span>
+                }
+            />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Conversion funnel with each stage showing total drop-off relative to the first stage.',
+            },
+        },
+    },
+}
+
+export const CustomTooltipFormatter: Story = {
+    render: () => (
+        <div className="w-200 h-135">
+            <Charts
+                chartType={ChartType.LINE}
+                data={generateMonthlyData()}
+                tooltip={{
+                    labelFormatter: (axisValue) => `Period: ${axisValue}`,
+                    formatter: ({ seriesName, value, dataIndex }) => (
+                        <span
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: 2,
+                            }}
+                        >
+                            <span>
+                                {String(seriesName)} · point {dataIndex + 1}
+                            </span>
+                            <span>Value: {String(value)}</span>
+                        </span>
+                    ),
+                }}
+                xAxis={{ label: 'Month', show: true }}
+                yAxis={{ label: 'Amount', show: true }}
+                chartHeaderSlot={
+                    <span className="text-lg font-bold">
+                        Custom Multi-line Tooltip
+                    </span>
+                }
+            />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Customizes the existing tooltip chrome with a ReactNode formatter and a formatted header.',
             },
         },
     },

--- a/packages/blend/__tests__/components/Charts/Charts.accessibility.test.tsx
+++ b/packages/blend/__tests__/components/Charts/Charts.accessibility.test.tsx
@@ -76,13 +76,14 @@ describe('Charts Accessibility', () => {
             expect(results).toHaveNoViolations()
         })
 
-        it('meets WCAG standards for all chart types (Line, Bar, Pie, Scatter)', async () => {
+        it('meets WCAG standards for all chart types (Line, Bar, Pie, Scatter, Funnel)', async () => {
             const data = generateChartData()
             const chartTypes = [
                 ChartType.LINE,
                 ChartType.BAR,
                 ChartType.PIE,
                 ChartType.SCATTER,
+                ChartType.FUNNEL,
             ]
 
             for (const chartType of chartTypes) {

--- a/packages/blend/__tests__/components/Charts/Charts.tooltip.test.tsx
+++ b/packages/blend/__tests__/components/Charts/Charts.tooltip.test.tsx
@@ -4,10 +4,17 @@ import { render } from '../../test-utils'
 import { renderChart } from '../../../lib/components/Charts/renderChart'
 import { CustomTooltip } from '../../../lib/components/Charts/CustomTooltip'
 import {
+    calculateFunnelDropOff,
+    FunnelChart,
+    getFunnelStages,
+} from '../../../lib/components/Charts/FunnelChart'
+import {
     ChartType,
     NewNestedDataPoint,
+    TooltipConfig,
     TooltipContentProps,
 } from '../../../lib/components/Charts/types'
+import { DEFAULT_COLORS } from '../../../lib/components/Charts/utils'
 import { FOUNDATION_THEME } from '../../../lib/tokens'
 
 /**
@@ -22,6 +29,8 @@ vi.mock('recharts', async (importOriginal) => {
     const actual = await importOriginal<typeof import('recharts')>()
     const Passthrough = ({ children }: { children?: React.ReactNode }) =>
         React.createElement('div', null, children)
+    const MockLabelList = () =>
+        React.createElement('div', { 'data-testid': 'funnel-label-list' })
 
     const MockTooltip = ({
         content,
@@ -57,6 +66,8 @@ vi.mock('recharts', async (importOriginal) => {
         Area: Passthrough,
         Pie: Passthrough,
         Cell: Passthrough,
+        CartesianGrid: Passthrough,
+        LabelList: MockLabelList,
         Scatter: Passthrough,
         XAxis: Passthrough,
         YAxis: Passthrough,
@@ -77,6 +88,21 @@ const chartData: NewNestedDataPoint[] = [
             revenue: { primary: { label: 'Revenue', val: 3000 } },
             profit: { primary: { label: 'Profit', val: 1398 } },
         },
+    },
+]
+
+const funnelData: NewNestedDataPoint[] = [
+    {
+        name: 'Visited',
+        data: { visitors: { primary: { label: 'Visitors', val: 1000 } } },
+    },
+    {
+        name: 'Started',
+        data: { visitors: { primary: { label: 'Visitors', val: 500 } } },
+    },
+    {
+        name: 'Completed',
+        data: { visitors: { primary: { label: 'Visitors', val: 250 } } },
     },
 ]
 
@@ -248,6 +274,37 @@ describe('Charts tooltip.content', () => {
         expect(lastCallArg.chartType).toBe(ChartType.AREA)
     })
 
+    it('passes chartType=FUNNEL and funnel config to custom content', () => {
+        const contentSpy = createContentSpy()
+
+        render(
+            <svg>
+                {renderChart({
+                    ...baseRenderProps,
+                    chartType: ChartType.FUNNEL,
+                    data: funnelData,
+                    flattenedData: funnelData.map((item) => ({
+                        name: item.name,
+                        visitors: item.data.visitors.primary.val,
+                    })),
+                    lineKeys: ['visitors'],
+                    funnelConfig: {
+                        percentageBase: 'first',
+                        showLabels: false,
+                    },
+                    tooltip: { content: contentSpy },
+                })}
+            </svg>
+        )
+
+        expect(contentSpy).toHaveBeenCalled()
+        const lastCallArg = contentSpy.mock.calls.at(
+            -1
+        )?.[0] as unknown as Partial<TooltipContentProps>
+        expect(lastCallArg.chartType).toBe(ChartType.FUNNEL)
+        expect(lastCallArg.originalData).toBe(funnelData)
+    })
+
     it('renders default CustomTooltip as a JSX element when content is not provided', () => {
         // When no tooltip.content is given, CustomTooltip should be rendered
         // as <CustomTooltip {...mergedProps} /> (JSX), not a bare function call.
@@ -368,5 +425,255 @@ describe('Charts tooltip.content', () => {
                 },
             })
         expect(typeof renderer).toBe('function')
+    })
+
+    it('calculates funnel drop-off against the previous stage by default', () => {
+        const stages = getFunnelStages(
+            funnelData,
+            ['visitors'],
+            [{ key: 'visitors', color: '#4F46E5' }]
+        )
+
+        expect(stages.map((stage) => stage.dropOffPercentage)).toEqual([
+            0, 50, 50,
+        ])
+        expect(stages.map((stage) => stage.color)).toEqual([
+            '#4F46E5',
+            '#4F46E5',
+            '#4F46E5',
+        ])
+    })
+
+    it('calculates funnel drop-off against the first stage when configured', () => {
+        const stages = getFunnelStages(
+            funnelData,
+            ['visitors'],
+            [{ key: 'visitors', color: '#4F46E5' }],
+            'first'
+        )
+
+        expect(stages.map((stage) => stage.dropOffPercentage)).toEqual([
+            0, 50, 75,
+        ])
+    })
+
+    it('returns a finite drop-off for a zero comparison base', () => {
+        expect(calculateFunnelDropOff(0, 0)).toBe(0)
+        expect(calculateFunnelDropOff(10, 0)).toBe(0)
+        expect(getFunnelStages([], [], [])).toEqual([])
+    })
+
+    it('uses safe values and default token colors for malformed funnel data', () => {
+        const stages = getFunnelStages(
+            [
+                {
+                    name: 'Visited',
+                    data: {
+                        visitors: {
+                            primary: { label: 'Visitors', val: Number.NaN },
+                        },
+                    },
+                },
+                {
+                    name: 'Completed',
+                    data: {
+                        visitors: {
+                            primary: { label: 'Visitors', val: 25 },
+                        },
+                    },
+                },
+            ],
+            ['visitors'],
+            []
+        )
+
+        expect(stages.map((stage) => stage.value)).toEqual([0, 25])
+        expect(stages.map((stage) => stage.color)).toEqual([
+            DEFAULT_COLORS[0].color,
+            DEFAULT_COLORS[1].color,
+        ])
+        expect(
+            stages.every((stage) => Number.isFinite(stage.dropOffPercentage))
+        ).toBe(true)
+    })
+
+    it('supports disabling funnel labels and falls back from an invalid selected key', () => {
+        expect(
+            getFunnelStages(
+                funnelData,
+                ['missing'],
+                [{ key: 'visitors', color: '#4F46E5' }]
+            )[0].seriesKey
+        ).toBe('visitors')
+
+        const chartProps = {
+            data: funnelData,
+            selectedKeys: ['visitors'],
+            colors: [{ key: 'visitors', color: '#4F46E5' }],
+            hoveredKey: null,
+            setHoveredKey: () => {},
+        }
+        const withLabels = render(
+            <FunnelChart {...chartProps} funnelConfig={{ showLabels: true }} />
+        )
+        expect(withLabels.getByTestId('funnel-label-list')).toBeTruthy()
+        withLabels.unmount()
+
+        const withoutLabels = render(
+            <FunnelChart {...chartProps} funnelConfig={{ showLabels: false }} />
+        )
+        expect(withoutLabels.queryByTestId('funnel-label-list')).toBeNull()
+    })
+
+    it('renders formatter and labelFormatter output inside the default tooltip chrome', () => {
+        const formatter = vi.fn(
+            ({ seriesName, value, dataIndex, color, payload }) => (
+                <span data-testid="formatted-value">
+                    {`${seriesName}:${value}:${dataIndex}:${color}:${String(
+                        (payload as { name: string }).name
+                    )}`}
+                    <br />
+                    details
+                </span>
+            )
+        )
+        const labelFormatter = vi.fn((axisValue) => (
+            <span data-testid="formatted-label">Stage: {axisValue}</span>
+        ))
+        const formatterData: NewNestedDataPoint[] = [
+            {
+                name: 'Jan',
+                data: {
+                    revenue: { primary: { label: 'Revenue', val: 4000 } },
+                },
+            },
+        ]
+        const payload = [
+            {
+                dataKey: 'revenue',
+                name: 'Revenue',
+                value: 4000,
+                color: '#4F46E5',
+                payload: { name: 'Jan', revenue: 4000 },
+            },
+        ]
+
+        const { getByTestId } = render(
+            <CustomTooltip
+                active
+                payload={payload}
+                label="Jan"
+                hoveredKey={null}
+                originalData={formatterData}
+                setHoveredKey={() => {}}
+                chartType={ChartType.BAR}
+                selectedKeys={[]}
+                formatter={formatter}
+                labelFormatter={labelFormatter}
+            />
+        )
+
+        expect(formatter).toHaveBeenCalledWith({
+            seriesName: 'Revenue',
+            value: 4000,
+            dataIndex: 0,
+            color: '#4F46E5',
+            payload: { name: 'Jan', revenue: 4000 },
+        })
+        expect(labelFormatter).toHaveBeenCalledWith('Jan')
+        expect(getByTestId('formatted-label').textContent).toBe('Stage: Jan')
+        expect(getByTestId('formatted-value').textContent).toContain(
+            'Revenue:4000:0:#4F46E5:Jan'
+        )
+        expect(getByTestId('formatted-value').textContent).toContain('details')
+    })
+
+    it('applies formatter callbacks to line, pie, and scatter tooltip branches', () => {
+        const formatter = vi.fn(({ seriesName, value }) =>
+            React.createElement(
+                'span',
+                null,
+                `${String(seriesName)}:${String(value)}`
+            )
+        )
+        const labelFormatter = vi.fn((axisValue) => `Period: ${axisValue}`)
+
+        const branchProps = [
+            {
+                chartType: ChartType.LINE,
+                payload: [
+                    {
+                        dataKey: 'revenue',
+                        name: 'Revenue',
+                        value: 4000,
+                        color: '#4F46E5',
+                        payload: { name: 'Jan', revenue: 4000 },
+                    },
+                ],
+                hoveredKey: 'revenue',
+            },
+            {
+                chartType: ChartType.PIE,
+                payload: [
+                    {
+                        dataKey: 'revenue',
+                        name: 'revenue',
+                        value: 4000,
+                        color: '#4F46E5',
+                        payload: { name: 'revenue', fill: '#4F46E5' },
+                    },
+                ],
+                hoveredKey: 'revenue',
+            },
+            {
+                chartType: ChartType.SCATTER,
+                payload: [
+                    {
+                        dataKey: 'revenue',
+                        name: 'revenue',
+                        value: 4000,
+                        color: '#4F46E5',
+                        payload: {
+                            name: 'Jan',
+                            x: 1,
+                            y: 4000,
+                            fill: '#4F46E5',
+                        },
+                    },
+                ],
+                hoveredKey: 'revenue',
+            },
+        ] as const
+
+        branchProps.forEach(({ chartType, payload, hoveredKey }) => {
+            const view = render(
+                <CustomTooltip
+                    active
+                    payload={payload}
+                    label="Jan"
+                    hoveredKey={hoveredKey}
+                    originalData={chartData}
+                    setHoveredKey={() => {}}
+                    chartType={chartType}
+                    selectedKeys={['revenue']}
+                    formatter={formatter}
+                    labelFormatter={labelFormatter}
+                />
+            )
+            view.unmount()
+        })
+
+        expect(formatter).toHaveBeenCalledTimes(3)
+        expect(labelFormatter).toHaveBeenCalledTimes(3)
+    })
+
+    it('exposes the formatter API in TooltipConfig', () => {
+        const tooltipConfig: TooltipConfig = {
+            formatter: ({ value }) => `Value: ${String(value)}`,
+            labelFormatter: (axisValue) => `Stage: ${axisValue}`,
+        }
+
+        expect(tooltipConfig.formatter).toBeDefined()
+        expect(tooltipConfig.labelFormatter).toBeDefined()
     })
 })

--- a/packages/blend/lib/components/Charts/Charts.tsx
+++ b/packages/blend/lib/components/Charts/Charts.tsx
@@ -34,6 +34,7 @@ const Charts: React.FC<ChartsProps> = ({
     xAxis,
     yAxis,
     tooltip,
+    funnelConfig,
     noData,
     height = 400,
     showHeader = true,
@@ -453,6 +454,7 @@ const Charts: React.FC<ChartsProps> = ({
                                                                   : mergedYAxis.showLabel,
                                                       },
                                                       tooltip,
+                                                      funnelConfig,
                                                       noData,
                                                       onKeyClick:
                                                           handleLegendClick,
@@ -525,6 +527,7 @@ const Charts: React.FC<ChartsProps> = ({
                                                                   : mergedYAxis.showLabel,
                                                       },
                                                       tooltip,
+                                                      funnelConfig,
                                                       noData,
                                                       onKeyClick:
                                                           handleLegendClick,
@@ -771,6 +774,7 @@ const Charts: React.FC<ChartsProps> = ({
                                                                   : mergedYAxis.showLabel,
                                                       },
                                                       tooltip,
+                                                      funnelConfig,
                                                       noData,
                                                       onKeyClick:
                                                           handleLegendClick,
@@ -953,6 +957,7 @@ const Charts: React.FC<ChartsProps> = ({
                                                                   : mergedYAxis.showLabel,
                                                       },
                                                       tooltip,
+                                                      funnelConfig,
                                                       noData,
                                                       onKeyClick:
                                                           handleLegendClick,

--- a/packages/blend/lib/components/Charts/CoreChart.tsx
+++ b/packages/blend/lib/components/Charts/CoreChart.tsx
@@ -13,6 +13,7 @@ export const CoreChart: React.FC<CoreChartProps> = ({
     xAxis,
     yAxis,
     tooltip,
+    funnelConfig,
     height = '100%',
     width = '100%',
     isSmallScreen = false,
@@ -66,6 +67,7 @@ export const CoreChart: React.FC<CoreChartProps> = ({
                 xAxis,
                 yAxis,
                 tooltip,
+                funnelConfig,
                 lineSeriesKeys,
             })}
         </ResponsiveContainer>

--- a/packages/blend/lib/components/Charts/CustomTooltip.tsx
+++ b/packages/blend/lib/components/Charts/CustomTooltip.tsx
@@ -3,6 +3,7 @@ import {
     ChartType,
     CustomTooltipProps,
     NewNestedDataPoint,
+    TooltipFormatter,
     XAxisConfig,
     YAxisConfig,
 } from './types'
@@ -14,7 +15,7 @@ import {
 import { parseTimestamp } from './DateTimeFormatter'
 import Block from '../../components/Primitives/Block/Block'
 import Text from '../../components/Text/Text'
-import { useEffect, useRef } from 'react'
+import { ReactNode, useEffect, useRef } from 'react'
 
 import {
     Payload,
@@ -116,6 +117,52 @@ export const findDataPointByLabel = (
     })
 }
 
+const getDataIndex = (
+    originalData: NewNestedDataPoint[],
+    label: string | number
+): number => {
+    const dataPoint = findDataPointByLabel(originalData, label)
+    return dataPoint ? originalData.indexOf(dataPoint) : -1
+}
+
+const formatTooltipHeader = (
+    label: string | number,
+    xAxis: XAxisConfig | undefined,
+    labelFormatter: CustomTooltipProps['labelFormatter']
+): ReactNode => {
+    return labelFormatter
+        ? labelFormatter(label)
+        : formatTooltipLabel(label, xAxis)
+}
+
+const formatPrimaryTooltipValue = ({
+    value,
+    seriesName,
+    dataIndex,
+    color,
+    payload,
+    yAxis,
+    formatter,
+}: {
+    value: string | number
+    seriesName: string | number
+    dataIndex: number
+    color: string | undefined
+    payload: unknown
+    yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+}): ReactNode => {
+    if (!formatter) return formatTooltipValue(value, yAxis)
+
+    return formatter({
+        seriesName,
+        value,
+        dataIndex,
+        color: color || '#AD46FF',
+        payload,
+    })
+}
+
 export const getRelevantData = (
     originalData: NewNestedDataPoint[],
     label: string | number,
@@ -145,14 +192,19 @@ export const CustomTooltip = ({
     selectedKeys,
     xAxis,
     yAxis,
+    formatter,
+    labelFormatter,
 }: CustomTooltipProps) => {
     if (!active || !payload || !payload.length) {
         return null
     }
 
     const getColor = (key: string) => {
-        const payloadItem = payload.find((item) => item.dataKey === key)
-        return payloadItem ? payloadItem.color : '#AD46FF'
+        const payloadItem = payload.find(
+            (item) =>
+                String(item.dataKey) === key || item.payload?.seriesKey === key
+        )
+        return payloadItem?.color || payloadItem?.payload?.color || '#AD46FF'
     }
 
     return (
@@ -182,17 +234,23 @@ export const CustomTooltip = ({
                     getColor={getColor}
                     xAxis={xAxis}
                     yAxis={yAxis}
+                    formatter={formatter}
+                    labelFormatter={labelFormatter}
                 />
             )}
             {(chartType === ChartType.BAR ||
                 chartType === ChartType.AREA ||
-                chartType === ChartType.LINE_BAR) && (
+                chartType === ChartType.LINE_BAR ||
+                chartType === ChartType.FUNNEL) && (
                 <BarChartTooltip
                     originalData={originalData}
                     label={label}
+                    payload={payload}
                     getColor={getColor}
                     xAxis={xAxis}
                     yAxis={yAxis}
+                    formatter={formatter}
+                    labelFormatter={labelFormatter}
                 />
             )}
             {chartType === ChartType.PIE && (
@@ -203,8 +261,11 @@ export const CustomTooltip = ({
                     setHoveredKey={setHoveredKey}
                     originalData={originalData}
                     hoveredKey={hoveredKey}
+                    label={label}
                     xAxis={xAxis}
                     yAxis={yAxis}
+                    formatter={formatter}
+                    labelFormatter={labelFormatter}
                 />
             )}
             {chartType === ChartType.SCATTER && (
@@ -216,6 +277,8 @@ export const CustomTooltip = ({
                     hoveredKey={hoveredKey}
                     xAxis={xAxis}
                     yAxis={yAxis}
+                    formatter={formatter}
+                    labelFormatter={labelFormatter}
                 />
             )}
         </Block>
@@ -225,17 +288,24 @@ export const CustomTooltip = ({
 const BarChartTooltip = ({
     originalData,
     label,
+    payload,
     getColor,
     xAxis,
     yAxis,
+    formatter,
+    labelFormatter,
 }: {
     originalData: NewNestedDataPoint[]
     label: string | number
+    payload: Payload<ValueType, NameType>[]
     getColor: (key: string) => string | undefined
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+    labelFormatter?: CustomTooltipProps['labelFormatter']
 }) => {
     const relevantData = findDataPointByLabel(originalData, label)?.data
+    const dataIndex = getDataIndex(originalData, label)
 
     // Collect all aux data from all DataPoints in relevantData, attaching the key to each aux item
     const auxData = relevantData
@@ -259,7 +329,7 @@ const BarChartTooltip = ({
                     fontWeight={FOUNDATION_THEME.font.weight[600]}
                     color={FOUNDATION_THEME.colors.gray[900]}
                 >
-                    {formatTooltipLabel(label, xAxis)}
+                    {formatTooltipHeader(label, xAxis, labelFormatter)}
                 </Text>
             </Block>
 
@@ -272,66 +342,93 @@ const BarChartTooltip = ({
                 {relevantData &&
                     Object.keys(relevantData)
                         .filter((key) => key !== 'name')
-                        .map((key, index) => (
-                            <Block
-                                display="flex"
-                                alignItems="center"
-                                justifyContent="space-between"
-                                key={`bar-${index}`}
-                                width="100%"
-                            >
+                        .map((key, index) => {
+                            const payloadItem = payload.find(
+                                (item) =>
+                                    String(item.dataKey) === key ||
+                                    item.payload?.seriesKey === key
+                            )
+
+                            return (
                                 <Block
                                     display="flex"
                                     alignItems="center"
-                                    gap={FOUNDATION_THEME.unit[8]}
+                                    justifyContent="space-between"
+                                    key={`bar-${index}`}
+                                    width="100%"
                                 >
                                     <Block
-                                        backgroundColor={
-                                            getColor(key) || '#AD46FF'
-                                        }
-                                        width={FOUNDATION_THEME.unit[4]}
-                                        height={FOUNDATION_THEME.unit[16]}
-                                        borderRadius={
-                                            FOUNDATION_THEME.border.radius[8]
-                                        }
-                                    />
-                                    <Text
-                                        fontSize={
-                                            FOUNDATION_THEME.font.size.body.sm
-                                                .fontSize as number
-                                        }
-                                        fontWeight={
-                                            FOUNDATION_THEME.font.weight[500]
-                                        }
-                                        color={
-                                            FOUNDATION_THEME.colors.gray[400]
-                                        }
+                                        display="flex"
+                                        alignItems="center"
+                                        gap={FOUNDATION_THEME.unit[8]}
                                     >
-                                        {key}
-                                    </Text>
+                                        <Block
+                                            backgroundColor={
+                                                getColor(key) || '#AD46FF'
+                                            }
+                                            width={FOUNDATION_THEME.unit[4]}
+                                            height={FOUNDATION_THEME.unit[16]}
+                                            borderRadius={
+                                                FOUNDATION_THEME.border
+                                                    .radius[8]
+                                            }
+                                        />
+                                        <Text
+                                            fontSize={
+                                                FOUNDATION_THEME.font.size.body
+                                                    .sm.fontSize as number
+                                            }
+                                            fontWeight={
+                                                FOUNDATION_THEME.font
+                                                    .weight[500]
+                                            }
+                                            color={
+                                                FOUNDATION_THEME.colors
+                                                    .gray[400]
+                                            }
+                                        >
+                                            {key}
+                                        </Text>
+                                    </Block>
+                                    <Block>
+                                        <Text
+                                            fontSize={
+                                                FOUNDATION_THEME.font.size.body
+                                                    .sm.fontSize as number
+                                            }
+                                            fontWeight={
+                                                FOUNDATION_THEME.font
+                                                    .weight[600]
+                                            }
+                                            color={
+                                                FOUNDATION_THEME.colors
+                                                    .gray[900]
+                                            }
+                                            truncate={!formatter}
+                                        >
+                                            {formatPrimaryTooltipValue({
+                                                value: relevantData[key].primary
+                                                    .val,
+                                                seriesName:
+                                                    payloadItem?.payload
+                                                        ?.seriesKey ||
+                                                    payloadItem?.name ||
+                                                    key,
+                                                dataIndex,
+                                                color:
+                                                    payloadItem?.color ||
+                                                    getColor(key),
+                                                payload:
+                                                    payloadItem?.payload ||
+                                                    relevantData[key],
+                                                yAxis,
+                                                formatter,
+                                            })}
+                                        </Text>
+                                    </Block>
                                 </Block>
-                                <Block>
-                                    <Text
-                                        fontSize={
-                                            FOUNDATION_THEME.font.size.body.sm
-                                                .fontSize as number
-                                        }
-                                        fontWeight={
-                                            FOUNDATION_THEME.font.weight[600]
-                                        }
-                                        color={
-                                            FOUNDATION_THEME.colors.gray[900]
-                                        }
-                                        truncate={true}
-                                    >
-                                        {formatTooltipValue(
-                                            relevantData[key].primary.val,
-                                            yAxis
-                                        )}
-                                    </Text>
-                                </Block>
-                            </Block>
-                        ))}
+                            )
+                        })}
             </Block>
             {auxData && auxData.length > 0 && (
                 <Block
@@ -391,6 +488,8 @@ const LineChartTooltip = ({
     setHoveredKey,
     xAxis,
     yAxis,
+    formatter,
+    labelFormatter,
 }: {
     originalData: NewNestedDataPoint[]
     hoveredKey: string | null
@@ -402,6 +501,8 @@ const LineChartTooltip = ({
     setHoveredKey: (key: string) => void
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+    labelFormatter?: CustomTooltipProps['labelFormatter']
 }) => {
     const updateScheduledRef = useRef(false)
 
@@ -459,7 +560,7 @@ const LineChartTooltip = ({
                         fontWeight={FOUNDATION_THEME.font.weight[500]}
                         color={FOUNDATION_THEME.colors.gray[400]}
                     >
-                        {formatTooltipLabel(label, xAxis)}
+                        {formatTooltipHeader(label, xAxis, labelFormatter)}
                     </Text>
                 </Block>
             </Block>
@@ -476,9 +577,20 @@ const LineChartTooltip = ({
                     fontSize={12}
                     fontWeight={FOUNDATION_THEME.font.weight[600]}
                     color={FOUNDATION_THEME.colors.gray[900]}
-                    truncate={true}
+                    truncate={!formatter}
                 >
-                    {formatTooltipValue(relevantData.primary.val, yAxis)}
+                    {formatPrimaryTooltipValue({
+                        value: relevantData.primary.val,
+                        seriesName: hoveredKey,
+                        dataIndex: getDataIndex(originalData, label),
+                        color: getColor(hoveredKey),
+                        payload:
+                            payload.find(
+                                (item) => String(item.dataKey) === hoveredKey
+                            )?.payload || relevantData,
+                        yAxis,
+                        formatter,
+                    })}
                 </Text>
             </Block>
 
@@ -614,6 +726,9 @@ const PieChartTooltip = ({
     setHoveredKey,
     xAxis,
     yAxis,
+    label,
+    formatter,
+    labelFormatter,
 }: {
     originalData: NewNestedDataPoint[]
     hoveredKey: string | null
@@ -621,8 +736,11 @@ const PieChartTooltip = ({
     payload: Payload<ValueType, NameType>[]
     selectedKeys: string[]
     setHoveredKey: (key: string) => void
+    label: string | number
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+    labelFormatter?: CustomTooltipProps['labelFormatter']
 }) => {
     const updateScheduledRef = useRef(false)
 
@@ -681,7 +799,11 @@ const PieChartTooltip = ({
                         fontWeight={FOUNDATION_THEME.font.weight[500]}
                         color={FOUNDATION_THEME.colors.gray[400]}
                     >
-                        {formatTooltipLabel(originalData[0].name, xAxis)}
+                        {formatTooltipHeader(
+                            label || originalData[0].name,
+                            xAxis,
+                            labelFormatter
+                        )}
                     </Text>
                 </Block>
             </Block>
@@ -698,9 +820,20 @@ const PieChartTooltip = ({
                     fontSize={12}
                     fontWeight={FOUNDATION_THEME.font.weight[600]}
                     color={FOUNDATION_THEME.colors.gray[900]}
-                    truncate={true}
+                    truncate={!formatter}
                 >
-                    {formatTooltipValue(data.primary.val, yAxis)}
+                    {formatPrimaryTooltipValue({
+                        value: data.primary.val,
+                        seriesName: name,
+                        dataIndex: getDataIndex(
+                            originalData,
+                            originalData[0].name
+                        ),
+                        color: payload[0].color || payload[0].payload.fill,
+                        payload: payload[0].payload,
+                        yAxis,
+                        formatter,
+                    })}
                 </Text>
             </Block>
 
@@ -751,6 +884,8 @@ const ScatterChartTooltip = ({
     selectedKeys,
     xAxis,
     yAxis,
+    formatter,
+    labelFormatter,
 }: {
     originalData: NewNestedDataPoint[]
     hoveredKey: string | null
@@ -759,6 +894,8 @@ const ScatterChartTooltip = ({
     selectedKeys: string[]
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+    labelFormatter?: CustomTooltipProps['labelFormatter']
 }) => {
     if (!active || !payload || !payload.length) {
         return null
@@ -815,7 +952,11 @@ const ScatterChartTooltip = ({
                         fontWeight={FOUNDATION_THEME.font.weight[500]}
                         color={FOUNDATION_THEME.colors.gray[400]}
                     >
-                        {point.name || 'Data Point'}
+                        {formatTooltipHeader(
+                            point.name || 'Data Point',
+                            xAxis,
+                            labelFormatter
+                        )}
                     </Text>
                 </Block>
             </Block>
@@ -863,9 +1004,20 @@ const ScatterChartTooltip = ({
                         fontSize={12}
                         fontWeight={FOUNDATION_THEME.font.weight[600]}
                         color={FOUNDATION_THEME.colors.gray[900]}
-                        truncate={true}
+                        truncate={!formatter}
                     >
-                        {formatTooltipValue(point.y, yAxis)}
+                        {formatPrimaryTooltipValue({
+                            value: point.y,
+                            seriesName: seriesKey,
+                            dataIndex: getDataIndex(
+                                originalData,
+                                point.name || ''
+                            ),
+                            color: point.fill,
+                            payload: point,
+                            yAxis,
+                            formatter,
+                        })}
                     </Text>
                 </Block>
             </Block>

--- a/packages/blend/lib/components/Charts/FunnelChart.tsx
+++ b/packages/blend/lib/components/Charts/FunnelChart.tsx
@@ -1,0 +1,282 @@
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Cell,
+    LabelList,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts'
+import {
+    ChartType,
+    FunnelConfig,
+    NewNestedDataPoint,
+    TooltipContentProps,
+    TooltipConfig,
+    XAxisConfig,
+    YAxisConfig,
+} from './types'
+import { formatNumber } from './ChartUtils'
+import { CustomTooltip } from './CustomTooltip'
+import { DEFAULT_COLORS } from './utils'
+import { FOUNDATION_THEME } from '../../tokens'
+
+const FUNNEL_MARGIN = 10
+const FUNNEL_LABEL_OFFSET = 8
+const FUNNEL_LABEL_MARGIN = 180
+const FUNNEL_COMPACT_LABEL_MARGIN = 136
+const FUNNEL_NO_LABEL_MARGIN = 30
+const FUNNEL_AXIS_WIDTH = 110
+const FUNNEL_COMPACT_AXIS_WIDTH = 90
+
+export type FunnelStage = {
+    name: string
+    value: number
+    color: string
+    dropOffPercentage: number
+    seriesKey: string
+}
+
+export const calculateFunnelDropOff = (
+    value: number,
+    baseValue: number
+): number => {
+    if (
+        !Number.isFinite(value) ||
+        !Number.isFinite(baseValue) ||
+        baseValue <= 0
+    ) {
+        return 0
+    }
+
+    return ((baseValue - value) / baseValue) * 100
+}
+
+export const getFunnelStages = (
+    data: NewNestedDataPoint[],
+    selectedKeys: string[],
+    colors: { key: string; color: string }[],
+    percentageBase: FunnelConfig['percentageBase'] = 'previous'
+): FunnelStage[] => {
+    const seriesKey =
+        selectedKeys.find((key) =>
+            data.some((dataPoint) => dataPoint.data[key])
+        ) || Object.keys(data[0]?.data || {})[0]
+
+    if (!seriesKey) return []
+
+    const values = data.map((dataPoint) => {
+        const value = dataPoint.data[seriesKey]?.primary.val
+        return typeof value === 'number' && Number.isFinite(value) ? value : 0
+    })
+    const firstValue = values[0] ?? 0
+
+    return data.map((dataPoint, index) => {
+        const value = values[index]
+        const baseValue =
+            percentageBase === 'first'
+                ? firstValue
+                : index === 0
+                  ? value
+                  : values[index - 1]
+        const stageColor =
+            colors.find((color) => color.key === dataPoint.name)?.color ||
+            colors[index % colors.length]?.color ||
+            DEFAULT_COLORS[index % DEFAULT_COLORS.length].color
+
+        return {
+            name: dataPoint.name,
+            value,
+            color: stageColor,
+            dropOffPercentage: calculateFunnelDropOff(value, baseValue),
+            seriesKey,
+        }
+    })
+}
+
+const formatFunnelPercentage = (percentage: number): string => {
+    const rounded = Math.round(percentage * 10) / 10
+    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}%`
+}
+
+type FunnelViewBox = {
+    x?: number
+    y?: number
+    width?: number
+    height?: number
+}
+
+const FunnelLabel = ({
+    index,
+    viewBox,
+    stages,
+    isSmallScreen,
+}: {
+    index?: number
+    viewBox?: FunnelViewBox
+    stages: FunnelStage[]
+    isSmallScreen: boolean
+}) => {
+    const stage = index === undefined ? undefined : stages[index]
+    if (!stage || !viewBox) return null
+
+    const x = (viewBox.x || 0) + (viewBox.width || 0) + FUNNEL_LABEL_OFFSET
+    const y = (viewBox.y || 0) + (viewBox.height || 0) / 2
+
+    return (
+        <text
+            x={x}
+            y={y}
+            fill={FOUNDATION_THEME.colors.gray[700]}
+            fontSize={
+                isSmallScreen
+                    ? FOUNDATION_THEME.font.size.body.xs.fontSize
+                    : FOUNDATION_THEME.font.size.body.sm.fontSize
+            }
+            fontWeight={FOUNDATION_THEME.font.weight[500]}
+            dominantBaseline="central"
+        >
+            {`${formatNumber(stage.value)} · ${formatFunnelPercentage(stage.dropOffPercentage)} drop-off`}
+        </text>
+    )
+}
+
+export type FunnelChartProps = {
+    data: NewNestedDataPoint[]
+    selectedKeys: string[]
+    colors: { key: string; color: string }[]
+    funnelConfig?: FunnelConfig
+    barsize?: number
+    tooltip?: TooltipConfig
+    xAxis?: XAxisConfig
+    yAxis?: YAxisConfig
+    isSmallScreen?: boolean
+    hoveredKey: string | null
+    setHoveredKey: (key: string | null) => void
+}
+
+export const FunnelChart = ({
+    data,
+    selectedKeys,
+    colors,
+    funnelConfig,
+    barsize,
+    tooltip,
+    xAxis,
+    yAxis,
+    isSmallScreen = false,
+    hoveredKey,
+    setHoveredKey,
+}: FunnelChartProps) => {
+    const stages = getFunnelStages(
+        data,
+        selectedKeys,
+        colors,
+        funnelConfig?.percentageBase
+    )
+    const showLabels = funnelConfig?.showLabels ?? true
+
+    if (stages.length === 0) return null
+
+    return (
+        <BarChart
+            data-chart={ChartType.FUNNEL}
+            data={stages}
+            layout="vertical"
+            margin={{
+                top: FUNNEL_MARGIN,
+                right: showLabels
+                    ? isSmallScreen
+                        ? FUNNEL_COMPACT_LABEL_MARGIN
+                        : FUNNEL_LABEL_MARGIN
+                    : FUNNEL_NO_LABEL_MARGIN,
+                left: FUNNEL_MARGIN,
+                bottom: FUNNEL_MARGIN,
+            }}
+            onMouseLeave={() => setHoveredKey(null)}
+        >
+            <CartesianGrid
+                horizontal={false}
+                stroke={FOUNDATION_THEME.colors.gray[150]}
+            />
+            <XAxis type="number" dataKey="value" domain={[0, 'dataMax']} hide />
+            <YAxis
+                type="category"
+                dataKey="name"
+                axisLine={false}
+                tickLine={false}
+                interval={0}
+                width={
+                    isSmallScreen
+                        ? FUNNEL_COMPACT_AXIS_WIDTH
+                        : FUNNEL_AXIS_WIDTH
+                }
+                tick={{
+                    fill: FOUNDATION_THEME.colors.gray[400],
+                    fontSize: 12,
+                    fontWeight: FOUNDATION_THEME.font.weight[500],
+                }}
+            />
+            <Tooltip
+                position={tooltip?.position}
+                allowEscapeViewBox={tooltip?.allowEscapeViewBox}
+                cursor={{ fill: FOUNDATION_THEME.colors.gray[150] }}
+                content={(props) => {
+                    const mergedProps: TooltipContentProps = {
+                        ...props,
+                        originalData: data,
+                        chartType: ChartType.FUNNEL,
+                        selectedKeys,
+                        xAxis,
+                        yAxis,
+                    }
+
+                    return tooltip?.content ? (
+                        tooltip.content(mergedProps)
+                    ) : (
+                        <CustomTooltip
+                            {...mergedProps}
+                            hoveredKey={hoveredKey}
+                            setHoveredKey={setHoveredKey}
+                            formatter={tooltip?.formatter}
+                            labelFormatter={tooltip?.labelFormatter}
+                        />
+                    )
+                }}
+            />
+            <Bar
+                dataKey="value"
+                radius={[0, 4, 4, 0]}
+                maxBarSize={barsize}
+                animationDuration={350}
+            >
+                {stages.map((stage) => (
+                    <Cell key={stage.name} fill={stage.color} />
+                ))}
+                {showLabels && (
+                    <LabelList
+                        dataKey="value"
+                        content={(props) => {
+                            const viewBox =
+                                props.viewBox && 'x' in props.viewBox
+                                    ? props.viewBox
+                                    : undefined
+
+                            return (
+                                <FunnelLabel
+                                    index={props.index}
+                                    viewBox={viewBox}
+                                    stages={stages}
+                                    isSmallScreen={isSmallScreen}
+                                />
+                            )
+                        }}
+                    />
+                )}
+            </Bar>
+        </BarChart>
+    )
+}
+
+export default FunnelChart

--- a/packages/blend/lib/components/Charts/renderChart.tsx
+++ b/packages/blend/lib/components/Charts/renderChart.tsx
@@ -28,6 +28,7 @@ import {
     FlattenedDataPoint,
 } from './types'
 import SankeyChartWrapper from './SankeyChartWrapper'
+import FunnelChart from './FunnelChart'
 import {
     formatNumber,
     getAxisFormatter,
@@ -58,6 +59,7 @@ export const renderChart = ({
     xAxis,
     yAxis,
     tooltip,
+    funnelConfig,
     noData,
     height,
     CustomizedDot,
@@ -388,6 +390,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}
@@ -631,6 +635,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}
@@ -746,6 +752,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}
@@ -988,6 +996,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}
@@ -1155,6 +1165,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}
@@ -1263,6 +1275,24 @@ export const renderChart = ({
                     sankeyWidth={sankeyWidth}
                     sankeyHeight={sankeyHeight}
                     isSmallScreen={isSmallScreen}
+                />
+            )
+        }
+
+        case ChartType.FUNNEL: {
+            return (
+                <FunnelChart
+                    data={originalData}
+                    selectedKeys={selectedKeys}
+                    colors={colors}
+                    funnelConfig={funnelConfig}
+                    barsize={barsize}
+                    tooltip={tooltip}
+                    xAxis={finalXAxis}
+                    yAxis={finalYAxis}
+                    isSmallScreen={isSmallScreen}
+                    hoveredKey={hoveredKey}
+                    setHoveredKey={setHoveredKey}
                 />
             )
         }
@@ -1406,6 +1436,8 @@ export const renderChart = ({
                                     {...mergedProps}
                                     hoveredKey={hoveredKey}
                                     setHoveredKey={setHoveredKey}
+                                    formatter={tooltip?.formatter}
+                                    labelFormatter={tooltip?.labelFormatter}
                                 />
                             )
                         }}

--- a/packages/blend/lib/components/Charts/types.tsx
+++ b/packages/blend/lib/components/Charts/types.tsx
@@ -40,6 +40,7 @@ export enum ChartType {
     SCATTER = 'scatter',
     AREA = 'area',
     SANKEY = 'sankey',
+    FUNNEL = 'funnel',
 }
 
 export enum LegendsChangeType {
@@ -100,6 +101,21 @@ export type AxisConfig = {
 export type XAxisConfig = AxisConfig
 export type YAxisConfig = AxisConfig
 
+export type TooltipFormatterParams = {
+    seriesName: NameType
+    value: ValueType
+    dataIndex: number
+    color: string
+    payload: unknown
+}
+
+export type TooltipFormatter = (params: TooltipFormatterParams) => ReactNode
+
+export type FunnelConfig = {
+    percentageBase?: 'previous' | 'first'
+    showLabels?: boolean
+}
+
 export type TooltipContentProps = TooltipProps<ValueType, NameType> & {
     originalData: NewNestedDataPoint[]
     chartType: ChartType
@@ -112,6 +128,8 @@ export type TooltipConfig = {
     position?: { x?: number; y?: number }
     allowEscapeViewBox?: { x?: boolean; y?: boolean }
     content?: (props: TooltipContentProps) => ReactNode
+    formatter?: TooltipFormatter
+    labelFormatter?: (axisValue: string | number) => ReactNode
 }
 
 export type DotItemDotProps = {
@@ -151,6 +169,7 @@ export type RenderChartProps = {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
     tooltip?: TooltipConfig
+    funnelConfig?: FunnelConfig
     noData?: NoDataProps
     height?: number | string
     CustomizedDot?: (props: DotItemDotProps) => React.ReactElement<SVGElement>
@@ -166,6 +185,7 @@ export type CoreChartProps = {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
     tooltip?: TooltipConfig
+    funnelConfig?: FunnelConfig
     height?: number | string
     width?: number | string
     isSmallScreen?: boolean
@@ -198,6 +218,7 @@ export type ChartsProps = {
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
     tooltip?: TooltipConfig
+    funnelConfig?: FunnelConfig
     noData?: NoDataProps
     height?: number
     showHeader?: boolean
@@ -249,7 +270,10 @@ export type ChartLegendsProps = {
     showAllLegends?: boolean
 }
 
-export type CustomTooltipProps = TooltipProps<ValueType, NameType> & {
+export type CustomTooltipProps = Omit<
+    TooltipProps<ValueType, NameType>,
+    'formatter' | 'labelFormatter'
+> & {
     hoveredKey: string | null
     originalData: NewNestedDataPoint[]
     setHoveredKey: (key: string) => void
@@ -257,6 +281,8 @@ export type CustomTooltipProps = TooltipProps<ValueType, NameType> & {
     selectedKeys: string[]
     xAxis?: XAxisConfig
     yAxis?: YAxisConfig
+    formatter?: TooltipFormatter
+    labelFormatter?: (axisValue: string | number) => ReactNode
 }
 
 export type SankeyNode = {


### PR DESCRIPTION
## Summary

- Adds curated `chartType: 'funnel'` support to the Recharts-based Charts/CoreChart stack. Ordered stages render as value-proportional horizontal bars with token-themed colors, values, and drop-off percentages against either the previous or first stage; labels can be toggled with `funnelConfig`.
- Adds `tooltipConfig.formatter` and `labelFormatter` callbacks, rendered inside the existing themed tooltip chrome while preserving existing defaults and custom tooltip content.
- Adds stories for both funnel percentage bases and a custom multi-line tooltip, plus focused rendering, accessibility, edge-case, and formatter coverage.
- Tracks the unrelated intermittent Button hover performance threshold warning in `TODOS.md` as a P0 follow-up.
- XRange/Gantt remains available through the raw-options ChartV2 escape hatch and is out of scope here.

The package version and `docs/CHANGELOG.md` are intentionally unchanged per request; release metadata remains with the repository release workflow.

## Test Coverage

All new code paths have focused coverage.

```text
Chart config
  ├─ funnel → ordered stages → proportional bars → value/drop-off labels
  │                         └─ previous/first percentage base + label toggle
  └─ tooltip callbacks → existing themed chrome → formatter/labelFormatter ReactNodes
```

Tests: 222 existing test files → 222 (+0 new files); focused Charts tooltip tests: 21 passed.

## Pre-Landing Review

No issues found across the review passes. Enum completeness, rendering paths, data edge cases, accessibility coverage, tooltip callback branches, and scope drift were checked.

## Design Review

Skipped by the design-scope classifier (`SCOPE_FRONTEND=false`); Storybook visual verification was also skipped because no local Storybook server was available.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope check: CLEAN.

## Plan Completion

All autoplan items are complete: funnel type/config plumbing, funnel rendering, tooltip callbacks, stories, tests, package typecheck/build, and review loop. XRange/Gantt remains intentionally out of scope.

## Verification Results

- Package TypeScript check: passed.
- Focused Charts tooltip tests: 21 passed.
- Full Blend Vitest suite: 184 files passed, 16 skipped; 4,818 tests passed, 604 skipped.
- Package build and `check:dist`: passed.
- Storybook-wide typecheck remains blocked by unrelated pre-existing errors; no errors were reported from the changed Charts story.
- Local dev-server verification: skipped because no server was available.

The full suite initially exposed an unrelated Button hover performance threshold failure; it passed on rerun but emitted performance warnings, so the P0 TODO was recorded without changing Button code.

## TODOS

Added one P0 TODO for the unrelated intermittent Button hover performance regression observed during the ship checks.

## Documentation

No documentation or changelog update was made by explicit request. Release metadata is intentionally deferred.

## Test plan

- [x] Package typecheck
- [x] Focused Charts tests (21 passed)
- [x] Full Blend Vitest suite (184 files passed, 4,818 tests passed)
- [x] Package build and `check:dist`
- [ ] Storybook visual verification (no local server available)
