### PR TITLE
fix(data-table): guard useRowFlip against partial rowAnimationConfig

### DIFF
--- a/packages/blend/__tests__/components/DataTable/DataTable.rowAnimation.test.tsx
+++ b/packages/blend/__tests__/components/DataTable/DataTable.rowAnimation.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, renderHook, screen } from '../../test-utils'
+import DataTable from '../../../lib/components/DataTable/DataTable'
+import { useRowFlip } from '../../../lib/components/DataTable/hooks/useRowFlip'
+import {
+    ColumnDefinition,
+    ColumnType,
+    type RowAnimationConfig,
+} from '../../../lib/components/DataTable/types'
+
+type Row = { id: number; name: string }
+
+const columns: ColumnDefinition<Row>[] = [
+    {
+        field: 'name',
+        header: 'Name',
+        type: ColumnType.TEXT,
+        isSortable: false,
+    },
+]
+
+const rows: Row[] = [
+    { id: 1, name: 'Ada' },
+    { id: 2, name: 'Grace' },
+]
+
+/**
+ * A config a JS caller (or a generated binding) can produce but the
+ * discriminated union forbids: `transitionType: 'bezier'` with no `bezier`.
+ * Issue #1651 — this used to throw out of `useLayoutEffect` and take the
+ * whole DataTable down.
+ */
+const partialBezierConfig = {
+    enterDuration: 0.32,
+    enterOffset: 12,
+    transitionType: 'bezier',
+} as unknown as RowAnimationConfig
+
+describe('useRowFlip malformed rowAnimationConfig', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        warnSpy.mockRestore()
+    })
+
+    it('does not throw when transitionType is bezier but bezier is missing', () => {
+        expect(() =>
+            renderHook(() => useRowFlip(['1', '2'], partialBezierConfig))
+        ).not.toThrow()
+    })
+
+    it.each([
+        ['a non-array bezier', { bezier: 'ease-in-out' }],
+        ['a short bezier tuple', { bezier: [0.32, 0.72] }],
+        ['a bezier tuple with NaN', { bezier: [0.32, 0.72, 0, NaN] }],
+        [
+            'a non-finite duration',
+            { bezier: [0.32, 0.72, 0, 1], duration: NaN },
+        ],
+        ['a missing enterDuration', { bezier: [0.32, 0.72, 0, 1] }],
+    ])('does not throw for %s', (_label, overrides) => {
+        const config = {
+            enterOffset: 12,
+            transitionType: 'bezier',
+            ...overrides,
+        } as unknown as RowAnimationConfig
+
+        expect(() =>
+            renderHook(() => useRowFlip(['1', '2'], config))
+        ).not.toThrow()
+    })
+
+    it('warns in development instead of throwing', async () => {
+        // The warning is deduped at module scope, so load a fresh copy of the
+        // hook to observe the first emission.
+        vi.resetModules()
+        const { useRowFlip: freshUseRowFlip } =
+            await import('../../../lib/components/DataTable/hooks/useRowFlip')
+
+        renderHook(() => freshUseRowFlip(['1', '2'], partialBezierConfig))
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[DataTable] rowAnimationConfig')
+        )
+    })
+
+    it('still renders the table with row animation enabled', () => {
+        render(
+            <DataTable
+                data={rows}
+                columns={columns}
+                idField="id"
+                enableRowAnimation
+                rowAnimationConfig={partialBezierConfig}
+            />
+        )
+
+        expect(screen.getByText('Ada')).toBeInTheDocument()
+        expect(screen.getByText('Grace')).toBeInTheDocument()
+    })
+
+    it('still renders the table with row animation disabled', () => {
+        render(
+            <DataTable
+                data={rows}
+                columns={columns}
+                idField="id"
+                enableRowAnimation={false}
+                rowAnimationConfig={partialBezierConfig}
+            />
+        )
+
+        expect(screen.getByText('Ada')).toBeInTheDocument()
+        expect(screen.getByText('Grace')).toBeInTheDocument()
+    })
+
+    it('accepts a well-formed bezier config without warning', () => {
+        const config: RowAnimationConfig = {
+            enterDuration: 0.32,
+            enterOffset: 12,
+            transitionType: 'bezier',
+            duration: 0.4,
+            bezier: [0.32, 0.72, 0, 1],
+        }
+
+        expect(() =>
+            renderHook(() => useRowFlip(['1', '2'], config))
+        ).not.toThrow()
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+})

--- a/packages/blend/lib/components/DataTable/TableBody/index.tsx
+++ b/packages/blend/lib/components/DataTable/TableBody/index.tsx
@@ -663,7 +663,7 @@ const TableBody = forwardRef<
 
         const { register } = useRowFlip(
             enableRowAnimation ? orderedRowIds : [],
-            rowAnimationConfig
+            enableRowAnimation ? rowAnimationConfig : undefined
         )
 
         const getFlipRefCallback = useCallback(

--- a/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
+++ b/packages/blend/lib/components/DataTable/hooks/useRowFlip.ts
@@ -2,23 +2,59 @@ import { useRef, useLayoutEffect, useCallback, useMemo } from 'react'
 import { useReducedMotion } from './useReducedMotion'
 import type { RowAnimationConfig } from '../types'
 
+const DEFAULT_DURATION = 0.35
+const DEFAULT_ENTER_DURATION = 0.35
+const DEFAULT_ENTER_OFFSET = 12
+
+const warnedMessages = new Set<string>()
+
+function warnInvalidConfig(message: string) {
+    if (process.env.NODE_ENV === 'production') return
+    if (warnedMessages.has(message)) return
+    warnedMessages.add(message)
+    console.warn(`[DataTable] rowAnimationConfig: ${message}`)
+}
+
+function toFiniteNumber(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value)
+        ? value
+        : fallback
+}
+
+function isBezierTuple(
+    value: unknown
+): value is [number, number, number, number] {
+    return (
+        Array.isArray(value) &&
+        value.length === 4 &&
+        value.every((n) => typeof n === 'number' && Number.isFinite(n))
+    )
+}
+
 function toCssTransition(config: RowAnimationConfig): {
     transition: string
     duration: number
 } {
     if (config.transitionType === 'bezier') {
-        const [p0, p1, p2, p3] = config.bezier
-        const cssBezier = `cubic-bezier(${p0}, ${p1}, ${p2}, ${p3})`
-        return {
-            duration: config.duration,
-            transition: `transform ${config.duration}s ${cssBezier}, opacity ${config.duration}s ${cssBezier}`,
+        if (isBezierTuple(config.bezier)) {
+            const [p0, p1, p2, p3] = config.bezier
+            const cssBezier = `cubic-bezier(${p0}, ${p1}, ${p2}, ${p3})`
+            const duration = toFiniteNumber(config.duration, DEFAULT_DURATION)
+            return {
+                duration,
+                transition: `transform ${duration}s ${cssBezier}, opacity ${duration}s ${cssBezier}`,
+            }
         }
+
+        warnInvalidConfig(
+            `transitionType is 'bezier' but 'bezier' is not a tuple of four finite numbers — falling back to the default curve.`
+        )
     }
 
     const cssBezier = `cubic-bezier(0.32, 0.72, 0, 1)`
-    const transition = `transform 0.35s ${cssBezier}, opacity 0.35s ${cssBezier}`
+    const transition = `transform ${DEFAULT_DURATION}s ${cssBezier}, opacity ${DEFAULT_DURATION}s ${cssBezier}`
     return {
-        duration: 0.35,
+        duration: DEFAULT_DURATION,
         transition,
     }
 }
@@ -90,8 +126,22 @@ export function useRowFlip(
 
         const { transition: cssTransition, duration } =
             toCssTransition(currentConfig)
-        const enterDuration = currentConfig.enterDuration
-        const enterOffset = currentConfig.enterOffset
+        if (
+            !Number.isFinite(currentConfig.enterDuration) ||
+            !Number.isFinite(currentConfig.enterOffset)
+        ) {
+            warnInvalidConfig(
+                `'enterDuration' and 'enterOffset' must both be finite numbers — falling back to defaults.`
+            )
+        }
+        const enterDuration = toFiniteNumber(
+            currentConfig.enterDuration,
+            DEFAULT_ENTER_DURATION
+        )
+        const enterOffset = toFiniteNumber(
+            currentConfig.enterOffset,
+            DEFAULT_ENTER_OFFSET
+        )
 
         const prevIds = prevIdsRef.current
         const newRowIdSet = new Set(


### PR DESCRIPTION
Fixes #1651

## The bug

`toCssTransition` in `useRowFlip` destructured `config.bezier` without checking it exists:

```ts
if (config.transitionType === 'bezier') {
    const [p0, p1, p2, p3] = config.bezier   // throws if undefined
```

A `rowAnimationConfig` carrying `transitionType: 'bezier'` but no `bezier` array threw `TypeError: undefined is not iterable` from inside `useLayoutEffect`. By then the table is committed, so the nearest error boundary ate the whole `DataTable` subtree — no partial degradation, just a blank region.

TypeScript's discriminated union prevents this, so it's only reachable from JS callers or generated bindings — but that's exactly where it was hit.

`enableRowAnimation={false}` did not protect you either: `TableBody` passed the config unconditionally, and `toCssTransition` ran before any iteration over row ids, so the crash fired with row animation switched off.

## The fix

- **Validate the bezier tuple before destructuring.** Requires four finite numbers; anything else falls through to the existing default `cubic-bezier(0.32, 0.72, 0, 1)` path the function already had.
- **Default `duration`, `enterDuration`, `enterOffset` to finite values.** Same union arm, same problem — a partial config previously produced `transform ${undefined}s …`, a silently broken transition, and `NaN` in the cleanup-timeout `Math.max`.
- **Warn once per message in development** (`process.env.NODE_ENV !== 'production'`, deduped at module scope) so the malformed config still surfaces without costing the user their table.
- **`TableBody` no longer forwards `rowAnimationConfig` when `enableRowAnimation` is false**, so the flag actually disables the code path instead of just emptying the id list.

## Tests

New `__tests__/components/DataTable/DataTable.rowAnimation.test.tsx` (10 tests): the hook under missing / non-array / short / `NaN`-bearing bezier tuples, the dev warning, a well-formed config warning-free, and full `DataTable` renders with the repro config under both `enableRowAnimation` states.

Verified the suite fails on the unfixed code (4 failures) and passes with the fix. `pnpm vitest run __tests__/components/DataTable/` — 112 passed, 1 skipped. `tsc --noEmit` clean, prettier clean, no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)