### PR TITLE
v0.0.37 docs: document TextInputGroup theme scope

### DIFF
--- a/packages/blend/lib/components/TextInputGroup/TextInputGroup.tsx
+++ b/packages/blend/lib/components/TextInputGroup/TextInputGroup.tsx
@@ -29,6 +29,7 @@ const TextInputGroup = forwardRef<HTMLDivElement, TextInputGroupProps>(
     }
 )
 
+/** TextInputGroup owns layout/position composition only; it has no component-local color, border, background, or theme tokens, so it is excluded from the per-component dark-theme retrofit. */
 TextInputGroup.displayName = 'TextInputGroup'
 
 export default TextInputGroup


### PR DESCRIPTION
## Summary

- Confirmed `TextInputGroup` is a layout-only wrapper around `Group` and has no component-local color, border, background, or theme state.
- Added a one-line source comment documenting why `TextInputGroup` is excluded from the per-component dark-theme retrofit.
- No token files, dispatcher, registry, or `ThemeProvider` changes are needed.

## Scope decision

The audit covered `TextInputGroup.tsx`, `TextInputGroupProps.types.ts`, and `Primitives/Group`. `Group` contributes layout and position composition only. `positionProp="textInputGroupPosition"` handles grouped-child edge composition such as border-radius merging; the child `TextInput` instances continue to own their visual chrome and light/dark theme values. The layout-only path was therefore taken; no invented token modules were added.

## Test Coverage

No new executable code paths were introduced, so the non-executable change has complete coverage by inspection. No new tests were generated.

## Pre-Landing Review

- `/review` pass 1: no issues found.
- `/ship` pre-landing review: no issues found.
- Full review checklist, security scan, diff scope, and slop scan were clean.

## Design Review

Design review (lite): 0 findings, 0 auto-fixed. No rendered UI or CSS changed.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN.

## Plan Completion

All audit checks are complete. There are no remaining implementation items for `TextInputGroup`; the legacy `TextInput` dark-theme gap is a separate scope and was not expanded here.

## Verification Results

- Package test suite: 207 test files passed, 16 skipped; 5,111 tests passed, 606 skipped.
- Package build and `check:dist`: passed.
- Prettier check and `git diff --check`: passed.
- No runtime route or interaction changed; dev-server verification was not applicable.

## TODOS

No TODO items completed in this PR.

## Documentation

The requested source audit note is included. No additional documentation update is needed.

## Test plan

- [x] Existing full Vitest suite passes.
- [x] Distribution build and declaration checks pass.
- [x] No new executable code paths were introduced.

Release metadata is intentionally unchanged per request: no changelog update and no package version bump.
