### PR TITLE
v0.0.37 feat(menu-v1): add controlled item selection

### DIFF
--- a/.changeset/menu-v1-controlled-selection.md
+++ b/.changeset/menu-v1-controlled-selection.md
@@ -1,0 +1,5 @@
+---
+'@juspay/blend-design-system': minor
+---
+
+Add controlled item selection parity to the V1 `Menu` API, including checkmark/highlight styles, selection modes, close behavior, and keyboard accessibility semantics.

--- a/apps/ascent/app/docs/content/components/menu.mdx
+++ b/apps/ascent/app/docs/content/components/menu.mdx
@@ -84,6 +84,11 @@ function MyComponent() {
 
 ## API Reference
 
+For controlled selection, pass `selected` on each selectable item and update
+that value from the item's `onClick` handler. `selectionStyle` defaults to
+`checkmark`, `selectionMode` defaults to `single`, and `closeOnSelect` defaults
+to `true`. Omitting `selected` preserves the legacy action-item behavior.
+
 <DocsTypeTable
     data={[
         [
@@ -103,7 +108,7 @@ function MyComponent() {
             {
                 content: 'Menu.items',
                 hintText:
-                    'Optional array of MenuGroupType objects that define the menu structure. Each group can contain multiple MenuItemType items organized under an optional label. Groups can be separated with visual separators. If not provided, the menu will be empty. Each MenuGroupType contains: label (optional group label), items (required array of MenuItemType), and showSeparator (optional boolean). Defaults to an empty array.',
+                    'Optional array of MenuGroupType objects that define the menu structure. Each group can contain multiple MenuItemType items organized under an optional label. Groups can be separated with visual separators. If not provided, the menu will be empty. Each MenuGroupType contains: label (optional group label), items (required array of MenuItemType), showSeparator (optional boolean), selectionStyle (optional visual treatment override), and selectionMode (optional accessibility cardinality override). Defaults to an empty array.',
             },
             {
                 content: 'MenuGroupType[]',
@@ -112,8 +117,42 @@ function MyComponent() {
             },
             {
                 content:
-                    'MenuGroupType: { label?: string, items: MenuItemType[], showSeparator?: boolean }',
+                    "MenuGroupType: { label?: string, items: MenuItemType[], showSeparator?: boolean, selectionStyle?: 'checkmark' | 'highlight', selectionMode?: 'single' | 'multiple' }",
             },
+        ],
+        [
+            {
+                content: 'Menu.selectionStyle',
+                hintText: 'Visual treatment for controlled selected items.',
+            },
+            {
+                content: "'checkmark' | 'highlight'",
+                hintText: 'Defaults to checkmark for selectable items',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'Menu.selectionMode',
+                hintText:
+                    'Selection cardinality used for accessible radio or checkbox semantics.',
+            },
+            {
+                content: "'single' | 'multiple'",
+                hintText: 'Defaults to single for selectable items',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'Menu.closeOnSelect',
+                hintText: 'Whether activating an item closes the menu.',
+            },
+            {
+                content: 'boolean',
+                hintText: 'Defaults to true',
+            },
+            { content: '' },
         ],
         [
             {
@@ -379,6 +418,29 @@ function MyComponent() {
         ],
         [
             {
+                content: 'MenuGroupType.selectionStyle',
+                hintText: 'Overrides the Menu-level selected-item treatment.',
+            },
+            {
+                content: "'checkmark' | 'highlight'",
+                hintText: 'Visual treatment for this group',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'MenuGroupType.selectionMode',
+                hintText:
+                    'Overrides the Menu-level accessible selection cardinality.',
+            },
+            {
+                content: "'single' | 'multiple'",
+                hintText: 'Radio or checkbox semantics for this group',
+            },
+            { content: '' },
+        ],
+        [
+            {
                 content: 'MenuItemType.label',
                 hintText:
                     'Required string representing the main text label displayed for the menu item. This is the primary text users see and click. Should be concise and action-oriented, clearly describing what the menu item does (e.g., "Profile", "Settings", "Sign Out").',
@@ -487,6 +549,18 @@ function MyComponent() {
                 content: 'boolean',
                 hintText:
                     'true disables menu item, false allows normal interaction',
+            },
+            { content: '' },
+        ],
+        [
+            {
+                content: 'MenuItemType.selected',
+                hintText:
+                    'Controlled selection state. The consumer owns all selection updates.',
+            },
+            {
+                content: 'boolean',
+                hintText: 'Adds aria-checked and the selected visual treatment',
             },
             { content: '' },
         ],
@@ -672,6 +746,11 @@ export type MenuTokensType = {
             }
         }
         gap: CSSObject['gap']
+        checkmark?: {
+            position?: 'leading' | 'trailing'
+            width?: CSSObject['width']
+            color?: CSSObject['color']
+        }
         optionsLabel: {
             fontSize: CSSObject['fontSize']
             fontWeight: CSSObject['fontWeight']
@@ -755,4 +834,5 @@ export type MenuItemStates =
     | 'focus'
     | 'focusVisible'
     | 'disabled'
+    | 'selected'
 ```

--- a/apps/storybook/stories/components/Menu/v1/Menu.stories.tsx
+++ b/apps/storybook/stories/components/Menu/v1/Menu.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useState } from 'react'
+import { expect, userEvent, within } from '@storybook/test'
 import {
     Menu,
     MenuAlignment,
@@ -59,12 +60,18 @@ import {
     Code,
     Terminal,
 } from 'lucide-react'
+import {
+    getA11yConfig,
+    CHROMATIC_CONFIG,
+} from '../../../../.storybook/a11y.config'
 
 const meta: Meta<typeof Menu> = {
     title: 'Components/Menu',
     component: Menu,
     parameters: {
         layout: 'centered',
+        a11y: getA11yConfig('navigation'),
+        chromatic: CHROMATIC_CONFIG,
         docsSubtitle:
             "A versatile dropdown menu component built on top of Radix UI's DropdownMenu primitive.",
         docs: {
@@ -94,6 +101,9 @@ import { Menu, MenuAlignment, MenuSide, MenuItemVariant, MenuItemActionType } fr
 - Disabled state support
 - Sub-menu support for nested navigation
 - Virtual scrolling for large lists
+- Controlled item selection with checkmark or highlight styles
+- Single-select radio or multi-select checkbox accessibility semantics
+- \`closeOnSelect\` (default \`true\`) for controlled multi-select menus
 - Modal mode for focus trapping
 - Customizable dimensions (min/max width/height)
 - Keyboard navigation and accessibility
@@ -119,7 +129,15 @@ Built on Radix UI's DropdownMenu primitive for robust accessibility.
 **ARIA Attributes:**
 - Trigger: aria-haspopup, aria-expanded, aria-controls
 - Menu: role="menu", aria-orientation
-- Items: role="menuitem", aria-disabled
+- Items without \`selected\`: role="menuitem", aria-disabled
+- Selectable single-mode items: role="menuitemradio" with \`aria-checked\`
+- Selectable multiple-mode items: role="menuitemcheckbox" with \`aria-checked\`
+- Checkmark icons are decorative; submenu parents remain triggers and only leaves participate
+
+**Controlled selection:**
+- Set \`selected\` on every item that participates; omitting it preserves the legacy action item.
+- \`Menu\` never changes \`selected\`. Rebuild the \`items\` array from consumer state in each \`onClick\` callback.
+- \`closeOnSelect={false}\` is a menu-wide policy intended for multi-select workflows.
 
 **Screen Readers:**
 - Announces open/close state
@@ -176,6 +194,37 @@ Built on Radix UI's DropdownMenu primitive for robust accessibility.
                 type: { summary: 'boolean' },
                 defaultValue: { summary: 'false' },
                 category: 'Behavior',
+            },
+        },
+        selectionStyle: {
+            control: { type: 'inline-radio' },
+            options: ['checkmark', 'highlight'],
+            description:
+                'How selected items are indicated. Group-level selectionStyle overrides this value.',
+            table: {
+                type: { summary: "'checkmark' | 'highlight'" },
+                category: 'Selection',
+            },
+        },
+        selectionMode: {
+            control: { type: 'inline-radio' },
+            options: ['single', 'multiple'],
+            description:
+                'Accessibility cardinality for selected items. Group-level selectionMode overrides this value.',
+            table: {
+                type: { summary: "'single' | 'multiple'" },
+                defaultValue: { summary: 'single' },
+                category: 'Selection',
+            },
+        },
+        closeOnSelect: {
+            control: { type: 'boolean' },
+            description:
+                'When false, activating any leaf keeps this menu open. Defaults to true.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'true' },
+                category: 'Selection',
             },
         },
         alignment: {
@@ -955,6 +1004,165 @@ export const ControlledState: Story = {
         docs: {
             description: {
                 story: 'Menu with controlled open state. External buttons can control whether the menu is open or closed.',
+            },
+        },
+    },
+}
+
+export const SingleSelectCheckmark: Story = {
+    render: function SingleSelectCheckmarkRender() {
+        const [sortBy, setSortBy] = useState('name-asc')
+
+        const options = [
+            { id: 'name-asc', label: 'Name (A–Z)' },
+            { id: 'name-desc', label: 'Name (Z–A)' },
+            { id: 'date-newest', label: 'Date (newest)' },
+            { id: 'date-oldest', label: 'Date (oldest)' },
+        ]
+
+        const items: MenuGroupType[] = [
+            {
+                label: 'Sort by',
+                items: options.map((option) => ({
+                    label: option.label,
+                    selected: sortBy === option.id,
+                    onClick: () => setSortBy(option.id),
+                })),
+            },
+        ]
+
+        return (
+            <div className="flex flex-col gap-3">
+                <Menu
+                    trigger={
+                        <Button
+                            buttonType={ButtonType.SECONDARY}
+                            text={`Sort: ${options.find((option) => option.id === sortBy)?.label}`}
+                        />
+                    }
+                    items={items}
+                    selectionStyle="checkmark"
+                    selectionMode="single"
+                />
+                <p className="text-xs text-gray-600">
+                    Controlled single-select sort picker. The consumer owns
+                    <code>selected</code>; the menu closes by default after a
+                    keyboard or pointer selection.
+                </p>
+            </div>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const trigger = canvas.getByRole('button', { name: /sort:/i })
+
+        await userEvent.click(trigger)
+
+        const nameDesc = await canvas.findByRole('menuitemradio', {
+            name: /name \(z–a\)/i,
+        })
+        await expect(nameDesc).toHaveAttribute('aria-checked', 'false')
+
+        const nameAsc = canvas.getByRole('menuitemradio', {
+            name: /name \(a–z\)/i,
+        })
+        await expect(nameAsc).toHaveAttribute('aria-checked', 'true')
+
+        await userEvent.keyboard('{ArrowDown}')
+        await expect(nameDesc).toHaveFocus()
+        await userEvent.keyboard('{Enter}')
+        await expect(trigger).toHaveTextContent(/name \(z–a\)/i)
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `Controlled single-select menu with \`selectionStyle="checkmark"\` and \`selectionMode="single"\`. Each item maps \`selected\` from consumer state; the default \`closeOnSelect\` behavior closes the menu after activation.`,
+            },
+        },
+    },
+}
+
+export const MultiSelectHighlight: Story = {
+    render: function MultiSelectHighlightRender() {
+        const [views, setViews] = useState<string[]>(['grid', 'preview'])
+
+        const options = [
+            { id: 'list', label: 'List' },
+            { id: 'grid', label: 'Grid' },
+            { id: 'preview', label: 'Preview pane' },
+            { id: 'sidebar', label: 'Sidebar' },
+        ]
+
+        const toggle = (id: string) => {
+            setViews((previous) =>
+                previous.includes(id)
+                    ? previous.filter((value) => value !== id)
+                    : [...previous, id]
+            )
+        }
+
+        const items: MenuGroupType[] = [
+            {
+                label: 'Visible panels',
+                items: options.map((option) => ({
+                    label: option.label,
+                    selected: views.includes(option.id),
+                    onClick: () => toggle(option.id),
+                })),
+            },
+        ]
+
+        return (
+            <div className="flex flex-col gap-3">
+                <Menu
+                    trigger={
+                        <Button
+                            buttonType={ButtonType.SECONDARY}
+                            text="View options"
+                        />
+                    }
+                    items={items}
+                    selectionStyle="highlight"
+                    selectionMode="multiple"
+                    closeOnSelect={false}
+                />
+                <p className="text-xs text-gray-600">
+                    Controlled multi-select view switcher with{' '}
+                    <code>selectionStyle="highlight"</code>. The menu remains
+                    open because <code>closeOnSelect</code> is false.
+                </p>
+                <div className="text-xs text-gray-600">
+                    Active: <strong>{views.join(', ') || 'none'}</strong>
+                </div>
+            </div>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const trigger = canvas.getByRole('button', { name: /view options/i })
+
+        await userEvent.click(trigger)
+
+        const list = await canvas.findByRole('menuitemcheckbox', {
+            name: /^list$/i,
+        })
+        const grid = canvas.getByRole('menuitemcheckbox', { name: /^grid$/i })
+
+        await expect(list).toHaveAttribute('aria-checked', 'false')
+        await expect(grid).toHaveAttribute('aria-checked', 'true')
+
+        await userEvent.click(list)
+        await expect(
+            await canvas.findByRole('menuitemcheckbox', { name: /^list$/i })
+        ).toHaveAttribute('aria-checked', 'true')
+        await expect(
+            canvas.getByRole('menuitemcheckbox', { name: /^grid$/i })
+        ).toBeInTheDocument()
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: `Controlled multi-select menu with \`selectionStyle="highlight"\`, \`selectionMode="multiple"\`, and \`closeOnSelect={false}\`. Selection state remains fully controlled by the consumer.`,
             },
         },
     },

--- a/packages/blend/Design-docs/Menu/MenuDoc.md
+++ b/packages/blend/Design-docs/Menu/MenuDoc.md
@@ -4,7 +4,7 @@
 
 The Blend design system provides two Menu components:
 
-- **Menu (v1)** – Original component; uses internal or controlled open state; flat props for alignment, side, dimensions, and virtualization; optional `MENU` tokens; some hardcoded styles (e.g. content background, z-index); typo in prop name `collisonBoundaryRef`.
+- **Menu (v1)** – Original component; uses internal or controlled open state; flat props for alignment, side, dimensions, and virtualization; optional `MENU` tokens; controlled item-selection parity with MenuV2; some hardcoded styles (e.g. content background, z-index); typo in prop name `collisonBoundaryRef`.
 - **MenuV2** – Refactored API with **token-driven styling** (no hardcoded colors/z-index/dimensions; content z-index from tokens), controlled item selection, **grouped virtual config** (`virtualScrolling?: { itemHeight?, overscan?, threshold? }`), a **single leading slot on the item label** (`label.leftSlot`), optional `id` on groups and items; correct `collisionBoundaryRef`; TanStack Virtual for large lists; theme via `getMenuV2Tokens(foundationToken, theme)` from `menuV2.tokens`.
 
 Both support: trigger, grouped items with labels and separators, search, submenus with optional submenu search, item variants (default/action), action types (primary/danger), a leading slot, tooltips, virtualization, controlled open state, and Radix-based positioning (alignment, side, offsets, collision boundary).
@@ -22,8 +22,8 @@ Both support: trigger, grouped items with labels and separators, search, submenu
 - **Positioning**: `alignment`, `side`, `sideOffset`, `alignOffset`, `collisionBoundaryRef` (V1 had typo `collisonBoundaryRef`).
 - **Dimensions**: `maxHeight`, `minHeight`, `maxWidth`, `minWidth`; V2 falls back to tokens when min/max width omitted.
 - **State**: `open`, `onOpenChange` for controlled open; `asModal`.
-- **Selection (V2)**: Set `selected: boolean` on selectable items. `selectionStyle` controls checkmark or highlight visuals, `selectionMode` controls single/radio or multiple/checkbox semantics, and `closeOnSelect` defaults to `true`. Selection state remains fully controlled by the consumer.
-- **Accessibility**: Radix menu roles and keyboard navigation; selectable V2 items expose `menuitemradio` or `menuitemcheckbox` with `aria-checked`; focus management; `data-status="disabled"` on disabled items; `_focusVisible` from tokens for focus ring.
+- **Controlled selection (V1 and V2)**: Set `selected: boolean` on selectable items. `selectionStyle` controls checkmark or highlight visuals, `selectionMode` controls single/radio or multiple/checkbox semantics, and `closeOnSelect` defaults to `true`. Selection state remains fully controlled by the consumer; omitting `selected` preserves the legacy action item.
+- **Accessibility**: Radix menu roles and keyboard navigation; selectable V1 and V2 items expose `menuitemradio` or `menuitemcheckbox` with `aria-checked`; focus management; `data-status="disabled"` on disabled items; `_focusVisible` from tokens for focus ring.
 - **Theme**: V1 uses `MENU` tokens; V2 uses `MENU_V2` via `getMenuV2Tokens(foundationToken, theme)` exported from `menuV2.tokens` (light/dark).
 
 ---
@@ -60,7 +60,7 @@ Menu (dropdown):
 
 ### V1: flat props
 
-V1 uses flat props: `alignment`, `side`, `sideOffset`, `alignOffset`, `maxHeight`, `minHeight`, `maxWidth`, `minWidth`, `enableSearch`, `searchPlaceholder`, `enableVirtualScrolling`, `virtualItemHeight`, `virtualOverscan`, `virtualScrollThreshold`, `open`, `onOpenChange`, `asModal`, `collisonBoundaryRef`, `skeleton`.
+V1 uses flat props: `alignment`, `side`, `sideOffset`, `alignOffset`, `maxHeight`, `minHeight`, `maxWidth`, `minWidth`, `enableSearch`, `searchPlaceholder`, `enableVirtualScrolling`, `virtualItemHeight`, `virtualOverscan`, `virtualScrollThreshold`, `open`, `onOpenChange`, `asModal`, `selectionStyle`, `selectionMode`, `closeOnSelect`, `collisonBoundaryRef`, `skeleton`.
 
 ### V2: virtual config and tokens
 
@@ -82,7 +82,7 @@ V2 keeps flat props for positioning and dimensions but:
 | enableSearch, searchPlaceholder                              | ✓                                 | ✓                                     |
 | open, onOpenChange                                           | ✓                                 | ✓                                     |
 | asModal                                                      | ✓                                 | ✓                                     |
-| selectionStyle, selectionMode, closeOnSelect                 | —                                 | ✓                                     |
+| selectionStyle, selectionMode, closeOnSelect                 | ✓                                 | ✓                                     |
 | alignment, side, sideOffset, alignOffset                     | MenuAlignment, MenuSide           | MenuV2Alignment, MenuV2Side           |
 | collisionBoundaryRef                                         | collisonBoundaryRef (typo)        | collisionBoundaryRef                  |
 | enableVirtualScrolling                                       | ✓                                 | ✓                                     |
@@ -93,9 +93,9 @@ V2 keeps flat props for positioning and dimensions but:
 | Item: variant, actionType, disabled, onClick                 | ✓                                 | ✓                                     |
 | Item: subMenu, enableSubMenuSearch, subMenuSearchPlaceholder | ✓                                 | ✓                                     |
 | Item: tooltip, tooltipProps                                  | ✓                                 | ✓                                     |
-| Item: selected                                               | —                                 | optional controlled boolean           |
+| Item: selected                                               | optional controlled boolean       | optional controlled boolean           |
 | Group: label, items, showSeparator                           | ✓                                 | ✓                                     |
-| Group: selectionStyle, selectionMode                         | —                                 | optional overrides                    |
+| Group: selectionStyle, selectionMode                         | optional overrides                | optional overrides                    |
 | Group/Item id                                                | —                                 | optional id                           |
 
 ### V1-only
@@ -105,13 +105,33 @@ V2 keeps flat props for positioning and dimensions but:
 - **skeleton**: V1 supports `skeleton`; V2 does not (removed until implemented).
 - **collisonBoundaryRef** (typo) – same behavior as V2’s `collisionBoundaryRef`.
 
-### V2-only
+### V2-specific APIs
 
 - **slot**: Leading slot prop; `slot1` still supported for compatibility. `getItemSlots(item)` returns `[slot ?? slot1, slot2, slot3, slot4]` (slot takes priority when both set).
 - **virtualScrolling**: Single config object `{ itemHeight?, overscan?, threshold? }`.
 - **id** on `MenuV2GroupType` and `MenuV2ItemType`.
-- **Controlled selection**: `selected?: boolean` marks selectable items; menu/group `selectionStyle` and `selectionMode` resolve visuals and ARIA cardinality independently. `closeOnSelect={false}` keeps the menu open without creating internal selection state.
 - **Token export**: `getMenuV2Tokens` is exported from **`menuV2.tokens`**; content z-index from `menuTokens.content.zIndex` (no SelectV2 constant).
+
+Controlled selection is shared by V1 and V2. The selection prop names and semantics match, but item/group data types remain generation-specific: V1 uses string labels and `slot1`–`slot4`, while V2 uses object labels and its label-slot shape. MenuV2 remains the recommended target for new code; this V1 surface is compatibility parity.
+
+### Manual V2 → V1 selection mapping
+
+The selection state can be reused directly; only the item shape changes:
+
+```tsx
+// Shared consumer state
+const items = [{
+    items: options.map((option) => ({
+        label: option.label, // V1 string label; V2: label: { text: option.label }
+        selected: selectedId === option.id,
+        onClick: () => setSelectedId(option.id),
+    })),
+}]
+
+<Menu selectionStyle="checkmark" selectionMode="single" items={items} />
+```
+
+There is no V1/V2 item-shape adapter or codemod in this compatibility change. Keep stable domain ids in consumer state because V1 item types do not expose the V2 `id` field.
 
 ### Naming and structure differences
 
@@ -130,6 +150,13 @@ V2 keeps flat props for positioning and dimensions but:
 - **flattenMenuV2Groups(groups)**: Flattens groups into `MenuV2FlatRow[]` (label | separator | item) for virtual list.
 - **filterMenuItem**, **filterMenuGroups**: Search filtering; shared with V1-style logic.
 
+### Shared selection internals
+
+`Menu/selection.ts` contains the neutral selection types, context, and pure
+resolver used by both renderers. `MenuV2SelectionContext` re-exports that
+provider and hook under the existing V2 names, so V1 and V2 share selection
+semantics without sharing their token or layout implementations.
+
 ---
 
 ## Token Structure (V2)
@@ -147,6 +174,18 @@ Tokens are defined in `menuV2.tokens.ts`. Theme is selected via **`getMenuV2Toke
 **Helper types**: `MenuV2ItemStates` (from SelectV2); `StateToken<T>` for state-keyed values.
 
 Usage: `tokens.content.zIndex`, `tokens.content.minWidth`, `tokens.content.maxWidth`, `tokens.item.backgroundColor[variant].enabled[state]`, etc. Submenu and content use the same content tokens for layout and stacking.
+
+---
+
+## Token Structure (V1 selection additions)
+
+V1 keeps its existing `MENU` token namespace and slot layout. Generated V1 tokens include:
+
+- `item.backgroundColor[variant].enabled|disabled.selected` for highlight backgrounds.
+- `item.option.color[variant].enabled|disabled.selected` and matching `item.description.color` values for selected text.
+- `item.checkmark.position` (`leading` or `trailing`), `item.checkmark.width`, and `item.checkmark.color` for checkmark selection.
+
+These are additive fields. Existing custom `MENU` overrides that predate selection may omit the new fields; V1 falls back to the default state, a trailing position, and a 16px checkmark width/color rather than requiring a token migration. V1 values use the existing foundation-backed `MENU` palette; MenuV2 remains the theme-aware token implementation.
 
 ---
 
@@ -188,11 +227,11 @@ Usage: `tokens.content.zIndex`, `tokens.content.minWidth`, `tokens.content.maxWi
 
 **Rationale**: Stable keys for lists and submenus; better a11y and testing.
 
-### 7. Controlled selection (V2)
+### 7. Controlled selection (V1 and V2)
 
-**Decision**: Selection is opt-in per item through `selected?: boolean` and is never stored internally. `selectionStyle` controls visual treatment, while `selectionMode` independently controls `menuitemradio` or `menuitemcheckbox` semantics. Both can be overridden per group. `closeOnSelect` defaults to `true` and may be disabled for multi-select workflows.
+**Decision**: Selection is opt-in per item through `selected?: boolean` and is never stored internally. `selectionStyle` controls visual treatment, while `selectionMode` independently controls `menuitemradio` or `menuitemcheckbox` semantics. Both can be overridden per group. `closeOnSelect` defaults to `true` and may be disabled for multi-select workflows. The contract is shared by Menu and MenuV2 even though their item data shapes and token namespaces remain different.
 
-**Rationale**: Consumers can build accessible sort pickers and view switchers without faking checkmarks through slots or coupling visual treatment to selection cardinality. Items that omit `selected` retain the existing action-menu behavior.
+**Rationale**: Consumers can build accessible sort pickers and view switchers without faking checkmarks through slots or coupling visual treatment to selection cardinality. Items that omit `selected` retain the existing action-menu behavior, and consumers can move between Menu generations without remapping selection prop names.
 
 ---
 
@@ -205,7 +244,7 @@ Usage: `tokens.content.zIndex`, `tokens.content.minWidth`, `tokens.content.maxWi
 | Grouped virtual config and TanStack Virtual                            | MenuV2                                 |
 | Simple single-slot API                                                 | MenuV2                                 |
 | Correct `collisionBoundaryRef` spelling                                | MenuV2                                 |
-| Controlled single- or multiple-selection menu                          | MenuV2                                 |
+| Controlled single- or multiple-selection menu                          | Either; MenuV2 preferred for new code  |
 | Per-item virtual height function                                       | Menu (v1)                              |
 | Existing V1 usage with no breaking changes                             | Menu (v1)                              |
 | Same core behavior (trigger, groups, search, submenus, virtualization) | Either; API and tokens differ as above |

--- a/packages/blend/__tests__/components/Menu/Menu.accessibility.test.tsx
+++ b/packages/blend/__tests__/components/Menu/Menu.accessibility.test.tsx
@@ -1244,3 +1244,113 @@ describe('Menu Accessibility', () => {
         })
     })
 })
+
+describe('Menu Selection Accessibility', () => {
+    it('Selection Accessibility exposes conditional radio semantics and passes axe', async () => {
+        const { container, user } = render(
+            <Menu
+                trigger={<button type="button">Open selection menu</button>}
+                selectionMode="single"
+                items={[
+                    {
+                        items: [
+                            { label: 'Current', selected: true },
+                            { label: 'Next', selected: false },
+                            { label: 'Legacy' },
+                        ],
+                    },
+                ]}
+            />
+        )
+
+        await user.click(
+            screen.getByRole('button', { name: 'Open selection menu' })
+        )
+
+        expect(
+            screen.getByRole('menuitemradio', { name: 'Current' })
+        ).toHaveAttribute('aria-checked', 'true')
+        expect(
+            screen.getByRole('menuitemradio', { name: 'Next' })
+        ).toHaveAttribute('aria-checked', 'false')
+        expect(
+            screen.getByRole('menuitem', { name: 'Legacy' })
+        ).not.toHaveAttribute('aria-checked')
+
+        const results = await axe(container, {
+            rules: { 'aria-required-children': { enabled: false } },
+        })
+        expect(results).toHaveNoViolations()
+    })
+
+    it('Selection Accessibility activates a focused radio item once with Enter', async () => {
+        const onClick = vi.fn()
+        const { user } = render(
+            <Menu
+                trigger={<button type="button">Open selection menu</button>}
+                selectionMode="single"
+                items={[
+                    { items: [{ label: 'Next', selected: false, onClick }] },
+                ]}
+            />
+        )
+
+        await user.click(
+            screen.getByRole('button', { name: 'Open selection menu' })
+        )
+        const item = screen.getByRole('menuitemradio', { name: 'Next' })
+        item.focus()
+        await user.keyboard('{Enter}')
+
+        expect(onClick).toHaveBeenCalledTimes(1)
+        await waitFor(() =>
+            expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+        )
+    })
+
+    it('Selection Accessibility keeps a controlled checkbox menu open on Space', async () => {
+        const onClick = vi.fn()
+
+        const ControlledMenu = () => {
+            const [selected, setSelected] = React.useState(false)
+            return (
+                <Menu
+                    trigger={<button type="button">Open selection menu</button>}
+                    selectionMode="multiple"
+                    closeOnSelect={false}
+                    items={[
+                        {
+                            items: [
+                                {
+                                    label: 'Toggle me',
+                                    selected,
+                                    onClick: () => {
+                                        onClick()
+                                        setSelected(true)
+                                    },
+                                },
+                            ],
+                        },
+                    ]}
+                />
+            )
+        }
+
+        const { user } = render(<ControlledMenu />)
+        await user.click(
+            screen.getByRole('button', { name: 'Open selection menu' })
+        )
+        const item = screen.getByRole('menuitemcheckbox', { name: 'Toggle me' })
+        expect(item).toHaveAttribute('aria-checked', 'false')
+        item.focus()
+        await user.keyboard(' ')
+
+        expect(onClick).toHaveBeenCalledTimes(1)
+        await waitFor(() =>
+            expect(
+                screen.getByRole('menuitemcheckbox', { name: 'Toggle me' })
+            ).toHaveAttribute('aria-checked', 'true')
+        )
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+    })
+})

--- a/packages/blend/__tests__/components/Menu/Menu.selection.test.tsx
+++ b/packages/blend/__tests__/components/Menu/Menu.selection.test.tsx
@@ -1,0 +1,292 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '../../test-utils'
+import Menu from '../../../lib/components/Menu/Menu'
+import ThemeProvider from '../../../lib/context/ThemeProvider'
+import { FOUNDATION_THEME } from '../../../lib/tokens'
+import { getMenuTokens } from '../../../lib/components/Menu/menu.tokens'
+
+const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole('button', { name: 'Open menu' }))
+    return screen.findByRole('menu')
+}
+
+describe('Menu controlled selection', () => {
+    it('keeps omitted selected items on the legacy menuitem path', async () => {
+        const user = userEvent.setup()
+        const menuItems = [
+            {
+                items: [
+                    { label: 'Legacy item' },
+                    { label: 'Unselected item', selected: false },
+                    { label: 'Selected item', selected: true },
+                ],
+            },
+        ]
+
+        const menu = await (async () => {
+            render(
+                <Menu
+                    trigger={<button type="button">Open menu</button>}
+                    items={menuItems}
+                />
+            )
+            return openMenu(user)
+        })()
+
+        expect(
+            screen.getByRole('menuitem', { name: 'Legacy item' })
+        ).not.toHaveAttribute('aria-checked')
+        expect(
+            screen.getByRole('menuitemradio', { name: 'Unselected item' })
+        ).toHaveAttribute('aria-checked', 'false')
+        const selectedItem = screen.getByRole('menuitemradio', {
+            name: 'Selected item',
+        })
+        expect(selectedItem).toHaveAttribute('aria-checked', 'true')
+        expect(
+            menu.querySelectorAll('[data-element="menu-item-checkmark"]')
+        ).toHaveLength(1)
+    })
+
+    it('uses highlight tokens and group overrides independently', async () => {
+        const user = userEvent.setup()
+        render(
+            <Menu
+                trigger={<button type="button">Open menu</button>}
+                selectionStyle="highlight"
+                selectionMode="multiple"
+                items={[
+                    {
+                        selectionStyle: 'checkmark',
+                        selectionMode: 'single',
+                        items: [{ label: 'Radio item', selected: true }],
+                    },
+                    {
+                        items: [{ label: 'Checkbox item', selected: true }],
+                    },
+                ]}
+            />
+        )
+
+        await openMenu(user)
+
+        const radio = screen.getByRole('menuitemradio', {
+            name: 'Radio item',
+        })
+        const checkbox = screen.getByRole('menuitemcheckbox', {
+            name: 'Checkbox item',
+        })
+        expect(radio).toHaveAttribute('data-selection-style', 'checkmark')
+        expect(checkbox).toHaveAttribute('data-selection-style', 'highlight')
+        expect(
+            radio.querySelector('[data-element="menu-item-checkmark"]')
+        ).toBeInTheDocument()
+        expect(
+            checkbox.querySelector('[data-element="menu-item-checkmark"]')
+        ).not.toBeInTheDocument()
+    })
+
+    it('preserves empty submenu triggers unless selected is explicit', async () => {
+        const user = userEvent.setup()
+        render(
+            <Menu
+                trigger={<button type="button">Open menu</button>}
+                items={[
+                    {
+                        items: [
+                            { label: 'Legacy empty submenu', subMenu: [] },
+                            {
+                                label: 'Unselected empty submenu',
+                                subMenu: [],
+                                selected: false,
+                            },
+                            {
+                                label: 'Selected empty submenu',
+                                subMenu: [],
+                                selected: true,
+                            },
+                        ],
+                    },
+                ]}
+            />
+        )
+
+        await openMenu(user)
+
+        expect(
+            screen.getByRole('menuitem', { name: 'Legacy empty submenu' })
+        ).toHaveAttribute('aria-haspopup', 'menu')
+        expect(
+            screen.getByRole('menuitemradio', {
+                name: 'Unselected empty submenu',
+            })
+        ).toHaveAttribute('aria-checked', 'false')
+        expect(
+            screen.getByRole('menuitemradio', {
+                name: 'Selected empty submenu',
+            })
+        ).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('uses the V1 checkmark token position without changing the slot order', async () => {
+        const user = userEvent.setup()
+        const tokens = getMenuTokens(FOUNDATION_THEME)
+        const leadingTokens = {
+            sm: {
+                ...tokens.sm,
+                item: {
+                    ...tokens.sm.item,
+                    checkmark: {
+                        ...tokens.sm.item.checkmark,
+                        position: 'leading' as const,
+                    },
+                },
+            },
+            lg: {
+                ...tokens.lg,
+                item: {
+                    ...tokens.lg.item,
+                    checkmark: {
+                        ...tokens.lg.item.checkmark,
+                        position: 'leading' as const,
+                    },
+                },
+            },
+        }
+
+        render(
+            <ThemeProvider componentTokens={{ MENU: leadingTokens }}>
+                <Menu
+                    trigger={<button type="button">Open menu</button>}
+                    items={[{ items: [{ label: 'Selected', selected: true }] }]}
+                />
+            </ThemeProvider>
+        )
+
+        await openMenu(user)
+        const item = screen.getByRole('menuitemradio', { name: 'Selected' })
+        expect(
+            item.querySelector('[data-element="menu-item-checkmark"]')
+        ).toHaveAttribute('data-position', 'leading')
+    })
+
+    it('falls back when a legacy MENU override has no selection branches', async () => {
+        const user = userEvent.setup()
+        const stripSelectionFields = (value: unknown): unknown => {
+            if (Array.isArray(value)) {
+                return value.map(stripSelectionFields)
+            }
+            if (value && typeof value === 'object') {
+                return Object.fromEntries(
+                    Object.entries(value)
+                        .filter(
+                            ([key]) => key !== 'selected' && key !== 'checkmark'
+                        )
+                        .map(([key, nestedValue]) => [
+                            key,
+                            stripSelectionFields(nestedValue),
+                        ])
+                )
+            }
+            return value
+        }
+        const legacyTokens = stripSelectionFields(
+            getMenuTokens(FOUNDATION_THEME)
+        ) as ReturnType<typeof getMenuTokens>
+
+        render(
+            <ThemeProvider componentTokens={{ MENU: legacyTokens }}>
+                <Menu
+                    trigger={<button type="button">Open menu</button>}
+                    selectionStyle="highlight"
+                    selectionMode="multiple"
+                    items={[{ items: [{ label: 'Selected', selected: true }] }]}
+                />
+            </ThemeProvider>
+        )
+
+        await openMenu(user)
+        expect(
+            screen.getByRole('menuitemcheckbox', { name: 'Selected' })
+        ).toBeInTheDocument()
+    })
+
+    it('calls the controlled callback once and closes by default', async () => {
+        const user = userEvent.setup()
+        const onClick = vi.fn()
+        render(
+            <Menu
+                trigger={<button type="button">Open menu</button>}
+                items={[{ items: [{ label: 'Select me', onClick }] }]}
+            />
+        )
+
+        await openMenu(user)
+        await user.click(screen.getByRole('menuitem', { name: 'Select me' }))
+
+        expect(onClick).toHaveBeenCalledTimes(1)
+        await waitFor(() =>
+            expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+        )
+    })
+
+    it('keeps the menu open when closeOnSelect is false', async () => {
+        const user = userEvent.setup()
+        const onClick = vi.fn()
+        render(
+            <Menu
+                trigger={<button type="button">Open menu</button>}
+                closeOnSelect={false}
+                items={[{ items: [{ label: 'Select me', onClick }] }]}
+            />
+        )
+
+        await openMenu(user)
+        await user.click(screen.getByRole('menuitem', { name: 'Select me' }))
+
+        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+    })
+
+    it('propagates selection config through submenu and virtual leaves', async () => {
+        const user = userEvent.setup()
+        render(
+            <Menu
+                trigger={<button type="button">Open menu</button>}
+                selectionMode="multiple"
+                closeOnSelect={false}
+                enableVirtualScrolling
+                virtualScrollThreshold={0}
+                items={[
+                    {
+                        items: [
+                            {
+                                label: 'Submenu',
+                                subMenu: [
+                                    { label: 'Nested item', selected: true },
+                                ],
+                            },
+                            ...Array.from({ length: 25 }, (_, index) => ({
+                                label: `Virtual ${index}`,
+                                selected: index === 0,
+                            })),
+                        ],
+                    },
+                ]}
+            />
+        )
+
+        await openMenu(user)
+        expect(
+            screen.getByRole('menuitemcheckbox', { name: 'Virtual 0' })
+        ).toHaveAttribute('aria-checked', 'true')
+        await user.click(screen.getByRole('menuitem', { name: 'Submenu' }))
+        expect(
+            await screen.findByRole('menuitemcheckbox', {
+                name: 'Nested item',
+            })
+        ).toHaveAttribute('aria-checked', 'true')
+    })
+})

--- a/packages/blend/lib/components/Menu/Menu.tsx
+++ b/packages/blend/lib/components/Menu/Menu.tsx
@@ -7,6 +7,12 @@ import {
     MenuSide,
     type MenuItemType,
 } from './types'
+import {
+    MenuSelectionProvider,
+    type MenuSelectionContextValue,
+    type MenuSelectionMode,
+    type MenuSelectionStyle,
+} from './selection'
 import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { filterMenuGroups, defaultSearchSortFn } from './utils'
 import MenuItem from './MenuItem'
@@ -50,6 +56,20 @@ const Content = styled(RadixMenu.Content)`
     ${menuContentAnimations}
 `
 
+type SelectionContentProps = React.ComponentProps<typeof Content> & {
+    selectionContextValue: MenuSelectionContextValue
+}
+
+const SelectionContent = ({
+    selectionContextValue,
+    children,
+    ...props
+}: SelectionContentProps) => (
+    <MenuSelectionProvider value={selectionContextValue}>
+        <Content {...props}>{children}</Content>
+    </MenuSelectionProvider>
+)
+
 const Menu = ({
     trigger,
     items = [],
@@ -68,6 +88,9 @@ const Menu = ({
     maxWidth,
     open,
     onOpenChange,
+    selectionStyle,
+    selectionMode,
+    closeOnSelect = true,
     enableVirtualScrolling = false,
     virtualItemHeight = 40,
     virtualOverscan = 5,
@@ -86,6 +109,11 @@ const Menu = ({
     const filteredItems = filterMenuGroups(items, searchText, searchSortFn)
     const menuTokens = useResponsiveTokens<MenuTokensType>('MENU')
     const { target: portalContainer } = useShadowRoot()
+
+    const selectionContextValue = useMemo(
+        () => ({ selectionStyle, selectionMode, closeOnSelect }),
+        [selectionStyle, selectionMode, closeOnSelect]
+    )
 
     const menuIsOpen = open ?? isOpen
     useDropdownInteractionLock(asModal && menuIsOpen)
@@ -156,6 +184,8 @@ const Menu = ({
                         originalItem: item,
                         groupId,
                         itemIndex,
+                        selectionStyle: group.selectionStyle,
+                        selectionMode: group.selectionMode,
                     },
                 })
             })
@@ -186,12 +216,22 @@ const Menu = ({
     const renderVirtualItem = useCallback(
         ({ item }: { item: VirtualListItem; index: number }) => {
             const data = item.data || {}
-            const { type, label, originalItem, groupId, itemIndex } = data as {
+            const {
+                type,
+                label,
+                originalItem,
+                groupId,
+                itemIndex,
+                selectionStyle,
+                selectionMode,
+            } = data as {
                 type?: string
                 label?: string
                 originalItem?: unknown
                 groupId?: number
                 itemIndex?: number
+                selectionStyle?: MenuSelectionStyle
+                selectionMode?: MenuSelectionMode
             }
 
             if (type === 'label') {
@@ -235,6 +275,8 @@ const Menu = ({
                         item={originalItem as MenuItemType}
                         idx={itemIndex || 0}
                         maxHeight={maxHeight}
+                        selectionStyle={selectionStyle}
+                        selectionMode={selectionMode}
                     />
                 )
             }
@@ -253,7 +295,8 @@ const Menu = ({
         >
             <RadixMenu.Trigger asChild>{trigger}</RadixMenu.Trigger>
             <RadixMenu.Portal container={portalContainer ?? undefined}>
-                <Content
+                <SelectionContent
+                    selectionContextValue={selectionContextValue}
                     data-menu="menu"
                     data-dropdown="dropdown"
                     sideOffset={sideOffset}
@@ -311,19 +354,19 @@ const Menu = ({
                             flexDirection="column"
                             gap={menuTokens.item.gap}
                         >
-                            {Array.from({ length: skeleton.count || 3 }).map(
-                                (_, index) => (
-                                    <Skeleton
-                                        key={index}
-                                        width="100%"
-                                        height="33px"
-                                        variant={
-                                            (skeleton.variant as SkeletonVariant) ||
-                                            'pulse'
-                                        }
-                                    />
-                                )
-                            )}
+                            {Array.from({
+                                length: skeleton.count || 3,
+                            }).map((_, index) => (
+                                <Skeleton
+                                    key={index}
+                                    width="100%"
+                                    height="33px"
+                                    variant={
+                                        (skeleton.variant as SkeletonVariant) ||
+                                        'pulse'
+                                    }
+                                />
+                            ))}
                         </Block>
                     ) : (
                         <>
@@ -467,6 +510,12 @@ const Menu = ({
                                                             maxHeight={
                                                                 maxHeight
                                                             }
+                                                            selectionStyle={
+                                                                group.selectionStyle
+                                                            }
+                                                            selectionMode={
+                                                                group.selectionMode
+                                                            }
                                                         />
                                                     )
                                                 )}
@@ -515,7 +564,7 @@ const Menu = ({
                             )}
                         </>
                     )}
-                </Content>
+                </SelectionContent>
             </RadixMenu.Portal>
         </RadixMenu.Root>
     )

--- a/packages/blend/lib/components/Menu/MenuItem.tsx
+++ b/packages/blend/lib/components/Menu/MenuItem.tsx
@@ -1,13 +1,24 @@
 import * as RadixMenu from '@radix-ui/react-dropdown-menu'
 import React from 'react'
+import { Check } from 'lucide-react'
 import { MenuItemActionType, type MenuItemType, MenuItemVariant } from './types'
 // eslint-disable-next-line import-x/no-cycle -- intentional recursion: MenuItem renders SubMenu which renders MenuItem
 import { SubMenu } from './SubMenu'
 import Block from '../Primitives/Block/Block'
 import Text from '../Text/Text'
-import { type MenuItemStates, type MenuTokensType } from './menu.tokens'
+import {
+    getMenuItemStateToken,
+    type MenuItemSelectionStates,
+    type MenuTokensType,
+} from './menu.tokens'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { Tooltip } from '../Tooltip'
+import {
+    resolveMenuSelection,
+    useMenuSelection,
+    type MenuSelectionMode,
+    type MenuSelectionStyle,
+} from './selection'
 
 const MenuSlot = ({
     slot,
@@ -34,8 +45,41 @@ const MenuSlot = ({
     )
 }
 
+const CheckmarkIndicator = ({
+    menuTokens,
+    disabled,
+}: {
+    menuTokens: MenuTokensType
+    disabled?: boolean
+}) => {
+    const checkmark = menuTokens.item.checkmark
+    const position = checkmark?.position ?? 'trailing'
+    const width = checkmark?.width ?? 16
+
+    return (
+        <Block
+            data-element="menu-item-checkmark"
+            data-position={position}
+            flexShrink={0}
+            display="flex"
+            alignItems="center"
+            contentCentered
+            maxWidth={width}
+            maxHeight={width}
+            aria-hidden="true"
+        >
+            <Check
+                size={typeof width === 'number' ? width : 16}
+                color={checkmark?.color}
+                data-state="selected"
+                data-status={disabled ? 'disabled' : 'enabled'}
+            />
+        </Block>
+    )
+}
+
 const getBgColor = (
-    state: MenuItemStates,
+    state: MenuItemSelectionStates,
     menuTokens: MenuTokensType,
     item: MenuItemType
 ) => {
@@ -44,9 +88,9 @@ const getBgColor = (
     // check for variant
     if (item.variant === MenuItemVariant.DEFAULT) {
         if (!item.disabled) {
-            return bg.default.enabled[state]
+            return getMenuItemStateToken(bg.default.enabled, state)
         } else {
-            return bg.default.disabled[state]
+            return getMenuItemStateToken(bg.default.disabled, state)
         }
     } else {
         // check for action type
@@ -55,22 +99,22 @@ const getBgColor = (
         }
         if (item.actionType === MenuItemActionType.PRIMARY) {
             if (!item.disabled) {
-                return bg.action.primary.enabled[state]
+                return getMenuItemStateToken(bg.action.primary.enabled, state)
             } else {
-                return bg.action.primary.disabled[state]
+                return getMenuItemStateToken(bg.action.primary.disabled, state)
             }
         } else {
             if (!item.disabled) {
-                return bg.action.danger.enabled[state]
+                return getMenuItemStateToken(bg.action.danger.enabled, state)
             } else {
-                return bg.action.danger.disabled[state]
+                return getMenuItemStateToken(bg.action.danger.disabled, state)
             }
         }
     }
 }
 
 const getColor = (
-    state: MenuItemStates,
+    state: MenuItemSelectionStates,
     menuTokens: MenuTokensType,
     item: MenuItemType
 ) => {
@@ -79,9 +123,9 @@ const getColor = (
     // check for variant
     if (item.variant === MenuItemVariant.DEFAULT) {
         if (!item.disabled) {
-            return bg.default.enabled[state]
+            return getMenuItemStateToken(bg.default.enabled, state)
         } else {
-            return bg.default.disabled[state]
+            return getMenuItemStateToken(bg.default.disabled, state)
         }
     } else {
         // check for action type
@@ -90,15 +134,15 @@ const getColor = (
         }
         if (item.actionType === MenuItemActionType.PRIMARY) {
             if (!item.disabled) {
-                return bg.action.primary.enabled[state]
+                return getMenuItemStateToken(bg.action.primary.enabled, state)
             } else {
-                return bg.action.primary.disabled[state]
+                return getMenuItemStateToken(bg.action.primary.disabled, state)
             }
         } else {
             if (!item.disabled) {
-                return bg.action.danger.enabled[state]
+                return getMenuItemStateToken(bg.action.danger.enabled, state)
             } else {
-                return bg.action.danger.disabled[state]
+                return getMenuItemStateToken(bg.action.danger.disabled, state)
             }
         }
     }
@@ -108,43 +152,104 @@ const MenuItem = ({
     item,
     idx,
     maxHeight,
+    selectionStyle: groupSelectionStyle,
+    selectionMode: groupSelectionMode,
 }: {
     item: MenuItemType
     idx: number
     maxHeight?: number
+    selectionStyle?: MenuSelectionStyle
+    selectionMode?: MenuSelectionMode
 }) => {
     const menuTokens = useResponsiveTokens<MenuTokensType>('MENU')
-    if (item.subMenu) {
-        return <SubMenu item={item} idx={idx} maxHeight={maxHeight} />
+    const {
+        selectionStyle: menuSelectionStyle,
+        selectionMode: menuSelectionMode,
+        closeOnSelect,
+    } = useMenuSelection()
+
+    const isSubMenu =
+        item.subMenu &&
+        (item.subMenu.length > 0 || typeof item.selected !== 'boolean')
+
+    if (isSubMenu) {
+        return (
+            <SubMenu
+                item={item}
+                idx={idx}
+                maxHeight={maxHeight}
+                selectionStyle={groupSelectionStyle}
+                selectionMode={groupSelectionMode}
+            />
+        )
     }
     if (item.variant === undefined) {
         item.variant = MenuItemVariant.DEFAULT
+    }
+
+    const selection = resolveMenuSelection({
+        selected: item.selected,
+        groupSelectionStyle,
+        groupSelectionMode,
+        menuSelectionStyle,
+        menuSelectionMode,
+    })
+    const useHighlight =
+        selection.selectionStyle === 'highlight' && selection.isSelected
+    const showCheckmark =
+        selection.selectionStyle === 'checkmark' && selection.isSelected
+    const checkmarkPosition = menuTokens.item.checkmark?.position ?? 'trailing'
+    const showLeadingCheck = showCheckmark && checkmarkPosition === 'leading'
+    const showTrailingCheck = showCheckmark && checkmarkPosition === 'trailing'
+    const defaultState: MenuItemSelectionStates = useHighlight
+        ? 'selected'
+        : 'default'
+
+    const handleSelect = (event: Event) => {
+        if (item.disabled) return
+        if (!closeOnSelect) {
+            event.preventDefault()
+        }
+        item.onClick?.()
     }
 
     const menuItemContent = (
         <RadixMenu.Item
             asChild
             disabled={item.disabled}
+            onSelect={item.disabled ? undefined : handleSelect}
             style={{ outline: 'none', border: 'none', userSelect: 'none' }}
         >
             <Block
                 key={idx}
+                {...(selection.selectionRole
+                    ? { role: selection.selectionRole }
+                    : {})}
+                {...(selection.isSelectable
+                    ? { 'aria-checked': selection.isSelected }
+                    : {})}
                 data-element="select-item"
                 data-status={item.disabled ? 'disabled' : 'enabled'}
                 data-numeric={idx + 1}
                 data-id={item.label}
+                {...(selection.isSelected ? { 'data-state': 'selected' } : {})}
+                {...(selection.selectionStyle
+                    ? { 'data-selection-style': selection.selectionStyle }
+                    : {})}
+                {...(selection.selectionMode
+                    ? { 'data-selection-mode': selection.selectionMode }
+                    : {})}
                 display="flex"
                 paddingX={menuTokens.item.padding.x}
                 paddingY={menuTokens.item.padding.y}
                 marginY={menuTokens.item.margin.y}
                 marginX={menuTokens.item.margin.x}
                 borderRadius={menuTokens.item.borderRadius}
-                onClick={item.disabled ? undefined : item.onClick}
                 cursor={item.disabled ? 'not-allowed' : 'pointer'}
                 flexDirection="column"
                 gap={menuTokens.item.gap}
-                backgroundColor={getBgColor('default', menuTokens, item)}
-                color={getColor('default', menuTokens, item)}
+                backgroundColor={getBgColor(defaultState, menuTokens, item)}
+                color={getColor(defaultState, menuTokens, item)}
                 _hover={{
                     backgroundColor: getBgColor('hover', menuTokens, item),
                 }}
@@ -169,6 +274,12 @@ const MenuItem = ({
                     width="100%"
                     overflow="hidden"
                 >
+                    {showLeadingCheck && (
+                        <CheckmarkIndicator
+                            menuTokens={menuTokens}
+                            disabled={item.disabled}
+                        />
+                    )}
                     {item.slot1 && (
                         <Block data-element="slot-1">
                             <MenuSlot slot={item.slot1} isDecorative={true} />
@@ -185,7 +296,7 @@ const MenuItem = ({
                     >
                         <Text
                             data-text={item.label}
-                            color={getColor('default', menuTokens, item)}
+                            color={getColor(defaultState, menuTokens, item)}
                             fontWeight={menuTokens.item.option.fontWeight}
                             fontSize={menuTokens.item.option.fontSize}
                             truncate
@@ -208,6 +319,12 @@ const MenuItem = ({
                             <MenuSlot slot={item.slot4} isDecorative={true} />
                         </Block>
                     )}
+                    {showTrailingCheck && (
+                        <CheckmarkIndicator
+                            menuTokens={menuTokens}
+                            disabled={item.disabled}
+                        />
+                    )}
                 </Block>
                 {item.subLabel && (
                     <Block
@@ -218,7 +335,7 @@ const MenuItem = ({
                         width="100%"
                     >
                         <Text
-                            color={getColor('default', menuTokens, item)}
+                            color={getColor(defaultState, menuTokens, item)}
                             fontWeight={menuTokens.item.description.fontWeight}
                             fontSize={menuTokens.item.description.fontSize}
                         >

--- a/packages/blend/lib/components/Menu/SubMenu.tsx
+++ b/packages/blend/lib/components/Menu/SubMenu.tsx
@@ -6,7 +6,11 @@ import Text from '../Text/Text'
 // eslint-disable-next-line import-x/no-cycle -- intentional recursion: SubMenu renders MenuItem which renders SubMenu
 import MenuItem from './MenuItem'
 import { ChevronRightIcon, Search } from 'lucide-react'
-import { type MenuItemStates, type MenuTokensType } from './menu.tokens'
+import {
+    getMenuItemStateToken,
+    type MenuItemStates,
+    type MenuTokensType,
+} from './menu.tokens'
 import PrimitiveText from '../Primitives/PrimitiveText/PrimitiveText'
 import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import SearchInput from '../Inputs/SearchInput/SearchInput'
@@ -15,6 +19,7 @@ import { filterMenuItem, defaultSearchSortFn } from './utils'
 import React, { useState, useRef, useMemo, useCallback } from 'react'
 import { submenuContentAnimations } from './menu.animations'
 import { VirtualList, type VirtualListItem } from '../VirtualList'
+import type { MenuSelectionMode, MenuSelectionStyle } from './selection'
 
 const MenuSlot = ({ slot }: { slot: React.ReactNode }) => {
     return (
@@ -57,9 +62,9 @@ const getBgColor = (
         (item.subMenu && item.subMenu.length > 0)
     ) {
         if (!item.disabled) {
-            return bg.default.enabled[state]
+            return getMenuItemStateToken(bg.default.enabled, state)
         } else {
-            return bg.default.disabled[state]
+            return getMenuItemStateToken(bg.default.disabled, state)
         }
     } else {
         // check for action type
@@ -68,15 +73,15 @@ const getBgColor = (
         }
         if (item.actionType === MenuItemActionType.PRIMARY) {
             if (!item.disabled) {
-                return bg.action.primary.enabled[state]
+                return getMenuItemStateToken(bg.action.primary.enabled, state)
             } else {
-                return bg.action.primary.disabled[state]
+                return getMenuItemStateToken(bg.action.primary.disabled, state)
             }
         } else {
             if (!item.disabled) {
-                return bg.action.danger.enabled[state]
+                return getMenuItemStateToken(bg.action.danger.enabled, state)
             } else {
-                return bg.action.danger.disabled[state]
+                return getMenuItemStateToken(bg.action.danger.disabled, state)
             }
         }
     }
@@ -95,9 +100,9 @@ const getLabelColor = (
         (item.subMenu && item.subMenu.length > 0)
     ) {
         if (!item.disabled) {
-            return bg.default.enabled[state]
+            return getMenuItemStateToken(bg.default.enabled, state)
         } else {
-            return bg.default.disabled[state]
+            return getMenuItemStateToken(bg.default.disabled, state)
         }
     } else {
         // check for action type
@@ -106,15 +111,15 @@ const getLabelColor = (
         }
         if (item.actionType === MenuItemActionType.PRIMARY) {
             if (!item.disabled) {
-                return bg.action.primary.enabled[state]
+                return getMenuItemStateToken(bg.action.primary.enabled, state)
             } else {
-                return bg.action.primary.disabled[state]
+                return getMenuItemStateToken(bg.action.primary.disabled, state)
             }
         } else {
             if (!item.disabled) {
-                return bg.action.danger.enabled[state]
+                return getMenuItemStateToken(bg.action.danger.enabled, state)
             } else {
-                return bg.action.danger.disabled[state]
+                return getMenuItemStateToken(bg.action.danger.disabled, state)
             }
         }
     }
@@ -133,9 +138,9 @@ const getSubLabelColor = (
         (item.subMenu && item.subMenu.length > 0)
     ) {
         if (!item.disabled) {
-            return bg.default.enabled[state]
+            return getMenuItemStateToken(bg.default.enabled, state)
         } else {
-            return bg.default.disabled[state]
+            return getMenuItemStateToken(bg.default.disabled, state)
         }
     } else {
         // check for action type
@@ -144,15 +149,15 @@ const getSubLabelColor = (
         }
         if (item.actionType === MenuItemActionType.PRIMARY) {
             if (!item.disabled) {
-                return bg.action.primary.enabled[state]
+                return getMenuItemStateToken(bg.action.primary.enabled, state)
             } else {
-                return bg.action.primary.disabled[state]
+                return getMenuItemStateToken(bg.action.primary.disabled, state)
             }
         } else {
             if (!item.disabled) {
-                return bg.action.danger.enabled[state]
+                return getMenuItemStateToken(bg.action.danger.enabled, state)
             } else {
-                return bg.action.danger.disabled[state]
+                return getMenuItemStateToken(bg.action.danger.disabled, state)
             }
         }
     }
@@ -162,10 +167,14 @@ export const SubMenu = ({
     item,
     idx,
     maxHeight,
+    selectionStyle,
+    selectionMode,
 }: {
     item: MenuItemType
     idx: number
     maxHeight?: number
+    selectionStyle?: MenuSelectionStyle
+    selectionMode?: MenuSelectionMode
 }) => {
     const menuTokens = useResponsiveTokens<MenuTokensType>('MENU')
     const [searchText, setSearchText] = useState<string>('')
@@ -223,9 +232,17 @@ export const SubMenu = ({
     const renderVirtualItem = useCallback(
         ({ item }: { item: VirtualListItem; index: number }) => {
             const data = item.data as { item: MenuItemType; idx: number }
-            return <MenuItem key={data.idx} item={data.item} idx={data.idx} />
+            return (
+                <MenuItem
+                    key={data.idx}
+                    item={data.item}
+                    idx={data.idx}
+                    selectionStyle={selectionStyle}
+                    selectionMode={selectionMode}
+                />
+            )
         },
-        []
+        [selectionMode, selectionStyle]
     )
 
     const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -432,6 +449,8 @@ export const SubMenu = ({
                                     key={subIdx}
                                     item={subItem}
                                     idx={subIdx}
+                                    selectionStyle={selectionStyle}
+                                    selectionMode={selectionMode}
                                 />
                             ))}
                         </>

--- a/packages/blend/lib/components/Menu/menu.tokens.ts
+++ b/packages/blend/lib/components/Menu/menu.tokens.ts
@@ -10,6 +10,16 @@ export type MenuItemStates =
     | 'focus'
     | 'focusVisible'
     | 'disabled'
+export type MenuItemSelectionStates = MenuItemStates | 'selected'
+
+export type MenuItemStateTokens<T> = {
+    [key in MenuItemStates]: T
+} & { selected?: T }
+
+export const getMenuItemStateToken = <T>(
+    stateTokens: MenuItemStateTokens<T>,
+    state: MenuItemSelectionStates
+) => stateTokens[state] ?? stateTokens.default
 
 export type MenuTokensType = {
     boxShadow: CSSObject['boxShadow']
@@ -33,25 +43,22 @@ export type MenuTokensType = {
         borderRadius: CSSObject['borderRadius']
         backgroundColor: {
             [MenuItemVariant.DEFAULT]: {
-                enabled: {
-                    [key in MenuItemStates]: CSSObject['backgroundColor']
-                }
-                disabled: {
-                    [key in MenuItemStates]: CSSObject['backgroundColor']
-                }
+                enabled: MenuItemStateTokens<CSSObject['backgroundColor']>
+                disabled: MenuItemStateTokens<CSSObject['backgroundColor']>
             }
             [MenuItemVariant.ACTION]: {
                 [key in MenuItemActionType]: {
-                    enabled: {
-                        [key in MenuItemStates]: CSSObject['backgroundColor']
-                    }
-                    disabled: {
-                        [key in MenuItemStates]: CSSObject['backgroundColor']
-                    }
+                    enabled: MenuItemStateTokens<CSSObject['backgroundColor']>
+                    disabled: MenuItemStateTokens<CSSObject['backgroundColor']>
                 }
             }
         }
         gap: CSSObject['gap']
+        checkmark?: {
+            position?: 'leading' | 'trailing'
+            width?: CSSObject['width']
+            color?: CSSObject['color']
+        }
         optionsLabel: {
             fontSize: CSSObject['fontSize']
             fontWeight: CSSObject['fontWeight']
@@ -70,21 +77,13 @@ export type MenuTokensType = {
             fontWeight: CSSObject['fontWeight']
             color: {
                 [MenuItemVariant.DEFAULT]: {
-                    enabled: {
-                        [key in MenuItemStates]: CSSObject['color']
-                    }
-                    disabled: {
-                        [key in MenuItemStates]: CSSObject['color']
-                    }
+                    enabled: MenuItemStateTokens<CSSObject['color']>
+                    disabled: MenuItemStateTokens<CSSObject['color']>
                 }
                 [MenuItemVariant.ACTION]: {
                     [key in MenuItemActionType]: {
-                        enabled: {
-                            [key in MenuItemStates]: CSSObject['color']
-                        }
-                        disabled: {
-                            [key in MenuItemStates]: CSSObject['color']
-                        }
+                        enabled: MenuItemStateTokens<CSSObject['color']>
+                        disabled: MenuItemStateTokens<CSSObject['color']>
                     }
                 }
             }
@@ -94,21 +93,13 @@ export type MenuTokensType = {
             fontWeight: CSSObject['fontWeight']
             color: {
                 [MenuItemVariant.DEFAULT]: {
-                    enabled: {
-                        [key in MenuItemStates]: CSSObject['color']
-                    }
-                    disabled: {
-                        [key in MenuItemStates]: CSSObject['color']
-                    }
+                    enabled: MenuItemStateTokens<CSSObject['color']>
+                    disabled: MenuItemStateTokens<CSSObject['color']>
                 }
                 [MenuItemVariant.ACTION]: {
                     [key in MenuItemActionType]: {
-                        enabled: {
-                            [key in MenuItemStates]: CSSObject['color']
-                        }
-                        disabled: {
-                            [key in MenuItemStates]: CSSObject['color']
-                        }
+                        enabled: MenuItemStateTokens<CSSObject['color']>
+                        disabled: MenuItemStateTokens<CSSObject['color']>
                     }
                 }
             }
@@ -128,10 +119,153 @@ export type ResponsiveMenuTokensType = {
     [key in keyof BreakpointType]: MenuTokensType
 }
 
+const withSelectionTokens = (
+    tokens: MenuTokensType,
+    foundationToken: FoundationTokenType
+): MenuTokensType => ({
+    ...tokens,
+    item: {
+        ...tokens.item,
+        checkmark: {
+            position: 'trailing',
+            width: foundationToken.unit[16],
+            color: foundationToken.colors.gray[600],
+            ...tokens.item.checkmark,
+        },
+        backgroundColor: {
+            ...tokens.item.backgroundColor,
+            default: {
+                ...tokens.item.backgroundColor.default,
+                enabled: {
+                    ...tokens.item.backgroundColor.default.enabled,
+                    selected: foundationToken.colors.gray[50],
+                },
+                disabled: {
+                    ...tokens.item.backgroundColor.default.disabled,
+                    selected: foundationToken.colors.gray[0],
+                },
+            },
+            action: {
+                ...tokens.item.backgroundColor.action,
+                primary: {
+                    ...tokens.item.backgroundColor.action.primary,
+                    enabled: {
+                        ...tokens.item.backgroundColor.action.primary.enabled,
+                        selected: foundationToken.colors.primary[50],
+                    },
+                    disabled: {
+                        ...tokens.item.backgroundColor.action.primary.disabled,
+                        selected: foundationToken.colors.gray[0],
+                    },
+                },
+                danger: {
+                    ...tokens.item.backgroundColor.action.danger,
+                    enabled: {
+                        ...tokens.item.backgroundColor.action.danger.enabled,
+                        selected: foundationToken.colors.red[50],
+                    },
+                    disabled: {
+                        ...tokens.item.backgroundColor.action.danger.disabled,
+                        selected: foundationToken.colors.gray[0],
+                    },
+                },
+            },
+        },
+        option: {
+            ...tokens.item.option,
+            color: {
+                ...tokens.item.option.color,
+                default: {
+                    ...tokens.item.option.color.default,
+                    enabled: {
+                        ...tokens.item.option.color.default.enabled,
+                        selected: foundationToken.colors.gray[600],
+                    },
+                    disabled: {
+                        ...tokens.item.option.color.default.disabled,
+                        selected: foundationToken.colors.gray[400],
+                    },
+                },
+                action: {
+                    ...tokens.item.option.color.action,
+                    primary: {
+                        ...tokens.item.option.color.action.primary,
+                        enabled: {
+                            ...tokens.item.option.color.action.primary.enabled,
+                            selected: foundationToken.colors.primary[600],
+                        },
+                        disabled: {
+                            ...tokens.item.option.color.action.primary.disabled,
+                            selected: foundationToken.colors.primary[400],
+                        },
+                    },
+                    danger: {
+                        ...tokens.item.option.color.action.danger,
+                        enabled: {
+                            ...tokens.item.option.color.action.danger.enabled,
+                            selected: foundationToken.colors.red[600],
+                        },
+                        disabled: {
+                            ...tokens.item.option.color.action.danger.disabled,
+                            selected: foundationToken.colors.red[400],
+                        },
+                    },
+                },
+            },
+        },
+        description: {
+            ...tokens.item.description,
+            color: {
+                ...tokens.item.description.color,
+                default: {
+                    ...tokens.item.description.color.default,
+                    enabled: {
+                        ...tokens.item.description.color.default.enabled,
+                        selected: foundationToken.colors.gray[400],
+                    },
+                    disabled: {
+                        ...tokens.item.description.color.default.disabled,
+                        selected: foundationToken.colors.gray[400],
+                    },
+                },
+                action: {
+                    ...tokens.item.description.color.action,
+                    primary: {
+                        ...tokens.item.description.color.action.primary,
+                        enabled: {
+                            ...tokens.item.description.color.action.primary
+                                .enabled,
+                            selected: foundationToken.colors.primary[400],
+                        },
+                        disabled: {
+                            ...tokens.item.description.color.action.primary
+                                .disabled,
+                            selected: foundationToken.colors.primary[400],
+                        },
+                    },
+                    danger: {
+                        ...tokens.item.description.color.action.danger,
+                        enabled: {
+                            ...tokens.item.description.color.action.danger
+                                .enabled,
+                            selected: foundationToken.colors.red[400],
+                        },
+                        disabled: {
+                            ...tokens.item.description.color.action.danger
+                                .disabled,
+                            selected: foundationToken.colors.red[400],
+                        },
+                    },
+                },
+            },
+        },
+    },
+})
+
 export const getMenuTokens = (
     foundationToken: FoundationTokenType
 ): ResponsiveMenuTokensType => {
-    return {
+    const tokens: ResponsiveMenuTokensType = {
         sm: {
             boxShadow: foundationToken.shadows.md,
             backgroundColor: foundationToken.colors.gray[0],
@@ -613,5 +747,10 @@ export const getMenuTokens = (
                 },
             },
         },
+    }
+
+    return {
+        sm: withSelectionTokens(tokens.sm, foundationToken),
+        lg: withSelectionTokens(tokens.lg, foundationToken),
     }
 }

--- a/packages/blend/lib/components/Menu/selection.ts
+++ b/packages/blend/lib/components/Menu/selection.ts
@@ -1,0 +1,63 @@
+import { createContext, useContext } from 'react'
+
+export type MenuSelectionStyle = 'checkmark' | 'highlight'
+export type MenuSelectionMode = 'single' | 'multiple'
+
+export type MenuSelectionContextValue = {
+    selectionStyle?: MenuSelectionStyle
+    selectionMode?: MenuSelectionMode
+    closeOnSelect: boolean
+}
+
+export type MenuSelectionResolution = {
+    isSelectable: boolean
+    isSelected: boolean
+    selectionStyle?: MenuSelectionStyle
+    selectionMode?: MenuSelectionMode
+    selectionRole?: 'menuitemradio' | 'menuitemcheckbox'
+}
+
+export const resolveMenuSelection = ({
+    selected,
+    groupSelectionStyle,
+    groupSelectionMode,
+    menuSelectionStyle,
+    menuSelectionMode,
+}: {
+    selected?: boolean
+    groupSelectionStyle?: MenuSelectionStyle
+    groupSelectionMode?: MenuSelectionMode
+    menuSelectionStyle?: MenuSelectionStyle
+    menuSelectionMode?: MenuSelectionMode
+}): MenuSelectionResolution => {
+    const isSelectable = typeof selected === 'boolean'
+    const isSelected = selected === true
+    const selectionStyle = isSelectable
+        ? (groupSelectionStyle ?? menuSelectionStyle ?? 'checkmark')
+        : undefined
+    const selectionMode = isSelectable
+        ? (groupSelectionMode ?? menuSelectionMode ?? 'single')
+        : undefined
+
+    return {
+        isSelectable,
+        isSelected,
+        selectionStyle,
+        selectionMode,
+        selectionRole:
+            selectionMode === 'single'
+                ? 'menuitemradio'
+                : selectionMode === 'multiple'
+                  ? 'menuitemcheckbox'
+                  : undefined,
+    }
+}
+
+const MenuSelectionContext = createContext<MenuSelectionContextValue>({
+    closeOnSelect: true,
+})
+
+export const MenuSelectionProvider = MenuSelectionContext.Provider
+
+export const useMenuSelection = (): MenuSelectionContextValue =>
+    useContext(MenuSelectionContext)

--- a/packages/blend/lib/components/Menu/types.tsx
+++ b/packages/blend/lib/components/Menu/types.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import type { SkeletonVariant } from '../Skeleton/types'
 import { TooltipSide, TooltipAlign, TooltipSize } from '../Tooltip/types'
+import type { MenuSelectionMode, MenuSelectionStyle } from './selection'
+
+export type { MenuSelectionMode, MenuSelectionStyle } from './selection'
 
 export enum MenuAlignment {
     START = 'start',
@@ -47,6 +50,12 @@ export type MenuProps = {
     open?: boolean
     onOpenChange?: (open: boolean) => void
     asModal?: boolean
+    /** How controlled selected items are indicated. */
+    selectionStyle?: MenuSelectionStyle
+    /** The selection cardinality used for selectable item accessibility semantics. */
+    selectionMode?: MenuSelectionMode
+    /** Whether activating an item closes the menu. Defaults to true. */
+    closeOnSelect?: boolean
     alignment?: MenuAlignment
     side?: MenuSide
     sideOffset?: number
@@ -82,6 +91,8 @@ export type MenuItemType = {
     variant?: MenuItemVariant
     actionType?: MenuItemActionType
     disabled?: boolean
+    /** Controlled selection state. Menu never changes this value internally. */
+    selected?: boolean
     onClick?: () => void
     subMenu?: MenuItemType[]
     enableSubMenuSearch?: boolean
@@ -112,4 +123,8 @@ export type MenuGroupType = {
     label?: string
     items: MenuItemType[]
     showSeparator?: boolean
+    /** Overrides the Menu-level selection style for this group's selectable items. */
+    selectionStyle?: MenuSelectionStyle
+    /** Overrides the Menu-level selection mode for this group's selectable items. */
+    selectionMode?: MenuSelectionMode
 }

--- a/packages/blend/lib/components/MenuV2/MenuV2Item.tsx
+++ b/packages/blend/lib/components/MenuV2/MenuV2Item.tsx
@@ -18,6 +18,7 @@ import {
 import type { MenuV2TokensType } from './menuV2.tokens'
 import { addPxToValue } from '../../global-utils/GlobalUtils'
 import { useMenuV2Selection } from './MenuV2SelectionContext'
+import { resolveMenuSelection } from '../Menu/selection'
 
 type MenuV2ItemProps = {
     item: MenuV2ItemType
@@ -116,16 +117,19 @@ const MenuV2Item = forwardRef<HTMLDivElement, MenuV2ItemProps>(
             closeOnSelect,
         } = useMenuV2Selection()
 
-        const isSelectable = typeof item.selected === 'boolean'
-        const isSelected = item.selected === true
-        const effectiveSelectionStyle: MenuV2SelectionStyle | undefined =
-            isSelectable
-                ? (groupSelectionStyle ?? menuSelectionStyle ?? 'checkmark')
-                : undefined
-        const effectiveSelectionMode: MenuV2SelectionMode | undefined =
-            isSelectable
-                ? (groupSelectionMode ?? menuSelectionMode ?? 'single')
-                : undefined
+        const {
+            isSelectable,
+            isSelected,
+            selectionStyle: effectiveSelectionStyle,
+            selectionMode: effectiveSelectionMode,
+            selectionRole,
+        } = resolveMenuSelection({
+            selected: item.selected,
+            groupSelectionStyle,
+            groupSelectionMode,
+            menuSelectionStyle,
+            menuSelectionMode,
+        })
         const useHighlight =
             effectiveSelectionStyle === 'highlight' && isSelected
         const showCheckmark =
@@ -136,13 +140,6 @@ const MenuV2Item = forwardRef<HTMLDivElement, MenuV2ItemProps>(
             showCheckmark && checkmarkPosition === 'leading'
         const showTrailingCheck =
             showCheckmark && checkmarkPosition === 'trailing'
-
-        const selectionRole =
-            effectiveSelectionMode === 'single'
-                ? 'menuitemradio'
-                : effectiveSelectionMode === 'multiple'
-                  ? 'menuitemcheckbox'
-                  : undefined
 
         const [slot] = getItemSlots(item)
         const itemStyle = {

--- a/packages/blend/lib/components/MenuV2/MenuV2SelectionContext.tsx
+++ b/packages/blend/lib/components/MenuV2/MenuV2SelectionContext.tsx
@@ -1,17 +1,5 @@
-import { createContext, useContext } from 'react'
-import type { MenuV2SelectionMode, MenuV2SelectionStyle } from './menuV2.types'
-
-export type MenuV2SelectionContextValue = {
-    selectionStyle?: MenuV2SelectionStyle
-    selectionMode?: MenuV2SelectionMode
-    closeOnSelect: boolean
-}
-
-const MenuV2SelectionContext = createContext<MenuV2SelectionContextValue>({
-    closeOnSelect: true,
-})
-
-export const MenuV2SelectionProvider = MenuV2SelectionContext.Provider
-
-export const useMenuV2Selection = (): MenuV2SelectionContextValue =>
-    useContext(MenuV2SelectionContext)
+export type { MenuSelectionContextValue as MenuV2SelectionContextValue } from '../Menu/selection'
+export {
+    MenuSelectionProvider as MenuV2SelectionProvider,
+    useMenuSelection as useMenuV2Selection,
+} from '../Menu/selection'

--- a/packages/blend/lib/components/MenuV2/menuV2.types.ts
+++ b/packages/blend/lib/components/MenuV2/menuV2.types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { TooltipSide, TooltipAlign, TooltipSize } from '../Tooltip/types'
 import type { CSSObject } from 'styled-components'
+import type { MenuSelectionMode, MenuSelectionStyle } from '../Menu/selection'
 
 export enum MenuV2Alignment {
     START = 'start',
@@ -42,8 +43,8 @@ export type MenuV2SearchSortFn = (
     items: MenuV2ItemType[],
     searchText: string
 ) => MenuV2ItemType[]
-export type MenuV2SelectionStyle = 'checkmark' | 'highlight'
-export type MenuV2SelectionMode = 'single' | 'multiple'
+export type MenuV2SelectionStyle = MenuSelectionStyle
+export type MenuV2SelectionMode = MenuSelectionMode
 
 export type MenuV2ItemType = {
     id?: string


### PR DESCRIPTION
## Summary

- Add the controlled selected, selectionStyle, selectionMode, and closeOnSelect API to V1 Menu, matching MenuV2 semantics.
- Render token-driven checkmarks or selected highlights, with menuitemradio / menuitemcheckbox roles and aria-checked for explicit selections.
- Keep selection fully controlled by consumers, preserve the legacy rendering path when selected is omitted, and preserve the default close behavior.
- Add controlled single-select and multi-select stories, keyboard/accessibility coverage, API docs, design documentation, and a minor changeset.
- Shared internals: packages/blend/lib/components/Menu/selection.ts owns the neutral selection types, resolver, and context. MenuV2 re-exports the context and uses the resolver; V1 and V2 token/rendering implementations remain native. No renderer refactor was forced.

## Test Coverage

- Coverage audit: all new selection branches are covered, including omitted/false/true selected, checkmark/highlight styles, leading/trailing token positions, group overrides, submenu and virtual leaves, close behavior, controlled rerendering, keyboard activation, and axe checks.
- Targeted Menu suites: 2 files, 41 tests passed.
- Full Blend suite: 212 files passed, 16 skipped; 5,134 tests passed, 606 skipped.
- Package build passed: lint, Vite production build, declarations, and check:dist.
- Existing Button performance warnings were emitted by the full suite but did not fail the run.

## Pre-Landing Review

Review pass 1 found and fixed three issues: a public token type compatibility regression, an incomplete group-field API summary, and missing empty-submenu regression coverage. Review pass 2 against the final diff found no outstanding issues.

## Design Review

Design review (lite): 0 findings, 0 auto-fixes. Selection visuals reuse MenuV2's token/rendering approach and preserve V1 layout behavior.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN.

## Plan Completion

All planned implementation, accessibility, story, documentation, shared-internal, and verification items are complete. The legacy V1 rendering path intentionally remains structurally unchanged when selected is omitted.

## Verification Results

- Package typecheck passed.
- Package lint passed with 0 errors and existing warnings.
- Changed-file Prettier check and git diff --check passed.
- Full Storybook lint/build was not used as a gate because the repository has unrelated baseline failures. Targeted story lint still reports the pre-existing ControlledState story hook-rule error; the new selection stories use named render functions and introduce no new lint error.

## TODOS

No TODO items completed in this PR. Existing unrelated backlog items remain unchanged.

## Test plan

- [x] V1 controlled selection unit tests
- [x] V1 keyboard and aria-checked accessibility tests
- [x] Full Blend Vitest suite
- [x] Package build and distribution check
- [x] Menu controlled selection stories

Version bump and changelog update were intentionally skipped per request.

🤖 Generated with Claude Code
