### PR TITLE
feat(dropdown-input): add dropDownPlaceholder prop (#1661)

### DIFF
--- a/apps/ascent/app/docs/content/components/dropdowninput.mdx
+++ b/apps/ascent/app/docs/content/components/dropdowninput.mdx
@@ -175,6 +175,19 @@ function MyComponent() {
         ],
         [
             {
+                content: 'dropDownPlaceholder',
+                hintText:
+                    'Optional placeholder text string displayed in the dropdown when no option is selected. Falls back to placeholder when omitted, so existing usage is unchanged. Use it to keep the two halves distinct — e.g. "Code" on a dial-code select next to "Enter your mobile number" on the input.',
+            },
+            {
+                content: 'string',
+                hintText:
+                    'Placeholder text shown in the dropdown when nothing is selected',
+            },
+            { content: '' },
+        ],
+        [
+            {
                 content: 'size',
                 hintText:
                     'Optional TextInputSize enum value that controls the physical dimensions of the input field and dropdown. SMALL creates a compact input, MEDIUM provides standard sizing, LARGE creates a more prominent input. Size affects padding, font size, and overall height. Defaults to MEDIUM.',

--- a/apps/storybook/stories/components/DropdownInput/v1/DropdownInput.stories.tsx
+++ b/apps/storybook/stories/components/DropdownInput/v1/DropdownInput.stories.tsx
@@ -261,6 +261,15 @@ pnpm test DropdownInput.accessibility
                 category: 'Content',
             },
         },
+        dropDownPlaceholder: {
+            control: { type: 'text' },
+            description:
+                'Placeholder shown in the dropdown when nothing is selected. Falls back to `placeholder`.',
+            table: {
+                type: { summary: 'string' },
+                category: 'Content',
+            },
+        },
         dropdownName: {
             control: { type: 'text' },
             description: 'Name attribute for the dropdown',
@@ -397,6 +406,36 @@ export const PhoneNumberInput: Story = {
         docs: {
             description: {
                 story: 'DropdownInput configured for phone number entry with country code selection.',
+            },
+        },
+    },
+}
+
+// Separate placeholder for the dropdown half
+export const SeparateDropdownPlaceholder: Story = {
+    render: () => {
+        const [phoneNumber, setPhoneNumber] = useState('')
+        const [countryCode, setCountryCode] = useState('')
+
+        return (
+            <DropdownInput
+                label="Phone Number"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                dropDownValue={countryCode}
+                onDropDownChange={setCountryCode}
+                dropDownItems={phoneCodeData}
+                dropdownPosition={DropdownPosition.LEFT}
+                placeholder="Enter your mobile number"
+                dropDownPlaceholder="Code"
+                type="tel"
+            />
+        )
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'With no `dropDownValue` selected, both halves would otherwise render the same `placeholder` string. `dropDownPlaceholder` gives the select its own short hint while the input keeps the longer one.',
             },
         },
     },

--- a/packages/blend/__tests__/components/Inputs/DropdownInput.regression.test.tsx
+++ b/packages/blend/__tests__/components/Inputs/DropdownInput.regression.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor, within } from '../../test-utils'
 import DropdownInput from '../../../lib/components/Inputs/DropdownInput/DropdownInput'
+import { DropdownPosition } from '../../../lib/components/Inputs/DropdownInput/types'
 import ThemeProvider from '../../../lib/context/ThemeProvider'
 
 const items = [
@@ -106,5 +107,72 @@ describe('DropdownInput menu behavior', () => {
 
         unmount()
         host.remove()
+    })
+})
+
+describe('DropdownInput dropdown placeholder', () => {
+    it.each([DropdownPosition.LEFT, DropdownPosition.RIGHT])(
+        'gives the %s dropdown its own placeholder without touching the input',
+        (dropdownPosition) => {
+            render(
+                <DropdownInput
+                    value=""
+                    onChange={() => {}}
+                    dropDownValue=""
+                    onDropDownChange={() => {}}
+                    dropDownItems={items}
+                    dropdownPosition={dropdownPosition}
+                    placeholder="Enter your mobile number"
+                    dropDownPlaceholder="Code"
+                />
+            )
+
+            expect(
+                screen.getByRole('button', { name: 'Select option' })
+            ).toHaveTextContent('Code')
+            expect(screen.getByRole('textbox')).toHaveAttribute(
+                'placeholder',
+                'Enter your mobile number'
+            )
+        }
+    )
+
+    it('falls back to the input placeholder when dropDownPlaceholder is omitted', () => {
+        render(
+            <DropdownInput
+                value=""
+                onChange={() => {}}
+                dropDownValue=""
+                onDropDownChange={() => {}}
+                dropDownItems={items}
+                placeholder="Enter city"
+            />
+        )
+
+        expect(
+            screen.getByRole('button', { name: 'Select option' })
+        ).toHaveTextContent('Enter city')
+    })
+
+    it('lets an empty dropDownPlaceholder clear the dropdown hint only', () => {
+        render(
+            <DropdownInput
+                value=""
+                onChange={() => {}}
+                dropDownValue=""
+                onDropDownChange={() => {}}
+                dropDownItems={items}
+                placeholder="Enter city"
+                dropDownPlaceholder=""
+            />
+        )
+
+        expect(
+            screen.getByRole('button', { name: 'Select option' })
+        ).not.toHaveTextContent('Enter city')
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+            'placeholder',
+            'Enter city'
+        )
     })
 })

--- a/packages/blend/__tests__/components/Inputs/DropdownInput.regression.test.tsx
+++ b/packages/blend/__tests__/components/Inputs/DropdownInput.regression.test.tsx
@@ -169,7 +169,7 @@ describe('DropdownInput dropdown placeholder', () => {
 
         expect(
             screen.getByRole('button', { name: 'Select option' })
-        ).not.toHaveTextContent('Enter city')
+        ).toHaveTextContent(/^$/)
         expect(screen.getByRole('textbox')).toHaveAttribute(
             'placeholder',
             'Enter city'

--- a/packages/blend/lib/components/Inputs/DropdownInput/DropdownInput.tsx
+++ b/packages/blend/lib/components/Inputs/DropdownInput/DropdownInput.tsx
@@ -163,7 +163,7 @@ const DropdownInput = ({
         } else {
             setDropdownWidth(0)
         }
-    }, [slot, dropDownValue])
+    }, [slot, dropDownValue, dropDownPlaceholder, placeholder])
 
     return (
         <Block

--- a/packages/blend/lib/components/Inputs/DropdownInput/DropdownInput.tsx
+++ b/packages/blend/lib/components/Inputs/DropdownInput/DropdownInput.tsx
@@ -47,6 +47,7 @@ const DropdownInput = ({
     dropdownPosition = DropdownPosition.RIGHT,
     placeholder,
     dropDownValue,
+    dropDownPlaceholder,
     onDropDownChange,
     dropDownItems,
     dropdownName,
@@ -253,7 +254,9 @@ const DropdownInput = ({
                             }
                             variant={SingleSelectV2Variant.NO_CONTAINER}
                             size={SingleSelectV2Size.SM}
-                            placeholder={placeholder || ''}
+                            placeholder={
+                                dropDownPlaceholder ?? placeholder ?? ''
+                            }
                             menuDimensions={{
                                 maxHeight: maxMenuHeight ?? 400,
                                 minWidth: minMenuWidth,
@@ -397,7 +400,9 @@ const DropdownInput = ({
                             }
                             variant={SingleSelectV2Variant.NO_CONTAINER}
                             size={SingleSelectV2Size.SM}
-                            placeholder={placeholder || ''}
+                            placeholder={
+                                dropDownPlaceholder ?? placeholder ?? ''
+                            }
                             menuDimensions={{
                                 maxHeight: maxMenuHeight ?? 400,
                                 minWidth: minMenuWidth,

--- a/packages/blend/lib/components/Inputs/DropdownInput/types.ts
+++ b/packages/blend/lib/components/Inputs/DropdownInput/types.ts
@@ -34,6 +34,7 @@ export type DropdownInputProps = {
     slot?: ReactNode
     size?: TextInputSize
     dropDownValue?: string
+    dropDownPlaceholder?: string
     onDropDownChange?: (value: string) => void
     dropDownItems: SelectMenuGroupType[]
     dropdownName?: string


### PR DESCRIPTION
Closes #1661

## Problem

`DropdownInput` renders two interactive elements — a `SingleSelectV2` and a `PrimitiveInput` — but exposes only one `placeholder`, which is forwarded to both. Whenever `dropDownValue` is empty, both halves render the same string:

```
[ Enter your mobile number  ⌄ ][ Enter your mobile number ]
```

The duplication reads as a bug, and the long shared string is truncated inside the narrow select. The only workarounds today are `placeholder=""` (kills the hint on the number box too) or always seeding a `dropDownValue` (forces an arbitrary default like `+91`).

## Change

Adds an optional `dropDownPlaceholder`. Both dropdown positions (LEFT and RIGHT) now resolve:

```tsx
placeholder={dropDownPlaceholder ?? placeholder ?? ''}
```

`??` rather than `||` on purpose: an explicit `dropDownPlaceholder=""` clears the dropdown hint *alone*, which is the issue's workaround #1 without the collateral damage. Omitting the prop falls back to `placeholder`, so **existing consumers are unchanged**.

```
[ Code  ⌄ ][ Enter your mobile number ]
```

## Files

- `lib/components/Inputs/DropdownInput/types.ts` — `dropDownPlaceholder?: string`
- `lib/components/Inputs/DropdownInput/DropdownInput.tsx` — both `SingleSelectV2` call sites
- `__tests__/components/Inputs/DropdownInput.regression.test.tsx` — 3 new tests: own placeholder in both dropdown positions, fallback when omitted, empty string clears the dropdown only
- `apps/ascent/.../dropdowninput.mdx` — props table row
- Storybook — `dropDownPlaceholder` argType + a `SeparateDropdownPlaceholder` story showing the phone case with no seeded dial code

## Verification

- `pnpm vitest run __tests__/components/Inputs/DropdownInput.regression.test.tsx` — 8/8 pass
- `tsc --noEmit` clean
- `prettier --check .` clean

## Follow-up (out of scope)

The ReScript binding's props record in `@juspay/rescript-blend` (`src/DropdownInput.res`) needs the same field added once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)