### PR TITLE
feat(directory): add active-path highlighting (#1665)

### DIFF
--- a/apps/storybook/stories/components/Directory/v1/Directory.stories.tsx
+++ b/apps/storybook/stories/components/Directory/v1/Directory.stories.tsx
@@ -35,6 +35,41 @@ const directoryData: DirectoryData[] = [
     },
 ]
 
+// Deep tree for the active-path stories — mirrors the Entity Management
+// hierarchy (group → network → merchant).
+const entityData: DirectoryData[] = [
+    {
+        label: 'Entities',
+        isCollapsible: false,
+        defaultOpen: true,
+        items: [
+            {
+                label: 'Acme Commerce Group',
+                items: [
+                    {
+                        label: 'Helix Network',
+                        items: [
+                            { label: 'Orbit Pharma' },
+                            { label: 'Indus Pharma' },
+                            { label: 'Orion Pharma' },
+                            { label: 'Apollo Pharma' },
+                        ],
+                    },
+                    { label: 'Quanta Network' },
+                ],
+            },
+            { label: 'Nimbus Ventures' },
+            { label: 'Polaris Channel' },
+        ],
+    },
+]
+
+const entityExpanded = [
+    'Acme Commerce Group',
+    'Acme Commerce Group/Helix Network',
+]
+const entitySelection = 'Acme Commerce Group/Helix Network/Orion Pharma'
+
 const meta: Meta<typeof Directory> = {
     title: 'Components/Directory',
     component: Directory,
@@ -95,6 +130,61 @@ export const Dark: Story = {
                 story: 'Dark tokens for section headers, item default/hover/active, nested connectors, and icons.',
             },
         },
+        chromatic: { ...CHROMATIC_CONFIG, delay: 400 },
+    },
+}
+
+export const ActivePathHighlight: Story = {
+    name: 'Active path highlight',
+    args: {
+        directoryData: entityData,
+        showHierarchyLines: true,
+        highlightActivePath: true,
+        defaultExpandedItems: entityExpanded,
+        defaultActiveItem: entitySelection,
+    },
+    render: (args) => (
+        <div style={{ width: 300, minHeight: 400 }}>
+            <Directory {...args} />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `highlightActivePath`, the selected row keeps the `active` treatment, its ancestors read as `activePath`, and every unrelated branch is `muted`. Click a different merchant to watch the highlighted chain follow the selection. Toggle the prop off in Controls to compare — with it off, all three tiers collapse back to the single active/default pair.',
+            },
+        },
+    },
+}
+
+export const ActivePathHighlightDark: Story = {
+    name: 'Active path highlight (dark)',
+    args: {
+        directoryData: entityData,
+        showHierarchyLines: true,
+        highlightActivePath: true,
+        defaultExpandedItems: entityExpanded,
+        defaultActiveItem: entitySelection,
+    },
+    decorators: [
+        (Story) => (
+            <ThemeProvider theme={Theme.DARK}>
+                <div
+                    style={{
+                        background: '#0E121B',
+                        padding: 16,
+                        borderRadius: 8,
+                        width: 320,
+                        minHeight: 400,
+                    }}
+                >
+                    <Story />
+                </div>
+            </ThemeProvider>
+        ),
+    ],
+    render: (args) => <Directory {...args} />,
+    parameters: {
         chromatic: { ...CHROMATIC_CONFIG, delay: 400 },
     },
 }

--- a/packages/blend/__tests__/components/Directory/Directory.test.tsx
+++ b/packages/blend/__tests__/components/Directory/Directory.test.tsx
@@ -425,3 +425,152 @@ describe('Directory', () => {
         await waitForAnimationFrame()
     })
 })
+
+describe('Directory active-path highlighting', () => {
+    const hierarchyData: DirectoryData[] = [
+        {
+            label: 'Entities',
+            isCollapsible: false,
+            items: [
+                {
+                    label: 'Acme Commerce Group',
+                    items: [
+                        {
+                            label: 'Helix Network',
+                            items: [
+                                { label: 'Orbit Pharma' },
+                                { label: 'Orion Pharma' },
+                            ],
+                        },
+                        { label: 'Quanta Network' },
+                    ],
+                },
+                { label: 'Nimbus Ventures' },
+            ],
+        },
+    ]
+
+    const expanded = [
+        'Acme Commerce Group',
+        'Acme Commerce Group/Helix Network',
+    ]
+    const deepSelection = 'Acme Commerce Group/Helix Network/Orion Pharma'
+
+    const pathStateOf = (name: RegExp) =>
+        screen.getByRole('button', { name }).getAttribute('data-path-state')
+
+    it.each([
+        ['non-virtualized', false],
+        ['virtualized', true],
+    ])(
+        'marks ancestors as activePath and everything else as muted (%s)',
+        (_label, enableVirtualization) => {
+            render(
+                <Directory
+                    directoryData={hierarchyData}
+                    defaultExpandedItems={expanded}
+                    activeItem={deepSelection}
+                    highlightActivePath
+                    enableVirtualization={enableVirtualization}
+                    virtualization={{
+                        threshold: 0,
+                        rowHeight: 32,
+                        viewportHeight: 512,
+                        overscan: 4,
+                    }}
+                />
+            )
+
+            expect(pathStateOf(/acme commerce group/i)).toBe('activePath')
+            expect(pathStateOf(/helix network/i)).toBe('activePath')
+            expect(pathStateOf(/orion pharma/i)).toBe('active')
+            expect(pathStateOf(/orbit pharma/i)).toBe('muted')
+            expect(pathStateOf(/quanta network/i)).toBe('muted')
+            expect(pathStateOf(/nimbus ventures/i)).toBe('muted')
+        }
+    )
+
+    it('leaves every row in the default tier when the flag is off', () => {
+        render(
+            <Directory
+                directoryData={hierarchyData}
+                defaultExpandedItems={expanded}
+                activeItem={deepSelection}
+            />
+        )
+
+        expect(pathStateOf(/acme commerce group/i)).toBe('default')
+        expect(pathStateOf(/helix network/i)).toBe('default')
+        expect(pathStateOf(/orbit pharma/i)).toBe('default')
+        expect(pathStateOf(/nimbus ventures/i)).toBe('default')
+        // the selection itself is unaffected by the flag
+        expect(pathStateOf(/orion pharma/i)).toBe('active')
+    })
+
+    it('does not dim anything while nothing is selected', () => {
+        render(
+            <Directory
+                directoryData={hierarchyData}
+                defaultExpandedItems={expanded}
+                highlightActivePath
+            />
+        )
+
+        for (const name of [
+            /acme commerce group/i,
+            /helix network/i,
+            /orbit pharma/i,
+            /orion pharma/i,
+            /nimbus ventures/i,
+        ]) {
+            expect(pathStateOf(name)).toBe('default')
+        }
+    })
+
+    it('degrades to selected-only highlighting for a bare-label activeItem', () => {
+        // a bare label is not a path, so no row can be resolved as its ancestor
+        render(
+            <Directory
+                directoryData={hierarchyData}
+                defaultExpandedItems={expanded}
+                activeItem="Nimbus Ventures"
+                highlightActivePath
+            />
+        )
+
+        expect(pathStateOf(/nimbus ventures/i)).toBe('active')
+        expect(pathStateOf(/acme commerce group/i)).toBe('muted')
+        expect(pathStateOf(/helix network/i)).toBe('muted')
+    })
+
+    it('does not treat a sibling with a shared name prefix as an ancestor', () => {
+        // "Helix" must not match "Helix Network/..." — the separator matters
+        const prefixData: DirectoryData[] = [
+            {
+                label: 'Entities',
+                isCollapsible: false,
+                items: [
+                    { id: 'helix', label: 'Helix' },
+                    {
+                        id: 'helix-network',
+                        label: 'Helix Network',
+                        items: [{ id: 'orion', label: 'Orion Pharma' }],
+                    },
+                ],
+            },
+        ]
+
+        render(
+            <Directory
+                directoryData={prefixData}
+                defaultExpandedItems={['helix-network']}
+                activeItem="helix-network/orion"
+                highlightActivePath
+            />
+        )
+
+        expect(pathStateOf(/^helix$/i)).toBe('muted')
+        expect(pathStateOf(/^helix network$/i)).toBe('activePath')
+        expect(pathStateOf(/orion pharma/i)).toBe('active')
+    })
+})

--- a/packages/blend/lib/components/Directory/Directory.tsx
+++ b/packages/blend/lib/components/Directory/Directory.tsx
@@ -33,6 +33,7 @@ const Directory = ({
     onEndReached,
     endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
     enableParentSelection = false,
+    highlightActivePath = false,
     enableVirtualization = false,
     virtualization,
 }: DirectoryProps) => {
@@ -74,6 +75,7 @@ const Directory = ({
                 onEndReached={onEndReached}
                 endReachedThreshold={endReachedThreshold}
                 enableParentSelection={enableParentSelection}
+                highlightActivePath={highlightActivePath}
                 enableVirtualization={enableVirtualization}
                 virtualization={virtualization}
             />
@@ -119,6 +121,7 @@ const Directory = ({
                                 hierarchyLineBorderRadius
                             }
                             enableParentSelection={enableParentSelection}
+                            highlightActivePath={highlightActivePath}
                             onNavigateBetweenSections={(
                                 direction,
                                 currentIndex

--- a/packages/blend/lib/components/Directory/NavItem.tsx
+++ b/packages/blend/lib/components/Directory/NavItem.tsx
@@ -15,9 +15,12 @@ import { useResponsiveTokens } from '../../hooks/useResponsiveTokens'
 import { DirectoryTokenType } from './directory.tokens'
 import {
     getItemPathSegment,
+    getItemVisualState,
     handleKeyDown,
     normalizeExpandedItems,
+    resolveItemColors,
 } from './utils'
+import type { DirectoryItemVisualState } from './directory.tokens.types'
 import { TooltipV2 } from '../TooltipV2/TooltipV2'
 import { TooltipV2Side } from '../TooltipV2/tooltipV2.types'
 import { TruncatedTextWithTooltipV2 } from '../common/TruncatedTextWithTooltipV2'
@@ -26,15 +29,13 @@ import { addPxToValue } from '../../global-utils/GlobalUtils'
 
 const StyledElement = styled(Block)<{
     $isLink?: boolean
-    $isActive?: boolean
+    $visualState: DirectoryItemVisualState
     $tokens: DirectoryTokenType
     $iconOnlyMode?: boolean
     $hasHierarchyLineInset?: boolean
 }>`
-    background-color: ${({ $isActive, $tokens }) =>
-        $isActive
-            ? $tokens.section.itemList.item.backgroundColor.active
-            : $tokens.section.itemList.item.backgroundColor.default};
+    background-color: ${({ $visualState, $tokens }) =>
+        resolveItemColors($tokens, $visualState).backgroundColor};
     border: none;
     width: ${({ $hasHierarchyLineInset, $tokens }) =>
         $hasHierarchyLineInset
@@ -61,10 +62,8 @@ const StyledElement = styled(Block)<{
                             .itemPaddingLeft
                       : $tokens.section.itemList.item.padding.x
               }`};
-    color: ${({ $isActive, $tokens }) =>
-        $isActive
-            ? $tokens.section.itemList.item.color.active
-            : $tokens.section.itemList.item.color.default};
+    color: ${({ $visualState, $tokens }) =>
+        resolveItemColors($tokens, $visualState).color};
     font-weight: ${({ $tokens }) => $tokens.section.itemList.item.fontWeight};
     font-size: ${({ $tokens }) =>
         addPxToValue($tokens.section.itemList.item.fontSize)};
@@ -76,14 +75,16 @@ const StyledElement = styled(Block)<{
     cursor: pointer;
     overflow: hidden;
 
+    /* muted rows lift to the hover tier here, so a de-emphasised row regains
+       full contrast the moment it is hovered or keyboard-focused */
     &:hover,
     &:focus-visible {
-        background-color: ${({ $isActive, $tokens }) =>
-            $isActive
+        background-color: ${({ $visualState, $tokens }) =>
+            $visualState === 'active'
                 ? $tokens.section.itemList.item.backgroundColor.active
                 : $tokens.section.itemList.item.backgroundColor.hover};
-        color: ${({ $isActive, $tokens }) =>
-            $isActive
+        color: ${({ $visualState, $tokens }) =>
+            $visualState === 'active'
                 ? $tokens.section.itemList.item.color.active
                 : $tokens.section.itemList.item.color.hover};
         outline: none;
@@ -388,6 +389,7 @@ const NavItem = ({
     isLast = false,
     isNested = false,
     enableParentSelection = false,
+    highlightActivePath = false,
 }: NavItemProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
     const { isItemExpanded, setItemExpanded } = useExpandedItemsContext()
@@ -405,6 +407,14 @@ const NavItem = ({
             : isSelectable &&
               (activeItem === itemPath ||
                   (!item.id && activeItem === item.label))
+
+    const visualState = getItemVisualState({
+        isActive,
+        itemPath,
+        activeItem,
+        highlightActivePath,
+    })
+    const itemColors = resolveItemColors(tokens, visualState)
 
     const itemRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null)
     const nestedListRef = useRef<HTMLUListElement>(null)
@@ -473,13 +483,7 @@ const NavItem = ({
                     <Block
                         width={tokens.section.itemList.item.icon.width}
                         height={tokens.section.itemList.item.icon.width}
-                        backgroundColor={
-                            isActive
-                                ? tokens.section.itemList.item.backgroundColor
-                                      .active
-                                : tokens.section.itemList.item.backgroundColor
-                                      .default
-                        }
+                        backgroundColor={itemColors.backgroundColor}
                         borderRadius={tokens.section.itemList.item.borderRadius}
                         style={{
                             opacity: 0.3,
@@ -496,12 +500,7 @@ const NavItem = ({
                                     size?: number
                                 }
                             >,
-                            {
-                                color: isActive
-                                    ? tokens.section.itemList.item.color.active
-                                    : tokens.section.itemList.item.color
-                                          .default,
-                            }
+                            { color: itemColors.color }
                         )}
                     </IconWrapper>
                 )
@@ -527,13 +526,7 @@ const NavItem = ({
                                         size?: number
                                     }
                                 >,
-                                {
-                                    color: isActive
-                                        ? tokens.section.itemList.item.color
-                                              .active
-                                        : tokens.section.itemList.item.color
-                                              .default,
-                                }
+                                { color: itemColors.color }
                             )}
                         </IconWrapper>
                     )}
@@ -575,7 +568,7 @@ const NavItem = ({
         <StyledElement
             as={Element}
             $isLink={!!item.href}
-            $isActive={isActive}
+            $visualState={visualState}
             $tokens={tokens}
             $iconOnlyMode={iconOnlyMode}
             $hasHierarchyLineInset={showHierarchyLines && isNested}
@@ -607,6 +600,7 @@ const NavItem = ({
             data-element="sidebar-sub-section"
             data-id={getItemPathSegment(item)}
             data-status={isActive ? 'selected' : 'not selected'}
+            data-path-state={visualState}
         >
             {renderContent()}
         </StyledElement>
@@ -665,6 +659,7 @@ const NavItem = ({
                                     enableParentSelection={
                                         enableParentSelection
                                     }
+                                    highlightActivePath={highlightActivePath}
                                     onNavigate={(direction, currentIndex) => {
                                         if (
                                             direction === 'up' &&

--- a/packages/blend/lib/components/Directory/Section.tsx
+++ b/packages/blend/lib/components/Directory/Section.tsx
@@ -59,6 +59,7 @@ const Section = ({
     showHierarchyLines = false,
     hierarchyLineBorderRadius = 0,
     enableParentSelection = false,
+    highlightActivePath = false,
 }: SectionProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
     const sectionStateContext = useSectionState()
@@ -271,6 +272,7 @@ const Section = ({
                                 itemIdx === (section.items?.length || 0) - 1
                             }
                             enableParentSelection={enableParentSelection}
+                            highlightActivePath={highlightActivePath}
                             onNavigate={handleItemNavigation}
                         />
                     ))}

--- a/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
+++ b/packages/blend/lib/components/Directory/VirtualizedDirectory.tsx
@@ -13,12 +13,15 @@ import {
     DEFAULT_END_REACHED_THRESHOLD,
     flattenDirectoryData,
     getItemPathSegment,
+    getItemVisualState,
     handleKeyDown,
     normalizeExpandedItems,
     normalizeDirectoryData,
+    resolveItemColors,
     useDirectoryEndReached,
 } from './utils'
 import type { DirectoryFlatRow, DirectoryProps, NavbarItem } from './types'
+import type { DirectoryItemVisualState } from './directory.tokens.types'
 
 const DEFAULT_ROW_HEIGHT = 36
 const DEFAULT_SECTION_HEIGHT = 28
@@ -52,7 +55,6 @@ const SectionRow = styled.div<{
 
 const ItemRow = styled.div<{
     $tokens: DirectoryTokenType
-    $isActive: boolean
     $depth: number
 }>`
     width: 100%;
@@ -108,7 +110,7 @@ const ConnectorElbow = styled.span<{
 
 const ItemButton = styled(Block)<{
     $tokens: DirectoryTokenType
-    $isActive: boolean
+    $visualState: DirectoryItemVisualState
     $showHierarchyLines: boolean
 }>`
     width: ${({ $tokens, $showHierarchyLines }) =>
@@ -123,14 +125,10 @@ const ItemButton = styled(Block)<{
     border: none;
     border-radius: ${({ $tokens }) =>
         $tokens.section.itemList.item.borderRadius};
-    background-color: ${({ $tokens, $isActive }) =>
-        $isActive
-            ? $tokens.section.itemList.item.backgroundColor.active
-            : $tokens.section.itemList.item.backgroundColor.default};
-    color: ${({ $tokens, $isActive }) =>
-        $isActive
-            ? $tokens.section.itemList.item.color.active
-            : $tokens.section.itemList.item.color.default};
+    background-color: ${({ $tokens, $visualState }) =>
+        resolveItemColors($tokens, $visualState).backgroundColor};
+    color: ${({ $tokens, $visualState }) =>
+        resolveItemColors($tokens, $visualState).color};
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -150,14 +148,16 @@ const ItemButton = styled(Block)<{
     text-decoration: none;
     transition: ${({ $tokens }) => $tokens.section.itemList.item.transition};
 
+    /* muted rows lift to the hover tier here, so a de-emphasised row regains
+       full contrast the moment it is hovered or keyboard-focused */
     &:hover,
     &:focus-visible {
-        background-color: ${({ $tokens, $isActive }) =>
-            $isActive
+        background-color: ${({ $tokens, $visualState }) =>
+            $visualState === 'active'
                 ? $tokens.section.itemList.item.backgroundColor.active
                 : $tokens.section.itemList.item.backgroundColor.hover};
-        color: ${({ $tokens, $isActive }) =>
-            $isActive
+        color: ${({ $tokens, $visualState }) =>
+            $visualState === 'active'
                 ? $tokens.section.itemList.item.color.active
                 : $tokens.section.itemList.item.color.hover};
         outline: none;
@@ -249,6 +249,7 @@ const VirtualizedDirectory = ({
     onEndReached,
     endReachedThreshold = DEFAULT_END_REACHED_THRESHOLD,
     enableParentSelection = false,
+    highlightActivePath = false,
     virtualization,
 }: DirectoryProps) => {
     const tokens = useResponsiveTokens<DirectoryTokenType>('DIRECTORY')
@@ -469,6 +470,14 @@ const VirtualizedDirectory = ({
                   (activeItem === row.itemPath ||
                       (!row.item.id && activeItem === row.item.label))
 
+        const visualState = getItemVisualState({
+            isActive,
+            itemPath: row.itemPath,
+            activeItem,
+            highlightActivePath,
+        })
+        const itemColors = resolveItemColors(tokens, visualState)
+
         const Element = row.item.href ? 'a' : 'button'
         const elementProps = row.item.href
             ? { href: row.item.href }
@@ -499,7 +508,6 @@ const VirtualizedDirectory = ({
         return (
             <ItemRow
                 $tokens={tokens}
-                $isActive={isActive}
                 $depth={row.depth}
                 data-directory-hierarchy-item={
                     showItemHierarchyLines ? 'true' : undefined
@@ -533,13 +541,14 @@ const VirtualizedDirectory = ({
                     as={Element}
                     {...elementProps}
                     $tokens={tokens}
-                    $isActive={isActive}
+                    $visualState={visualState}
                     $showHierarchyLines={showItemHierarchyLines}
                     aria-expanded={hasChildren ? isExpanded : undefined}
                     aria-label={row.item.label}
                     data-element="sidebar-sub-section"
                     data-id={getItemPathSegment(row.item)}
                     data-status={isActive ? 'selected' : 'not selected'}
+                    data-path-state={visualState}
                     data-directory-row-index={rowIndex}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {
                         if (
@@ -577,13 +586,7 @@ const VirtualizedDirectory = ({
                                             size?: number
                                         }
                                     >,
-                                    {
-                                        color: isActive
-                                            ? tokens.section.itemList.item.color
-                                                  .active
-                                            : tokens.section.itemList.item.color
-                                                  .default,
-                                    }
+                                    { color: itemColors.color }
                                 )}
                             </IconWrapper>
                         )}

--- a/packages/blend/lib/components/Directory/directory.dark.tokens.ts
+++ b/packages/blend/lib/components/Directory/directory.dark.tokens.ts
@@ -53,12 +53,23 @@ export const getDirectoryDarkTokens = (
                             default: 'transparent',
                             hover: foundationToken.colors.gray[800],
                             active: foundationToken.colors.gray[700],
+                            // the fill is what marks the selection itself, so
+                            // the path tiers stay unfilled and differ by text
+                            activePath: 'transparent',
+                            muted: 'transparent',
                         },
 
                         color: {
                             default: foundationToken.colors.gray[400],
                             hover: foundationToken.colors.gray[300],
                             active: foundationToken.colors.gray[50],
+                            // 14.71:1 on gray[950] — clearly on-path, still
+                            // below the selected row which carries a fill
+                            activePath: foundationToken.colors.gray[200],
+                            // 4.17:1 on gray[950]. Under the 4.5:1 AA floor —
+                            // see the note in DirectoryProps.highlightActivePath.
+                            // Muted rows lift to `hover` on hover/focus-visible.
+                            muted: foundationToken.colors.gray[500],
                         },
 
                         icon: {
@@ -140,12 +151,23 @@ export const getDirectoryDarkTokens = (
                             default: 'transparent',
                             hover: foundationToken.colors.gray[800],
                             active: foundationToken.colors.gray[700],
+                            // the fill is what marks the selection itself, so
+                            // the path tiers stay unfilled and differ by text
+                            activePath: 'transparent',
+                            muted: 'transparent',
                         },
 
                         color: {
                             default: foundationToken.colors.gray[400],
                             hover: foundationToken.colors.gray[300],
                             active: foundationToken.colors.gray[50],
+                            // 14.71:1 on gray[950] — clearly on-path, still
+                            // below the selected row which carries a fill
+                            activePath: foundationToken.colors.gray[200],
+                            // 4.17:1 on gray[950]. Under the 4.5:1 AA floor —
+                            // see the note in DirectoryProps.highlightActivePath.
+                            // Muted rows lift to `hover` on hover/focus-visible.
+                            muted: foundationToken.colors.gray[500],
                         },
 
                         icon: {

--- a/packages/blend/lib/components/Directory/directory.light.tokens.ts
+++ b/packages/blend/lib/components/Directory/directory.light.tokens.ts
@@ -53,12 +53,23 @@ export const getDirectoryLightTokens = (
                             default: 'transparent',
                             hover: foundationToken.colors.gray[50],
                             active: foundationToken.colors.gray[150],
+                            // the fill is what marks the selection itself, so
+                            // the path tiers stay unfilled and differ by text
+                            activePath: 'transparent',
+                            muted: 'transparent',
                         },
 
                         color: {
                             default: foundationToken.colors.gray[600],
                             hover: foundationToken.colors.gray[600],
                             active: foundationToken.colors.gray[1000],
+                            // 13.22:1 on white — clearly on-path, still below
+                            // the selected row which also carries a fill
+                            activePath: foundationToken.colors.gray[700],
+                            // 4.49:1 on white. Just under the 4.5:1 AA floor —
+                            // see the note in DirectoryProps.highlightActivePath.
+                            // Muted rows lift to `hover` on hover/focus-visible.
+                            muted: foundationToken.colors.gray[500],
                         },
 
                         icon: {
@@ -140,12 +151,23 @@ export const getDirectoryLightTokens = (
                             default: 'transparent',
                             hover: foundationToken.colors.gray[50],
                             active: foundationToken.colors.gray[150],
+                            // the fill is what marks the selection itself, so
+                            // the path tiers stay unfilled and differ by text
+                            activePath: 'transparent',
+                            muted: 'transparent',
                         },
 
                         color: {
                             default: foundationToken.colors.gray[600],
                             hover: foundationToken.colors.gray[600],
                             active: foundationToken.colors.gray[1000],
+                            // 13.22:1 on white — clearly on-path, still below
+                            // the selected row which also carries a fill
+                            activePath: foundationToken.colors.gray[700],
+                            // 4.49:1 on white. Just under the 4.5:1 AA floor —
+                            // see the note in DirectoryProps.highlightActivePath.
+                            // Muted rows lift to `hover` on hover/focus-visible.
+                            muted: foundationToken.colors.gray[500],
                         },
 
                         icon: {

--- a/packages/blend/lib/components/Directory/directory.tokens.types.ts
+++ b/packages/blend/lib/components/Directory/directory.tokens.types.ts
@@ -4,6 +4,27 @@ import { type BreakpointType } from '../../breakpoints/breakPoints'
 export type DirectoryState = 'default' | 'hover' | 'active'
 
 /**
+ * Extra tiers used only when `highlightActivePath` is enabled:
+ * - `activePath` — an ancestor of the selected item
+ * - `muted` — a row on neither the selection nor its ancestor path
+ *
+ * Optional so existing whole-slot DIRECTORY token overrides keep type-checking;
+ * both fall back to an existing tier at runtime (see `resolveItemColors`).
+ */
+export type DirectoryPathState = 'activePath' | 'muted'
+
+/**
+ * The resolved visual tier of a single directory row. `default`, `active` and
+ * the hover treatment are the pre-existing behaviour; the other two only ever
+ * occur when `highlightActivePath` is on and something is selected.
+ */
+export type DirectoryItemVisualState =
+    | 'default'
+    | 'active'
+    | 'activePath'
+    | 'muted'
+
+/**
  * Directory Tokens following the pattern: [target].CSSProp.[state]
  *
  * Hierarchical Structure:
@@ -74,11 +95,15 @@ export type DirectoryTokenType = {
                 // Item background color for different states
                 backgroundColor: {
                     [key in DirectoryState]: CSSObject['backgroundColor']
+                } & {
+                    [key in DirectoryPathState]?: CSSObject['backgroundColor']
                 }
 
                 // Item text color for different states
                 color: {
                     [key in DirectoryState]: CSSObject['color']
+                } & {
+                    [key in DirectoryPathState]?: CSSObject['color']
                 }
 
                 // Icon/leftSlot styling

--- a/packages/blend/lib/components/Directory/types.ts
+++ b/packages/blend/lib/components/Directory/types.ts
@@ -48,6 +48,24 @@ export type DirectoryProps = {
      * @default false
      */
     enableParentSelection?: boolean
+    /**
+     * When true, selecting an item also styles its ancestor chain as
+     * `activePath` and every unrelated row as `muted`, so the branch you are
+     * in reads at a glance. With nothing selected the tree renders exactly as
+     * it does with this off.
+     *
+     * Requires a path-valued `activeItem` — a bare label (the backward-compat
+     * match for id-less items) resolves no ancestors and degrades to
+     * selected-only highlighting.
+     *
+     * Note: the default `muted` text colour is 4.49:1 (light) / 4.17:1 (dark),
+     * just under the 4.5:1 WCAG AA floor; muted rows lift to the `hover` tier
+     * on hover and focus-visible. Override `DIRECTORY` component tokens if
+     * your product needs muted rows to clear AA at rest.
+     *
+     * @default false
+     */
+    highlightActivePath?: boolean
     enableVirtualization?: boolean
     virtualization?: DirectoryVirtualizationConfig
 }
@@ -96,6 +114,7 @@ export type SectionProps = {
     showHierarchyLines?: boolean
     hierarchyLineBorderRadius?: CSSObject['borderRadius']
     enableParentSelection?: boolean
+    highlightActivePath?: boolean
 }
 
 export type NavItemProps = {
@@ -109,6 +128,7 @@ export type NavItemProps = {
     isLast?: boolean
     isNested?: boolean
     enableParentSelection?: boolean
+    highlightActivePath?: boolean
 }
 
 export type DirectoryFlatRow =

--- a/packages/blend/lib/components/Directory/utils.ts
+++ b/packages/blend/lib/components/Directory/utils.ts
@@ -6,6 +6,12 @@ import type {
     DirectoryFlatRow,
     NavbarItem,
 } from './types'
+// leaf types module, not ./directory.tokens — keeps this file out of the
+// token factory's import graph (see RFC 0007 / check:circular)
+import type {
+    DirectoryItemVisualState,
+    DirectoryTokenType,
+} from './directory.tokens.types'
 
 export const DEFAULT_END_REACHED_THRESHOLD = 200
 
@@ -70,6 +76,80 @@ export const normalizeExpandedItems = (
 // silently producing colliding empty path segments
 export const getItemPathSegment = (item: NavbarItem): string =>
     item.id || item.label
+
+/**
+ * True when `itemPath` is a strict ancestor of the selected item.
+ *
+ * itemPath segments are "/"-joined and ids may not contain "/", so ancestry is
+ * a prefix test rather than a tree walk. A bare-label activeItem (the
+ * backward-compat match for id-less items) is not a path, so it resolves no
+ * ancestors — the tree then degrades to selected-only highlighting.
+ */
+export const isActiveAncestorPath = (
+    itemPath: string,
+    activeItem: string | null | undefined
+): boolean =>
+    !!activeItem &&
+    activeItem !== itemPath &&
+    activeItem.startsWith(`${itemPath}/`)
+
+/**
+ * Resolves the visual tier of a row. Returns `default` for every row unless
+ * active-path highlighting is on AND something is selected, so the opt-out
+ * path is byte-identical to the pre-existing two-state behaviour.
+ */
+export const getItemVisualState = ({
+    isActive,
+    itemPath,
+    activeItem,
+    highlightActivePath,
+}: {
+    isActive: boolean
+    itemPath: string
+    activeItem: string | null | undefined
+    highlightActivePath: boolean
+}): DirectoryItemVisualState => {
+    if (isActive) return 'active'
+    if (!highlightActivePath || !activeItem) return 'default'
+    return isActiveAncestorPath(itemPath, activeItem) ? 'activePath' : 'muted'
+}
+
+/**
+ * Background/text colours for a visual tier. The two path tiers fall back to
+ * pre-existing tiers when a consumer's whole-slot DIRECTORY override predates
+ * them, so a partial override degrades instead of resolving to undefined.
+ */
+export const resolveItemColors = (
+    tokens: DirectoryTokenType,
+    state: DirectoryItemVisualState
+) => {
+    const { backgroundColor, color } = tokens.section.itemList.item
+
+    switch (state) {
+        case 'active':
+            return {
+                backgroundColor: backgroundColor.active,
+                color: color.active,
+            }
+        case 'activePath':
+            return {
+                backgroundColor:
+                    backgroundColor.activePath ?? backgroundColor.default,
+                color: color.activePath ?? color.active,
+            }
+        case 'muted':
+            return {
+                backgroundColor:
+                    backgroundColor.muted ?? backgroundColor.default,
+                color: color.muted ?? color.default,
+            }
+        default:
+            return {
+                backgroundColor: backgroundColor.default,
+                color: color.default,
+            }
+    }
+}
 
 const countItems = (items: NavbarItem[] | undefined): number =>
     (items ?? []).reduce((total, item) => total + 1 + countItems(item.items), 0)


### PR DESCRIPTION
Closes #1665

## Problem

`Directory` highlighted only the exact row matching `activeItem`. A deeply nested selection said nothing about which branch you were in, and unrelated branches competed with it visually.

## Change

Opt-in `highlightActivePath` resolves three tiers per row:

```
  Acme Commerce Group      <- activePath  (ancestor of the selection)
  └ Helix Network          <- activePath
    ├ Orbit Pharma         <- muted
    ├ Orion Pharma         <- active      (the selection)
    └ Apollo Pharma        <- muted
  ├ Quanta Network         <- muted
  └ Nimbus Ventures        <- muted
```

`itemPath` is `/`-joined and ids may not contain `/`, so ancestry is a prefix test, not a tree walk:

```ts
activeItem !== itemPath && activeItem.startsWith(`${itemPath}/`)
```

## Backward compatibility

Deliberately zero-change when off:

- **`highlightActivePath` defaults to `false`.** With it off, or with nothing selected, `getItemVisualState` returns `default`/`active` — exactly the pre-existing pair.
- **The two new token keys are optional** (`activePath`, `muted`), and `resolveItemColors` falls back to existing tiers. A whole-slot `DIRECTORY` override written before this PR still type-checks and degrades gracefully instead of resolving to `undefined`.
- No change to `data-status`, and `aria-current` was deliberately **not** added — it would alter accessible output for every existing consumer, which would break the "off means identical" guarantee. Worth doing, but as its own PR.

## Both renderers

`NavItem.tsx` and `VirtualizedDirectory.tsx` duplicate the `isActive` logic — the trap called out in the issue. Tier resolution (`getItemVisualState`) and colour lookup (`resolveItemColors`) now live in `utils.ts` and are shared, and the tests run the same assertions against both renderers via `it.each`.

`utils.ts` imports the token *types* from the leaf `directory.tokens.types` module, not `directory.tokens`, so it stays out of the token factory's import graph. `check:circular` is clean.

## Accessibility — needs a design call

The default `muted` text colour is `gray[500]`, which measures:

| | ratio | AA (4.5:1) |
|---|---|---|
| light, on white | 4.49:1 | ✗ by 0.01 |
| dark, on `gray[950]` | 4.17:1 | ✗ |

I picked `gray[500]` over `gray[400]` (2.63:1) precisely to stay near the line, but it does not clear AA at rest, and muted rows stay clickable. Mitigations in place: muted rows lift to the `hover` tier on hover **and** `focus-visible`, the behaviour is opt-in, and the values are token-overridable in one line.

The alternative is leaving muted at today's `default` colour — but that removes the dimming the design asked for and collapses this into "highlight the path only". Flagging for design sign-off rather than picking silently.

## Files

- `directory.tokens.types.ts` — `DirectoryPathState`, `DirectoryItemVisualState`, optional token keys
- `directory.{light,dark}.tokens.ts` — values for both breakpoints, with the measured ratios in comments
- `utils.ts` — `isActiveAncestorPath`, `getItemVisualState`, `resolveItemColors`
- `types.ts` — `highlightActivePath` on `DirectoryProps` / `SectionProps` / `NavItemProps`
- `Directory.tsx`, `Section.tsx`, `NavItem.tsx`, `VirtualizedDirectory.tsx` — plumbing + styling
- `Directory.test.tsx` — 6 new tests
- Storybook — `Active path highlight` + a dark variant

## Verification

- `Directory.test.tsx` — 18/18 pass. New cases: both renderers via `it.each`, flag-off, nothing-selected, bare-label degradation, and a name-prefix guard (`Helix` must not match `Helix Network/...`).
- Full unit suite — **5114 passed**, 0 failures
- `pnpm test:a11y` — 2616 passed
- `pnpm build:blend` — vite + `check:dist` clean; `check:circular` clean; `tsc --noEmit` clean; prettier clean
- Driven in Storybook, light and dark: three tiers render as specified, and clicking a different merchant moves the highlighted chain (selecting a root-level item correctly dims the entire other branch).

## Follow-ups (out of scope)

- `aria-current` on the selected row — the feature is currently a visual-only signal.
- Whether hierarchy connector lines should also recolour along the active path (open question in #1665; the Figma frame shows uniform connectors).
- Whether the `muted` tier should apply to count badges and entity icons, or text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
