### PR TITLE
fix: reversing gradient color in button v2

### DIFF
--- a/packages/blend/lib/components/ButtonV2/buttonV2.light.tokens.ts
+++ b/packages/blend/lib/components/ButtonV2/buttonV2.light.tokens.ts
@@ -827,15 +827,15 @@ export const getButtonV2LightTokens = (
             backgroundColor: {
                 primary: {
                     default: {
-                        default: `linear-gradient(180deg, ${foundationToken.colors.primary[500]} -5%, ${foundationToken.colors.primary[600]} 107.5%)`,
+                        default: `linear-gradient(180deg, ${foundationToken.colors.primary[600]} -5%, ${foundationToken.colors.primary[500]} 107.5%)`,
                         hover: foundationToken.colors.primary[600],
-                        active: `linear-gradient(180deg, ${foundationToken.colors.primary[500]} -5%, ${foundationToken.colors.primary[600]} 107.5%)`,
+                        active: `linear-gradient(180deg, ${foundationToken.colors.primary[600]} -5%, ${foundationToken.colors.primary[500]} 107.5%)`,
                         disabled: foundationToken.colors.primary[300],
                     },
                     iconOnly: {
-                        default: `linear-gradient(180deg, ${foundationToken.colors.primary[500]} -5%, ${foundationToken.colors.primary[600]} 107.5%)`,
+                        default: `linear-gradient(180deg, ${foundationToken.colors.primary[600]} -5%, ${foundationToken.colors.primary[500]} 107.5%)`,
                         hover: foundationToken.colors.primary[600],
-                        active: `linear-gradient(180deg, ${foundationToken.colors.primary[500]} -5%, ${foundationToken.colors.primary[600]} 107.5%)`,
+                        active: `linear-gradient(180deg, ${foundationToken.colors.primary[600]} -5%, ${foundationToken.colors.primary[500]} 107.5%)`,
                         disabled: foundationToken.colors.primary[300],
                     },
                     inline: {


### PR DESCRIPTION
### Summary

reversing the gradient color in button v2 to match the figma 

### Issue Ticket

Closes #[issue_number] or Related to #[issue_number]

pot 
<img width="574" height="112" alt="Screenshot 2026-08-13 at 7 21 42 PM" src="https://github.com/user-attachments/assets/840d1872-f906-4a1f-86a1-1cdb8581c7e7" />
