### PR TITLE
fix(modal): clip dialog so top corners stay rounded

### DIFF
--- a/packages/blend/__tests__/components/Modal/Modal.test.tsx
+++ b/packages/blend/__tests__/components/Modal/Modal.test.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '../../test-utils'
+import Modal from '../../../lib/components/Modal/Modal'
+
+describe('Modal', () => {
+    const OpenModal = (props: Record<string, unknown> = {}) => {
+        const Wrapper = () => {
+            const [isOpen, setIsOpen] = useState(true)
+            return (
+                <Modal
+                    isOpen={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    title="Modal Title"
+                    {...props}
+                >
+                    <p>Modal body</p>
+                </Modal>
+            )
+        }
+        return render(<Wrapper />)
+    }
+
+    describe('rounded corners (regression: #1687)', () => {
+        // Since #1642, the opaque, square-cornered header painted over the
+        // container's rounded top corners. The container clips its children to
+        // the border radius, so every corner stays rounded — the header's own
+        // background can no longer leak past the dialog's rounded top.
+        it('clips the dialog container so all four corners stay rounded', () => {
+            OpenModal()
+            expect(screen.getByRole('dialog')).toHaveStyle({
+                overflow: 'hidden',
+            })
+        })
+
+        it('still clips when a title (opaque header) is present', () => {
+            OpenModal({ title: 'With Header', showCloseButton: true })
+            expect(screen.getByRole('dialog')).toHaveStyle({
+                overflow: 'hidden',
+            })
+        })
+    })
+})

--- a/packages/blend/lib/components/Modal/Modal.tsx
+++ b/packages/blend/lib/components/Modal/Modal.tsx
@@ -329,6 +329,10 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
                         maxWidth={maxWidth}
                         maxHeight={maxHeight}
                         borderRadius={modalTokens.borderRadius}
+                        // Clip children (opaque header/footer) to the container
+                        // radius — otherwise their square corners paint over the
+                        // rounded top/bottom of the dialog (issue #1687).
+                        overflow="hidden"
                         boxShadow={modalTokens.boxShadow}
                         role="dialog"
                         aria-modal="true"


### PR DESCRIPTION
## Summary

Since `0.0.38-beta.0`, `<Modal>` renders with **sharp top corners** while the bottom stays rounded. Regressed by #1642.

The header gained an opaque `backgroundColor` (`gray[0]`) but no top radius (it's commented out in the header tokens), and the `role="dialog"` container has a `borderRadius` yet never clipped its children. So the square-cornered header paints over the container's rounded top.

## Fix

Add `overflow: hidden` to the dialog container so every child — the opaque header and footer included — is clipped to `modalTokens.borderRadius`. This is the robust option from the issue: it also protects the footer and any future opaque child, so no per-corner radius hacks are needed.

```tsx
borderRadius={modalTokens.borderRadius}
overflow="hidden"   // ← clips children to the container radius (#1687)
boxShadow={modalTokens.boxShadow}
```

## Why it's safe

- **Dropdowns / Selects / Menus / Popovers inside a modal are unaffected** — they render through **Radix portals** (`RadixPopover.Portal`, `RadixMenu.Portal`) at the document body with `zIndex: 101`, so they are not DOM children of the dialog and cannot be clipped.
- The modal **body already had `overflow: auto`**, so inline content was already contained — this change only clips the corner slivers.
- `boxShadow` is unaffected (renders outside the border box), so the drop shadow still shows.
- **Dark theme** is fixed by the same line (overflow is theme-agnostic).

## Scope

- **V1 `Modal.tsx` only.** `ModalV2` already handles this via header top-radius tokens; `MobileModal` uses a different (bottom-sheet) structure.

## Tests

- Adds `packages/blend/__tests__/components/Modal/Modal.test.tsx` (V1 Modal had no unit test) asserting the dialog container clips (`overflow: hidden`), with and without an opaque header. Both pass.

## Verification

Ran the `Components/Modal → Default` and `Dark theme` Storybook stories — all four corners rounded, header no longer square.

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)