### PR TITLE
feat(ascent): add a visible search entry point to the docs navbar

### DIFF
--- a/apps/ascent/components/Navigation/GlobalKeyboardNavigation.tsx
+++ b/apps/ascent/components/Navigation/GlobalKeyboardNavigation.tsx
@@ -324,7 +324,10 @@ export const GlobalKeyboardNavigationProvider = ({
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Don't interfere with search modal
-            if (isSearchModalOpen || document.querySelector('[cmdk-dialog]')) {
+            if (
+                isSearchModalOpen ||
+                document.querySelector('[data-cmd-open]')
+            ) {
                 return
             }
 

--- a/apps/ascent/components/Navigation/Navbar.tsx
+++ b/apps/ascent/components/Navigation/Navbar.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from '@/lib/utils/cn'
 import ThemeToggle from '../ui/ThemeToggle/ThemeToggle'
 import VersionToggle from '../ui/VersionToggle'
+import SearchTrigger from '../ui/SearchTrigger'
 
 const PRIMARY_NAV_LABELS = ['Docs', 'Storybook']
 const MORE_NAV_LABELS = ['Blogs', 'Changelog', 'Showcase']
@@ -287,12 +288,14 @@ export default function Navbar() {
                     </nav>
 
                     <IconBar />
+                    <SearchTrigger />
                     <ThemeToggle />
                 </div>
 
                 {/* Mobile */}
                 <div className="flex md:hidden items-center gap-2">
                     <IconBar />
+                    <SearchTrigger />
                     <ThemeToggle />
 
                     <Drawer.Root

--- a/apps/ascent/components/layout/DeferredCommandSearch.tsx
+++ b/apps/ascent/components/layout/DeferredCommandSearch.tsx
@@ -1,11 +1,24 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { useCommandSearch } from '../ui/CommandSearch/SearchContext'
 
-const CommandSearch = dynamic(() => import('../ui/CommandSearch'), {
-    ssr: false,
-})
+const loadCommandSearch = () => import('../ui/CommandSearch/CommandSearch')
+
+const CommandSearch = dynamic(loadCommandSearch, { ssr: false })
+
+/**
+ * Warms the modal's chunk — which statically imports the ~900KB search index —
+ * before the user commits to opening it. Triggers call this on hover/focus.
+ */
+export const preloadCommandSearch = () => {
+    void loadCommandSearch()
+}
 
 export default function DeferredCommandSearch() {
+    const { open } = useCommandSearch()
+
+    if (!open) return null
+
     return <CommandSearch />
 }

--- a/apps/ascent/components/layout/SharedLayout.tsx
+++ b/apps/ascent/components/layout/SharedLayout.tsx
@@ -5,6 +5,7 @@ import { TOCItem } from '../Navigation/TableOfContents'
 import { DynamicSnackbar } from '../ui/DynamicSnackBar'
 import Navbar from '../Navigation/Navbar'
 import DeferredCommandSearch from './DeferredCommandSearch'
+import { SearchProvider } from '../ui/CommandSearch/SearchContext'
 import { cn } from '@/lib/utils/cn'
 
 export interface SharedLayoutProps {
@@ -29,38 +30,41 @@ const SharedLayout = ({
     fullWidth = false,
 }: SharedLayoutProps) => {
     return (
-        <GlobalKeyboardNavigationProvider>
-            <div className={`min-h-screen ${className}`}>
-                <div className="w-full">
-                    <Navbar />
-                    <div className="border-t border-border w-full">
-                        <div
-                            className={cn(
-                                'flex justify-center items-start mx-auto w-full',
-                                !fullWidth &&
-                                    'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-360'
-                            )}
-                        >
-                            <main
+        <SearchProvider>
+            <GlobalKeyboardNavigationProvider>
+                <div className={`min-h-screen ${className}`}>
+                    <div className="w-full">
+                        <Navbar />
+                        <div className="border-t border-border w-full">
+                            <div
                                 className={cn(
-                                    'flex-1 min-w-0',
-                                    showSideBorder && 'border-x border-border'
+                                    'flex justify-center items-start mx-auto w-full',
+                                    !fullWidth &&
+                                        'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-360'
                                 )}
                             >
-                                {children}
-                            </main>
+                                <main
+                                    className={cn(
+                                        'flex-1 min-w-0',
+                                        showSideBorder &&
+                                            'border-x border-border'
+                                    )}
+                                >
+                                    {children}
+                                </main>
+                            </div>
                         </div>
                     </div>
+                    {showFooter && (
+                        <div className="fixed bottom-0 left-0 right-0 z-10 w-full border-t border-border h-17.75 bg-background hidden md:block">
+                            <div className="border-x border-border max-w-360 mx-auto h-17.75" />
+                        </div>
+                    )}
                 </div>
-                {showFooter && (
-                    <div className="fixed bottom-0 left-0 right-0 z-10 w-full border-t border-border h-17.75 bg-background hidden md:block">
-                        <div className="border-x border-border max-w-360 mx-auto h-17.75" />
-                    </div>
-                )}
-            </div>
-            <DynamicSnackbar />
-            <DeferredCommandSearch />
-        </GlobalKeyboardNavigationProvider>
+                <DynamicSnackbar />
+                <DeferredCommandSearch />
+            </GlobalKeyboardNavigationProvider>
+        </SearchProvider>
     )
 }
 

--- a/apps/ascent/components/ui/CommandSearch/CommandSearch.tsx
+++ b/apps/ascent/components/ui/CommandSearch/CommandSearch.tsx
@@ -10,6 +10,7 @@ import {
     GitDiffIcon,
 } from '@phosphor-icons/react/dist/ssr'
 import { cn } from '@/lib/utils/cn'
+import { useCommandSearch } from './SearchContext'
 import { HEADER_NAV_LINKS, ROUTES } from '@/lib/constants'
 import { showcaseData } from '@/lib/showcase-data'
 import searchIndex from '@/public/search-index.json'
@@ -211,22 +212,32 @@ const componentItemClassName = cn(
 )
 
 export function CommandSearch() {
-    const [open, setOpen] = useState(false)
+    const { closeSearch } = useCommandSearch()
     const [query, setQuery] = useState('')
     const listRef = useRef<HTMLDivElement>(null)
+    const inputRef = useRef<HTMLInputElement>(null)
     const router = useRouter()
     const normalizedQuery = query.trim()
 
     useEffect(() => {
-        const down = (e: KeyboardEvent) => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
                 e.preventDefault()
-                setOpen((o) => !o)
+                closeSearch()
+                return
+            }
+
+            // The command input is the only focusable element in the dialog, so
+            // trapping focus is just keeping Tab from moving it back out.
+            if (e.key === 'Tab') {
+                e.preventDefault()
+                inputRef.current?.focus()
             }
         }
-        document.addEventListener('keydown', down)
-        return () => document.removeEventListener('keydown', down)
-    }, [])
+
+        document.addEventListener('keydown', onKeyDown)
+        return () => document.removeEventListener('keydown', onKeyDown)
+    }, [closeSearch])
 
     useEffect(() => {
         requestAnimationFrame(() => {
@@ -236,8 +247,7 @@ export function CommandSearch() {
 
     const go = (path: string) => {
         router.push(path)
-        setOpen(false)
-        setQuery('')
+        closeSearch()
     }
 
     const filteredComponents = normalizedQuery
@@ -267,25 +277,24 @@ export function CommandSearch() {
         filteredChangelogEntries.length > 0 ||
         filteredShowcaseItems.length > 0
 
-    if (!open) return null
-
     return (
-        <div
-            data-cmd-open
-            className="fixed inset-0 z-150"
-            onKeyDown={(e) => e.key === 'Escape' && setOpen(false)}
-        >
+        <div data-cmd-open className="fixed inset-0 z-150">
             <div
+                aria-hidden="true"
                 className="absolute inset-0 bg-black/50"
-                onClick={() => setOpen(false)}
+                onClick={closeSearch}
             />
             <Command
+                role="dialog"
+                aria-modal="true"
+                aria-label="Search documentation"
                 shouldFilter={false}
                 className="absolute left-1/2 top-1/2 w-full max-w-2xl -translate-1/2 bg-background border border-border shadow-2xl overflow-hidden rounded-xl"
             >
                 <div className="flex items-center border-b border-border px-4">
                     <MagnifyingGlassIcon className="w-4 h-4 text-muted-foreground mr-3" />
                     <Command.Input
+                        ref={inputRef}
                         value={query}
                         onValueChange={setQuery}
                         placeholder="Search..."

--- a/apps/ascent/components/ui/CommandSearch/SearchContext.tsx
+++ b/apps/ascent/components/ui/CommandSearch/SearchContext.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
+
+type SearchContextValue = {
+    open: boolean
+    openSearch: () => void
+    closeSearch: () => void
+}
+
+const SearchContext = createContext<SearchContextValue | null>(null)
+
+export const useCommandSearch = () => {
+    const context = useContext(SearchContext)
+    if (!context) {
+        throw new Error('useCommandSearch must be used within a SearchProvider')
+    }
+    return context
+}
+
+/**
+ * Owns the command palette's open state.
+ *
+ * It lives outside CommandSearch so that visible triggers can open the modal,
+ * and so the keyboard shortcut keeps working while the modal's chunk — which
+ * carries the ~900KB search index — is still loading.
+ */
+export function SearchProvider({ children }: { children: React.ReactNode }) {
+    const [open, setOpen] = useState(false)
+    // Whatever had focus when the modal opened: the trigger for a click, the
+    // last focused element for the shortcut. Focus goes back there on close.
+    const lastFocusedRef = useRef<HTMLElement | null>(null)
+
+    const openSearch = useCallback(() => {
+        lastFocusedRef.current =
+            document.activeElement instanceof HTMLElement
+                ? document.activeElement
+                : null
+        setOpen(true)
+    }, [])
+
+    const closeSearch = useCallback(() => {
+        setOpen(false)
+        lastFocusedRef.current?.focus()
+        lastFocusedRef.current = null
+    }, [])
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return
+            e.preventDefault()
+            if (open) closeSearch()
+            else openSearch()
+        }
+
+        document.addEventListener('keydown', onKeyDown)
+        return () => document.removeEventListener('keydown', onKeyDown)
+    }, [open, openSearch, closeSearch])
+
+    const value = useMemo(
+        () => ({ open, openSearch, closeSearch }),
+        [open, openSearch, closeSearch]
+    )
+
+    return (
+        <SearchContext.Provider value={value}>
+            {children}
+        </SearchContext.Provider>
+    )
+}

--- a/apps/ascent/components/ui/SearchTrigger/SearchTrigger.tsx
+++ b/apps/ascent/components/ui/SearchTrigger/SearchTrigger.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
+import { preloadCommandSearch } from '@/components/layout/DeferredCommandSearch'
+import { useCommandSearch } from '../CommandSearch/SearchContext'
+import { cn } from '@/lib/utils/cn'
+
+/**
+ * The command palette's only visible entry point. Sized and styled to match
+ * ThemeToggle, which it sits beside in the navbar.
+ */
+export default function SearchTrigger({ className }: { className?: string }) {
+    const { open, openSearch } = useCommandSearch()
+    // Resolved after mount: the site is statically exported, so a
+    // platform-specific hint in the prerendered HTML would mismatch on hydrate.
+    const [shortcut, setShortcut] = useState<string | null>(null)
+
+    useEffect(() => {
+        const isApple = /Mac|iPhone|iPad|iPod/.test(
+            navigator.platform || navigator.userAgent
+        )
+        setShortcut(isApple ? '⌘K' : 'Ctrl K')
+    }, [])
+
+    return (
+        <button
+            type="button"
+            onClick={openSearch}
+            onPointerEnter={preloadCommandSearch}
+            onFocus={preloadCommandSearch}
+            title={shortcut ? `Search (${shortcut})` : 'Search'}
+            aria-label="Search documentation"
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            aria-keyshortcuts="Meta+K Control+K"
+            className={cn(
+                'p-2 border border-border text-muted-foreground transition-colors hover:text-foreground',
+                className
+            )}
+        >
+            <MagnifyingGlassIcon size={16} />
+        </button>
+    )
+}

--- a/apps/ascent/components/ui/SearchTrigger/index.ts
+++ b/apps/ascent/components/ui/SearchTrigger/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchTrigger'

--- a/apps/ascent/components/ui/index.ts
+++ b/apps/ascent/components/ui/index.ts
@@ -2,5 +2,5 @@
 export { default as CodeBlock } from './CodeBlock'
 export { default as Tooltip } from './Tooltip'
 export { default as ThemeToggle } from './ThemeToggle'
-export { default as CommandSearch } from './CommandSearch'
 export { default as VersionToggle } from './VersionToggle'
+export { default as SearchTrigger } from './SearchTrigger'


### PR DESCRIPTION
## Problem

The docs command palette could only be opened with `Cmd+K`. There was no search bar, icon, or any other affordance anywhere in the site chrome, so:

- on desktop, users had no way to learn the feature exists;
- on touch devices, search was **completely unreachable** — no keyboard, no trigger.

The blocker was that `CommandSearch` owned its `open` state privately (`useState` + its own `keydown` listener), so nothing outside the component could open it.

## What this does

Lifts the palette's open state into a `SearchProvider` and adds a square search button in the navbar, immediately left of the theme toggle, in both the desktop and mobile clusters. It reuses `ThemeToggle`'s classes and a 16px icon, so the two render as matching 34px squares.

```
Docs  Storybook  More   [GitHub|Figma]  [🔍]  [☀]
```

The shortcut lives in a `title` tooltip — `Search (⌘K)` on Apple platforms, `Search (Ctrl K)` elsewhere. It resolves after mount, since the site is `output: 'export'` and a platform-specific hint in prerendered HTML would mismatch on hydration.

## Also in here

**Bundle** — `public/search-index.json` is 918 KB and is statically imported by `CommandSearch`. The existing `dynamic(..., { ssr: false })` wrapper only deferred it past SSR; because the component rendered unconditionally, the chunk was still fetched on every page load. It's now gated on first open and preloaded on the trigger's `pointerenter`/`focus`. `CommandSearch` is also dropped from the `components/ui` barrel, which `MDXComponents.tsx` imports — a second path back into the index.

**Modal accessibility** — added `role="dialog"`, `aria-modal`, `aria-label`; `aria-hidden` on the overlay; focus capture on open and restore on close; a focus trap (the command input is the dialog's only focusable child); and Escape moved to a document listener so it works even if focus leaves the input.

**Two bugs found while reading the area**
- `GlobalKeyboardNavigation.tsx` guarded on `document.querySelector('[cmdk-dialog]')`, but the modal renders a bare `<Command>`, not `<Command.Dialog>` — that attribute never existed. Its "don't interfere with the search modal" guard was a no-op, only surviving because arrow keys landed on the `<input>` and hit the separate `HTMLInputElement` check. Now keyed on `[data-cmd-open]`, which the modal actually sets.
- The shortcut matched `e.key === 'k'` exactly, so `Shift+Cmd+K` did nothing. Now case-insensitive.

## Verification

- `next build` — 165 pages exported clean; confirmed in the exported HTML that the trigger renders between the icon bar and the theme toggle
- `tsc --noEmit` clean; `eslint --max-warnings 0` clean on all touched files
- `prettier --check` clean across `apps/ascent`
- Confirmed the search index now sits alone in an async chunk that no page HTML references

**Not verified:** I have not clicked through this in a browser. The open/close and focus-restore behaviour is reasoned from the code, not observed — worth a quick manual pass on review.

## Note for reviewers

The navbar is `relative`, not sticky, so once you scroll down a long docs page the button leaves the viewport and `Cmd+K` becomes the only way in. Earlier drafts of this change also placed triggers at the top of the docs sidebar and in the sticky breadcrumb bar; both were dropped in favour of the single navbar button. Making the header sticky would close that gap if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWUKeTncWa9TefasUTyenh