### PR TITLE
fix(button): mute disabled label text to match the frame

### DIFF
--- a/apps/storybook/stories/components/Button/v1/Button.stories.tsx
+++ b/apps/storybook/stories/components/Button/v1/Button.stories.tsx
@@ -284,6 +284,21 @@ export const Default: Story = {
 }
 
 /**
+ * Disabled Secondary with an icon — frame, icon and label all read as disabled.
+ */
+export const DisabledSecondary: Story = {
+    name: 'Disabled Secondary',
+    render: () => (
+        <Button
+            buttonType={ButtonType.SECONDARY}
+            text="Button"
+            disabled
+            leadingIcon={<Settings size={16} />}
+        />
+    ),
+}
+
+/**
  * Button types
  */
 export const ButtonTypes: Story = {

--- a/packages/blend/__tests__/components/Button/Button.test.tsx
+++ b/packages/blend/__tests__/components/Button/Button.test.tsx
@@ -8,6 +8,29 @@ import {
     ButtonSubType,
 } from '../../../lib/components/Button/types'
 import { MockIcon } from '../../test-utils'
+import FOUNDATION_THEME from '../../../lib/tokens/theme.token'
+
+describe('Button disabled label color (regression #1703)', () => {
+    it('mutes the Secondary label text in the disabled state', () => {
+        render(
+            <Button
+                buttonType={ButtonType.SECONDARY}
+                text="Disabled"
+                disabled
+            />
+        )
+        expect(screen.getByText('Disabled')).toHaveStyle({
+            color: FOUNDATION_THEME.colors.gray[300],
+        })
+    })
+
+    it('does not apply the disabled color to an enabled Secondary label', () => {
+        render(<Button buttonType={ButtonType.SECONDARY} text="Enabled" />)
+        expect(screen.getByText('Enabled')).not.toHaveStyle({
+            color: FOUNDATION_THEME.colors.gray[300],
+        })
+    })
+})
 
 describe.skip('Button Component', () => {
     describe('Rendering', () => {

--- a/packages/blend/lib/components/Button/ButtonBase.tsx
+++ b/packages/blend/lib/components/Button/ButtonBase.tsx
@@ -288,7 +288,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
                                         ? 'transparent'
                                         : buttonTokens.text.color[buttonType][
                                               subType
-                                          ][state]
+                                          ][isDisabled ? 'disabled' : state]
                                 }
                                 aria-hidden={isSkeleton ? true : undefined}
                                 lineHeight={lineHeight}


### PR DESCRIPTION
## Summary

A disabled `Button` dimmed its container and icons, but the **label text kept its enabled colour** — so Secondary (and other non-primary) buttons read as "half-disabled": a faded frame with active-looking text (#1703).

## Root cause

In `ButtonBase.tsx`, the label `<Text>` resolved its colour from the `state` prop alone:

```tsx
color[buttonType][subType][state]
```

…while the leading/trailing icons already used `disabled ? 'disabled' : 'default'`. So when `disabled=true` but `state='default'`, the label never picked up the disabled colour.

## Fix

Resolve the label colour with the disabled state, mirroring the icons:

```tsx
color[buttonType][subType][isDisabled ? 'disabled' : state]
```

- Secondary disabled label now renders `gray[300]` (faded), matching the frame + icon.
- Primary/Danger/Success already have correct disabled text tokens, so they're covered too.
- `hover`/`active` states are preserved when the button is enabled.

## Scope

**V1 `Button` only.** `ButtonV2` already handles this correctly in `getTextColor` (`disabled ? DISABLED : state`).

## Tests

Adds a regression test (`Button disabled label color (regression #1703)`) — the existing V1 Button suite is `describe.skip`, so the new tests live in their own non-skipped block. Both pass.

Also adds a **Disabled Secondary** story for visual verification.

Closes #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)