### PR TITLE
ci(blend-native): phase 1 — delivery rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,44 @@ jobs:
                   path: packages/blend/coverage
                   retention-days: 30
 
+    native:
+        name: Native Tests
+        runs-on: ubuntu-latest
+        needs: lint-build
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - run: pnpm install --frozen-lockfile
+
+            # blend-native's vitest suites resolve @juspay/blend-design-system/node
+            # through the workspace link, which serves built dist/.
+            - name: Build @juspay/blend-design-system
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Lint and typecheck
+              run: |
+                  pnpm --filter @juspay/blend-native lint
+                  pnpm --filter @juspay/blend-native typecheck
+                  pnpm --filter native-site typecheck
+
+            - name: Run tests (vitest + jest)
+              run: pnpm --filter @juspay/blend-native test
+              env:
+                  CI: true
+
+            - name: Build package
+              run: pnpm --filter @juspay/blend-native build
+
     preview:
         name: Publish preview to pkg.pr.new
         runs-on: ubuntu-latest
@@ -144,5 +182,10 @@ jobs:
             - name: Build @juspay/blend-design-system
               run: pnpm --filter @juspay/blend-design-system build
 
+            # pkg-pr-new packs without running prepublishOnly, so build
+            # blend-native's lib/ output explicitly first.
+            - name: Build @juspay/blend-native
+              run: pnpm --filter @juspay/blend-native build
+
             - name: Publish preview
-              run: pnpm dlx pkg-pr-new publish --pnpm './packages/blend'
+              run: pnpm dlx pkg-pr-new publish --pnpm './packages/blend' './packages/blend-native'

--- a/.github/workflows/publish-native-npm.yml
+++ b/.github/workflows/publish-native-npm.yml
@@ -1,0 +1,141 @@
+name: Publish Native to NPM
+
+# Publishes @juspay/blend-native on its own version line, independent of
+# @juspay/blend-design-system (compatibility is declared through the peer
+# range instead). Beta publishes run from dev or staging; stable from main.
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm_publish:
+                description: 'Type "PUBLISH" to confirm publishing to NPM'
+                required: true
+                type: string
+            dist_tag:
+                description: 'NPM dist-tag to publish under'
+                required: true
+                type: choice
+                options:
+                    - beta
+                    - latest
+
+concurrency:
+    group: publish-native-npm-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-native:
+        name: Publish @juspay/blend-native
+        runs-on: ubuntu-latest
+        environment: npm
+        if: github.event.inputs.confirm_publish == 'PUBLISH'
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: Verify branch for dist-tag
+              run: |
+                  TAG="${{ github.event.inputs.dist_tag }}"
+                  REF="${{ github.ref }}"
+                  if [[ "$TAG" == "latest" && "$REF" != "refs/heads/main" ]]; then
+                    echo "❌ Stable (latest) publishes must run from main (got $REF)"
+                    exit 1
+                  fi
+                  if [[ "$TAG" == "beta" && "$REF" != "refs/heads/dev" && "$REF" != "refs/heads/staging" ]]; then
+                    echo "❌ Beta publishes must run from dev or staging (got $REF)"
+                    exit 1
+                  fi
+                  echo "✅ $TAG publish allowed from $REF"
+
+            - name: Setup Node.js 22 and pnpm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: 'https://registry.npmjs.org'
+                  scope: '@juspay'
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Enable corepack & install deps
+              run: |
+                  corepack enable
+                  pnpm install --frozen-lockfile
+
+            - name: Verify version matches dist-tag
+              id: version
+              run: |
+                  cd packages/blend-native
+                  VERSION=$(node -p "require('./package.json').version")
+                  TAG="${{ github.event.inputs.dist_tag }}"
+                  if [[ "$TAG" == "beta" && ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+                    echo "❌ $VERSION is not a beta version (expected X.Y.Z-beta.N)"
+                    exit 1
+                  fi
+                  if [[ "$TAG" == "latest" && ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "❌ $VERSION is not a stable version (expected X.Y.Z)"
+                    exit 1
+                  fi
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "✅ Publishing $VERSION under dist-tag $TAG"
+
+            - name: Check version not already published
+              id: check_published
+              run: |
+                  VERSION="${{ steps.version.outputs.version }}"
+                  if npm view "@juspay/blend-native@$VERSION" version 2>/dev/null >/dev/null; then
+                    echo "already_published=true" >> $GITHUB_OUTPUT
+                    echo "⚠️ @juspay/blend-native@$VERSION already exists on NPM — skipping"
+                  else
+                    echo "already_published=false" >> $GITHUB_OUTPUT
+                    echo "✅ Version $VERSION is not yet published"
+                  fi
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            # bob's typescript target resolves @juspay/blend-design-system/node
+            # from the workspace package's built dist, so blend builds first.
+            - name: Build @juspay/blend-design-system
+              if: steps.check_published.outputs.already_published != 'true'
+              run: pnpm --filter @juspay/blend-design-system build
+
+            - name: Lint, typecheck and test
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  pnpm --filter @juspay/blend-native lint
+                  pnpm --filter @juspay/blend-native typecheck
+                  pnpm --filter @juspay/blend-native test
+              env:
+                  CI: true
+
+            - name: Build @juspay/blend-native
+              if: steps.check_published.outputs.already_published != 'true'
+              run: pnpm --filter @juspay/blend-native build
+
+            - name: Publish to NPM
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  cd packages/blend-native
+                  npm publish --access public --tag "${{ github.event.inputs.dist_tag }}"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Verify after publish
+              if: steps.check_published.outputs.already_published != 'true'
+              run: |
+                  VERSION="${{ steps.version.outputs.version }}"
+                  TAG="${{ github.event.inputs.dist_tag }}"
+                  sleep 10  # NPM propagation
+                  PUBLISHED=$(npm view "@juspay/blend-native@$TAG" version 2>/dev/null || echo "")
+                  if [[ "$PUBLISHED" == "$VERSION" ]]; then
+                    echo "✅ @juspay/blend-native@$VERSION is live under dist-tag $TAG"
+                  else
+                    echo "⚠️ Expected $VERSION but NPM shows '$PUBLISHED' for tag $TAG (may be propagation delay)"
+                  fi
+                  echo "## 🎉 @juspay/blend-native published" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Version**: \`$VERSION\` · **Tag**: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo '```bash' >> $GITHUB_STEP_SUMMARY
+                  echo "npm install @juspay/blend-native@$TAG" >> $GITHUB_STEP_SUMMARY
+                  echo '```' >> $GITHUB_STEP_SUMMARY

--- a/apps/native-site/package.json
+++ b/apps/native-site/package.json
@@ -7,7 +7,8 @@
         "start": "expo start",
         "android": "expo start --android",
         "ios": "expo start --ios",
-        "web": "expo start --web"
+        "web": "expo start --web",
+        "typecheck": "tsc --noEmit"
     },
     "dependencies": {
         "@expo/metro-runtime": "~56.0.20",

--- a/apps/native-site/tsconfig.json
+++ b/apps/native-site/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "expo/tsconfig.base",
     "compilerOptions": {
         "strict": true,
-        "baseUrl": ".",
         "moduleSuffixes": ["", ".native"],
         "paths": {
             "@juspay/blend-native": [

--- a/packages/blend-native/__tests__/nodeEntryContract.test.ts
+++ b/packages/blend-native/__tests__/nodeEntryContract.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+/**
+ * The web→native export contract.
+ *
+ * Every symbol this package imports from `@juspay/blend-design-system/node`
+ * must exist in the **built** entry (`dist/node.js`) — that is what the
+ * workspace link serves at runtime, and what published consumers get. A
+ * factory exported from `lib/node.ts` but not rebuilt, or dropped from the
+ * entry, surfaces in an app as an unrelated runtime `undefined` (the failure
+ * mode CLAUDE.md warns about). This test turns it into a CI failure with the
+ * missing name spelled out.
+ *
+ * The used-symbol list is derived by scanning `src/`, not hand-maintained —
+ * registering a new component's factory automatically extends the contract.
+ */
+
+const SRC = resolve(__dirname, '../src')
+const SPECIFIER = '@juspay/blend-design-system/node'
+
+function walk(dir: string): string[] {
+    return readdirSync(dir).flatMap((name) => {
+        const path = join(dir, name)
+        if (statSync(path).isDirectory()) return walk(path)
+        return /\.tsx?$/.test(name) ? [path] : []
+    })
+}
+
+/**
+ * Value names imported from the node entry across `src/`. Type-only imports
+ * (`import type {...}` blocks and `type X` specifiers) are erased at compile
+ * time and cannot produce a runtime `undefined`, so they are skipped.
+ */
+function collectValueImports(): Map<string, string[]> {
+    const usedBy = new Map<string, string[]>()
+    for (const file of walk(SRC)) {
+        const source = readFileSync(file, 'utf8')
+        const imports = source.matchAll(
+            /import\s+(type\s+)?\{([^}]*)\}\s*from\s*'([^']+)'/g
+        )
+        for (const [, typeOnly, names, spec] of imports) {
+            if (spec !== SPECIFIER || typeOnly) continue
+            for (const entry of names.split(',')) {
+                const trimmed = entry.trim()
+                if (!trimmed || trimmed.startsWith('type ')) continue
+                // `Foo as Bar` — the contract is about the source name `Foo`.
+                const name = trimmed.split(/\s+as\s+/)[0].trim()
+                const files = usedBy.get(name) ?? []
+                files.push(file.slice(SRC.length + 1))
+                usedBy.set(name, files)
+            }
+        }
+    }
+    return usedBy
+}
+
+describe('node entry contract', () => {
+    it('imports the node entry somewhere (scanner sanity check)', () => {
+        expect(collectValueImports().size).toBeGreaterThan(0)
+    })
+
+    it('every value used from the node entry exists in the built entry', async () => {
+        let node: Record<string, unknown>
+        try {
+            node = await import(SPECIFIER)
+        } catch (error) {
+            throw new Error(
+                `Could not load ${SPECIFIER} — the workspace link serves ` +
+                    `built dist/, so run \`pnpm build:blend\` first.\n${String(error)}`
+            )
+        }
+
+        const missing: string[] = []
+        for (const [name, files] of collectValueImports()) {
+            if (node[name] === undefined) {
+                missing.push(`${name} (used by ${files.join(', ')})`)
+            }
+        }
+
+        expect(
+            missing,
+            `Missing from the built ${SPECIFIER} entry — export it from ` +
+                `packages/blend/lib/node.ts and run \`pnpm build:blend\`:\n  ` +
+                missing.join('\n  ')
+        ).toEqual([])
+    })
+})

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
         "lint": {
             "dependsOn": ["^lint"]
         },
+        "typecheck": {},
+        "@juspay/blend-native#test": {
+            "dependsOn": ["@juspay/blend-design-system#build"]
+        },
         "dev": {
             "cache": false,
             "persistent": true


### PR DESCRIPTION
## Summary

**Stacked on #1711** (phase 0) — merge that first; GitHub will retarget this to `dev` when the base branch is deleted.

Phase 1 of the blend-native foundation plan: the delivery rails. Before this, zero blend-native tests/lint/typecheck ran anywhere in CI, no workflow could publish the package, and PR previews excluded it.

### CI (`ci.yml`, `turbo.json`)
- New **Native Tests** job: lint + typecheck (blend-native **and** `apps/native-site`) + vitest + jest render tests + the bob build.
- turbo gains a `typecheck` task and a package-scoped `@juspay/blend-native#test` task that builds blend first (blend-native's vitest resolves `/node` through the workspace link, which serves built `dist/`). Scoped rather than generic because blend's `test` script is watch-mode.
- pkg-pr-new previews now also publish `./packages/blend-native` (built explicitly first — pkg-pr-new packs without running `prepublishOnly`).
- `apps/native-site` gets a `typecheck` script; its tsconfig drops the TS6-deprecated `baseUrl` (paths no longer need it).

### Node-entry contract test
Scans `src/` for every value imported from `@juspay/blend-design-system/node` and asserts each exists in the **built** entry. A factory missing from `lib/node.ts` previously surfaced as an unrelated runtime `undefined` in a consumer app (the failure mode CLAUDE.md warns about); now it fails CI naming the missing symbol. Self-maintaining — registering a new component's factory extends the contract automatically.

### Publish workflow (`publish-native-npm.yml`)
`workflow_dispatch` publishing `@juspay/blend-native` on its **independent version line**: confirmation string, dist-tag choice (beta from `dev`/`staging`, latest from `main` only), version-format and already-published gates, full lint/typecheck/test before build, post-publish verification. Uses the same `npm` environment/secret as the existing publish workflows.

## Test plan
- `turbo run typecheck --filter=@juspay/blend-native --filter=native-site` — green
- `turbo run test --filter=@juspay/blend-native --dry-run` — confirms the blend-build → native-test graph
- Full native suite: 14 vitest files + 21 jest tests green; lint clean
- Both workflow files YAML-validated; the Native Tests job will exercise itself on this PR once retargeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS