### PR TITLE
feat(blend-native): phase 2b — gesture-driven bottom sheet

### DIFF
--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -8,13 +8,15 @@ import {
     Text as RNText,
     View,
 } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { BlendNativeProvider, Theme } from '@juspay/blend-native'
 import ButtonShowcase from './components/ButtonShowcase'
 import TagShowcase from './components/TagShowcase'
 import AlertShowcase from './components/AlertShowcase'
+import SheetShowcase from './components/SheetShowcase'
 import PlatformPreview from './components/PlatformPreview'
 
-type Tab = 'alert' | 'tag' | 'button'
+type Tab = 'alert' | 'tag' | 'button' | 'sheet'
 
 export default function App() {
     const [theme, setTheme] = useState<Theme>(Theme.LIGHT)
@@ -27,24 +29,33 @@ export default function App() {
 
     return (
         <PlatformPreview>
-            {/* A single provider themes every Blend component beneath it. Before
-                this existed each component took its own `theme` prop, so an
-                app-wide toggle like the one below was not expressible. */}
-            <BlendNativeProvider theme={theme}>
-                <SafeAreaView
-                    style={[styles.container, { backgroundColor: palette.bg }]}
-                >
-                    <StatusBar
-                        barStyle={isDark ? 'light-content' : 'dark-content'}
-                    />
-                    <ScrollView contentContainerStyle={styles.scroll}>
-                        <RNText style={[styles.header, { color: palette.fg }]}>
-                            Blend Native
-                        </RNText>
+            {/* GestureHandlerRootView is required for BottomSheet's pan
+                gesture; apps on react-navigation already have one. */}
+            <GestureHandlerRootView style={styles.container}>
+                {/* A single provider themes every Blend component beneath it.
+                    Before this existed each component took its own `theme`
+                    prop, so an app-wide toggle was not expressible. */}
+                <BlendNativeProvider theme={theme}>
+                    <SafeAreaView
+                        style={[
+                            styles.container,
+                            { backgroundColor: palette.bg },
+                        ]}
+                    >
+                        <StatusBar
+                            barStyle={isDark ? 'light-content' : 'dark-content'}
+                        />
+                        <ScrollView contentContainerStyle={styles.scroll}>
+                            <RNText
+                                style={[styles.header, { color: palette.fg }]}
+                            >
+                                Blend Native
+                            </RNText>
 
-                        <View style={styles.controls}>
-                            {(['alert', 'tag', 'button'] as Tab[]).map(
-                                (value) => (
+                            <View style={styles.controls}>
+                                {(
+                                    ['alert', 'tag', 'button', 'sheet'] as Tab[]
+                                ).map((value) => (
                                     <Pressable
                                         key={value}
                                         onPress={() => setTab(value)}
@@ -63,30 +74,33 @@ export default function App() {
                                                 value.slice(1)}
                                         </RNText>
                                     </Pressable>
-                                )
-                            )}
+                                ))}
 
-                            <Pressable
-                                onPress={() =>
-                                    setTheme(isDark ? Theme.LIGHT : Theme.DARK)
-                                }
-                                style={[
-                                    styles.control,
-                                    { backgroundColor: palette.muted },
-                                ]}
-                            >
-                                <RNText style={{ color: palette.fg }}>
-                                    {isDark ? '☾ Dark' : '☀ Light'}
-                                </RNText>
-                            </Pressable>
-                        </View>
+                                <Pressable
+                                    onPress={() =>
+                                        setTheme(
+                                            isDark ? Theme.LIGHT : Theme.DARK
+                                        )
+                                    }
+                                    style={[
+                                        styles.control,
+                                        { backgroundColor: palette.muted },
+                                    ]}
+                                >
+                                    <RNText style={{ color: palette.fg }}>
+                                        {isDark ? '☾ Dark' : '☀ Light'}
+                                    </RNText>
+                                </Pressable>
+                            </View>
 
-                        {tab === 'alert' ? <AlertShowcase /> : null}
-                        {tab === 'tag' ? <TagShowcase /> : null}
-                        {tab === 'button' ? <ButtonShowcase /> : null}
-                    </ScrollView>
-                </SafeAreaView>
-            </BlendNativeProvider>
+                            {tab === 'alert' ? <AlertShowcase /> : null}
+                            {tab === 'tag' ? <TagShowcase /> : null}
+                            {tab === 'button' ? <ButtonShowcase /> : null}
+                            {tab === 'sheet' ? <SheetShowcase /> : null}
+                        </ScrollView>
+                    </SafeAreaView>
+                </BlendNativeProvider>
+            </GestureHandlerRootView>
         </PlatformPreview>
     )
 }
@@ -95,6 +109,11 @@ const styles = StyleSheet.create({
     container: { flex: 1 },
     scroll: { padding: 16, gap: 8 },
     header: { fontSize: 22, fontWeight: '700', marginBottom: 12 },
-    controls: { flexDirection: 'row', gap: 8, marginBottom: 20 },
+    controls: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: 8,
+        marginBottom: 20,
+    },
     control: { paddingVertical: 6, paddingHorizontal: 12, borderRadius: 8 },
 })

--- a/apps/native-site/components/SheetShowcase.tsx
+++ b/apps/native-site/components/SheetShowcase.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { StyleSheet, Text as RNText, View } from 'react-native'
+import {
+    BottomSheet,
+    Button,
+    ButtonType,
+    Tag,
+    TagColor,
+    TagType,
+} from '@juspay/blend-native'
+
+/**
+ * BottomSheet verification: open/dismiss via drag, backdrop, and the
+ * Android back button. What to check on device (not react-native-web):
+ *
+ * - the sheet slides from the bottom edge with no flash-in-place
+ * - drag follows the finger, springs back below the dismiss threshold
+ * - a downward fling dismisses; an upward fling never does
+ * - reduce-motion in OS settings turns the slide into a fade
+ * - the home-indicator inset pads the content (with SafeAreaProvider)
+ */
+export default function SheetShowcase() {
+    const [open, setOpen] = useState(false)
+    const [tallOpen, setTallOpen] = useState(false)
+
+    return (
+        <View style={styles.column}>
+            <Button
+                buttonType={ButtonType.PRIMARY}
+                text="Open sheet"
+                onPress={() => setOpen(true)}
+            />
+            <Button
+                buttonType={ButtonType.SECONDARY}
+                text="Open tall sheet (height cap)"
+                onPress={() => setTallOpen(true)}
+            />
+
+            <BottomSheet
+                open={open}
+                onClose={() => setOpen(false)}
+                accessibilityLabel="Example sheet"
+                testID="showcase-sheet"
+            >
+                <View style={styles.sheetBody}>
+                    <RNText style={styles.title}>Bottom sheet</RNText>
+                    <RNText style={styles.copy}>
+                        Drag down to dismiss, tap the backdrop, or press the
+                        Android back button.
+                    </RNText>
+                    <View style={styles.row}>
+                        <Tag
+                            text="Foundation"
+                            type={TagType.SUBTLE}
+                            color={TagColor.PRIMARY}
+                        />
+                        <Tag
+                            text="Gesture-driven"
+                            type={TagType.SUBTLE}
+                            color={TagColor.SUCCESS}
+                        />
+                    </View>
+                    <Button
+                        buttonType={ButtonType.PRIMARY}
+                        text="Close"
+                        onPress={() => setOpen(false)}
+                    />
+                </View>
+            </BottomSheet>
+
+            <BottomSheet
+                open={tallOpen}
+                onClose={() => setTallOpen(false)}
+                accessibilityLabel="Tall sheet"
+            >
+                <View style={styles.sheetBody}>
+                    <RNText style={styles.title}>Height cap</RNText>
+                    {Array.from({ length: 30 }, (_, i) => (
+                        <RNText key={i} style={styles.copy}>
+                            Row {i + 1} — content beyond the 90% cap should
+                            scroll inside your own ScrollView, not grow the
+                            sheet.
+                        </RNText>
+                    ))}
+                </View>
+            </BottomSheet>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    column: { gap: 12 },
+    sheetBody: { padding: 20, gap: 12 },
+    row: { flexDirection: 'row', gap: 8 },
+    title: { fontSize: 18, fontWeight: '700', color: '#1A1C23' },
+    copy: { fontSize: 14, color: '#4A4F5A' },
+})

--- a/apps/native-site/package.json
+++ b/apps/native-site/package.json
@@ -21,8 +21,12 @@
         "react-device-frameset": "^1.3.4",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
+        "react-native-gesture-handler": "~2.31.1",
+        "react-native-reanimated": "~4.3.1",
+        "react-native-safe-area-context": "~5.7.0",
         "react-native-svg": "15.15.5",
-        "react-native-web": "~0.21.1"
+        "react-native-web": "~0.21.1",
+        "react-native-worklets": "0.8.3"
     },
     "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/packages/blend-native/__tests__/BottomSheet.render.test.tsx
+++ b/packages/blend-native/__tests__/BottomSheet.render.test.tsx
@@ -1,0 +1,116 @@
+import { Text } from 'react-native'
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import { BlendNativeProvider } from '../src/theme/BlendNativeProvider'
+import { BottomSheet } from '../src/overlay/sheet/BottomSheet'
+
+/**
+ * BottomSheet behaviour under the Reanimated jest mock (animations resolve
+ * synchronously) and the Gesture Handler jest mock (gestures inert). What
+ * these prove: mount/unmount around the open prop, backdrop dismissal,
+ * portal layering, and the modal accessibility posture. The gesture physics
+ * are covered by the pure sheetMath suite; the feel is verified on device.
+ */
+
+const renderSheet = (open: boolean, onClose = jest.fn()) => {
+    const ui = (isOpen: boolean) => (
+        <BlendNativeProvider>
+            <Text>app content</Text>
+            <BottomSheet open={isOpen} onClose={onClose} testID="sheet">
+                <Text>sheet content</Text>
+            </BottomSheet>
+        </BlendNativeProvider>
+    )
+    return { ...render(ui(open)), ui, onClose }
+}
+
+describe('BottomSheet', () => {
+    it('renders nothing while closed', () => {
+        renderSheet(false)
+        expect(screen.queryByText('sheet content')).toBeNull()
+        expect(screen.getByText('app content')).toBeTruthy()
+    })
+
+    it('presents its content when open', () => {
+        renderSheet(true)
+        expect(screen.getByText('sheet content')).toBeTruthy()
+        expect(screen.getByTestId('sheet')).toBeTruthy()
+        expect(
+            screen.getByTestId('sheet-backdrop', {
+                includeHiddenElements: true,
+            })
+        ).toBeTruthy()
+    })
+
+    it('unmounts after the exit animation when open flips off', () => {
+        const { rerender, ui } = renderSheet(true)
+        expect(screen.getByText('sheet content')).toBeTruthy()
+        // The Reanimated mock completes the exit animation synchronously.
+        rerender(ui(false))
+        expect(screen.queryByText('sheet content')).toBeNull()
+    })
+
+    it('requests close on backdrop press', () => {
+        const onClose = jest.fn()
+        renderSheet(true, onClose)
+        const backdrop = screen.getByTestId('sheet-backdrop', {
+            includeHiddenElements: true,
+        })
+        // The pressable fills the backdrop layer.
+        fireEvent.press(backdrop.children[0] as never)
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('can disable backdrop dismissal', () => {
+        const onClose = jest.fn()
+        render(
+            <BlendNativeProvider>
+                <BottomSheet
+                    open
+                    onClose={onClose}
+                    dismissOnBackdropPress={false}
+                    testID="sheet"
+                />
+            </BlendNativeProvider>
+        )
+        const backdrop = screen.getByTestId('sheet-backdrop', {
+            includeHiddenElements: true,
+        })
+        fireEvent.press(backdrop.children[0] as never)
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('marks the surface modal for assistive tech', () => {
+        renderSheet(true)
+        expect(screen.getByTestId('sheet').props.accessibilityViewIsModal).toBe(
+            true
+        )
+    })
+
+    it('hides the backdrop from assistive tech', () => {
+        renderSheet(true)
+        const backdrop = screen.getByTestId('sheet-backdrop', {
+            includeHiddenElements: true,
+        })
+        expect(backdrop.props.importantForAccessibility).toBe(
+            'no-hide-descendants'
+        )
+    })
+
+    it('hides the drag handle when asked', () => {
+        render(
+            <BlendNativeProvider>
+                <BottomSheet
+                    open
+                    onClose={jest.fn()}
+                    showHandle={false}
+                    testID="sheet"
+                >
+                    <Text>content</Text>
+                </BottomSheet>
+            </BlendNativeProvider>
+        )
+        const sheet = screen.getByTestId('sheet')
+        // Only the content remains inside the sheet surface.
+        expect(sheet.children).toHaveLength(1)
+    })
+})

--- a/packages/blend-native/__tests__/Portal.render.test.tsx
+++ b/packages/blend-native/__tests__/Portal.render.test.tsx
@@ -86,12 +86,20 @@ describe('Portal', () => {
         expect(screen.queryByText('overlay')).toBeNull()
     })
 
-    it('falls back to inline rendering with no provider', () => {
-        render(
-            <Portal>
-                <Text>inline</Text>
-            </Portal>
-        )
-        expect(screen.getByText('inline')).toBeTruthy()
+    it('falls back to inline rendering with no provider, warning once', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        try {
+            render(
+                <Portal>
+                    <Text>inline</Text>
+                </Portal>
+            )
+            expect(screen.getByText('inline')).toBeTruthy()
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringContaining('without BlendNativeProvider')
+            )
+        } finally {
+            warn.mockRestore()
+        }
     })
 })

--- a/packages/blend-native/__tests__/ThemePolicies.render.test.tsx
+++ b/packages/blend-native/__tests__/ThemePolicies.render.test.tsx
@@ -84,7 +84,7 @@ describe('theme="system"', () => {
     afterEach(() => mockColorScheme.mockReturnValue('light'))
 
     /** A leaf whose value differs between the light and dark factories. */
-    const probeTagBackground = (element: { props: { style: unknown } }) =>
+    const probeTagBackground = (element: { props: { style?: unknown } }) =>
         flatten(element.props.style).backgroundColor
 
     it('resolves dark tokens when the OS is dark', () => {

--- a/packages/blend-native/__tests__/publicApi.test.ts
+++ b/packages/blend-native/__tests__/publicApi.test.ts
@@ -95,6 +95,8 @@ describe('public API surface', () => {
     it('stays small enough to review in one sitting', () => {
         // A guard against drift, not a hard architectural limit — if this
         // trips, decide deliberately whether the additions are public API.
-        expect(exported.size).toBeLessThanOrEqual(30)
+        // Raised from 30 when the overlay foundation (Portal, BottomSheet,
+        // useReduceMotion) became public.
+        expect(exported.size).toBeLessThanOrEqual(36)
     })
 })

--- a/packages/blend-native/__tests__/sheetMath.test.ts
+++ b/packages/blend-native/__tests__/sheetMath.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+    clampSheetDrag,
+    resolveSheetMaxHeight,
+    shouldDismissSheet,
+    SHEET_DISMISS_FRACTION,
+    SHEET_DISMISS_VELOCITY,
+} from '../src/overlay/sheet/sheetMath'
+
+const HEIGHT = 400
+
+describe('clampSheetDrag', () => {
+    it('follows downward drag and pins upward drag', () => {
+        expect(clampSheetDrag(120)).toBe(120)
+        expect(clampSheetDrag(0)).toBe(0)
+        expect(clampSheetDrag(-80)).toBe(0)
+    })
+})
+
+describe('shouldDismissSheet', () => {
+    it('dismisses past the distance threshold', () => {
+        const threshold = HEIGHT * SHEET_DISMISS_FRACTION
+        expect(shouldDismissSheet(threshold, 0, HEIGHT)).toBe(true)
+        expect(shouldDismissSheet(threshold - 1, 0, HEIGHT)).toBe(false)
+    })
+
+    it('dismisses on a downward fling regardless of distance', () => {
+        expect(shouldDismissSheet(10, SHEET_DISMISS_VELOCITY, HEIGHT)).toBe(
+            true
+        )
+        expect(shouldDismissSheet(10, SHEET_DISMISS_VELOCITY - 1, HEIGHT)).toBe(
+            false
+        )
+    })
+
+    it('a downward fling that never moved down does not dismiss', () => {
+        expect(shouldDismissSheet(0, SHEET_DISMISS_VELOCITY, HEIGHT)).toBe(
+            false
+        )
+    })
+
+    it('an upward fling rescues even a past-threshold drag', () => {
+        expect(
+            shouldDismissSheet(HEIGHT * 0.5, -SHEET_DISMISS_VELOCITY, HEIGHT)
+        ).toBe(false)
+    })
+
+    it('an unmeasured sheet never dismisses by distance', () => {
+        expect(shouldDismissSheet(500, 0, 0)).toBe(false)
+    })
+})
+
+describe('resolveSheetMaxHeight', () => {
+    it('caps at the fraction of the window', () => {
+        expect(resolveSheetMaxHeight(800)).toBe(720)
+        expect(resolveSheetMaxHeight(800, 0, 0.5)).toBe(400)
+    })
+
+    it('never intrudes into the top inset', () => {
+        // 95% of 800 is 760, but only 800 - 59 = 741 is below the notch.
+        expect(resolveSheetMaxHeight(800, 59, 0.95)).toBe(741)
+    })
+
+    it('never returns a negative height', () => {
+        expect(resolveSheetMaxHeight(100, 200)).toBe(0)
+    })
+})

--- a/packages/blend-native/jest.config.cjs
+++ b/packages/blend-native/jest.config.cjs
@@ -24,8 +24,14 @@ module.exports = {
     // name is not the first segment after `node_modules/`. The leading
     // `(.*[\\/])?` lets the allowlist match at any depth.
     transformIgnorePatterns: [
-        'node_modules/(?!(.*[\\\\/])?((jest-)?react-native|@react-native([-/][a-z-]+)?|react-native-svg|lucide-react-native)[\\\\/])',
+        'node_modules/(?!(.*[\\\\/])?((jest-)?react-native|@react-native([-/][a-z-]+)?|react-native-svg|react-native-reanimated|react-native-worklets|react-native-gesture-handler|react-native-safe-area-context|lucide-react-native)[\\\\/])',
     ],
+    // Gesture Handler's own jest mock makes GestureDetector render its child
+    // and gestures inert but constructible.
+    setupFiles: ['react-native-gesture-handler/jestSetup.js'],
+    // Worklets' resolver strips `.native` for its own modules so Reanimated's
+    // mock loads the JS fallbacks instead of demanding native init.
+    resolver: 'react-native-worklets/jest/resolver.js',
     moduleNameMapper: {
         // Jest replaces the preset's `moduleNameMapper` wholesale rather than
         // merging, so the preset's own react-native mapping has to be restored
@@ -41,6 +47,10 @@ module.exports = {
         // Optional peer — see the mock's own note.
         '^expo-linear-gradient$':
             '<rootDir>/__tests__/mocks/expo-linear-gradient.tsx',
+        // Reanimated's shipped mock resolves every animation synchronously
+        // (values jump to their target, callbacks fire immediately), so
+        // enter/exit flows assert without timer choreography.
+        '^react-native-reanimated$': 'react-native-reanimated/mock',
         // lucide's `react-native` export condition points at an `.mjs` bundle,
         // which babel-jest does not transform by default. Its CJS build is
         // identical in behaviour, so point Jest straight at it rather than

--- a/packages/blend-native/package.json
+++ b/packages/blend-native/package.json
@@ -44,10 +44,16 @@
         "lucide-react-native": ">=1.0.0",
         "react": ">=18.2.0",
         "react-native": ">=0.74.0",
-        "react-native-svg": ">=12.0.0"
+        "react-native-svg": ">=12.0.0",
+        "react-native-reanimated": ">=3.16.0",
+        "react-native-gesture-handler": ">=2.20.0",
+        "react-native-safe-area-context": ">=4.10.0"
     },
     "peerDependenciesMeta": {
         "expo-linear-gradient": {
+            "optional": true
+        },
+        "react-native-safe-area-context": {
             "optional": true
         }
     },
@@ -69,7 +75,11 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-builder-bob": "^0.43.0",
+        "react-native-gesture-handler": "2.31.1",
+        "react-native-reanimated": "4.3.1",
+        "react-native-safe-area-context": "5.7.0",
         "react-native-svg": "15.15.5",
+        "react-native-worklets": "0.8.3",
         "react-test-renderer": "19.2.3",
         "test-renderer": "^1.2.0",
         "typescript": "~5.8.3",

--- a/packages/blend-native/src/index.ts
+++ b/packages/blend-native/src/index.ts
@@ -94,6 +94,11 @@ export { Portal } from './overlay/portal'
 export type { PortalProps } from './overlay/portal'
 export { useReduceMotion } from './motion/useReduceMotion'
 
+// The gesture-driven sheet foundation — DrawerV2 and the phone modes of
+// Select/Menu/Modal compose it; also public for consumer-built sheets.
+export { BottomSheet } from './overlay/sheet/BottomSheet'
+export type { BottomSheetProps } from './overlay/sheet/BottomSheet'
+
 /** Position of a control within a button or tag group. */
 export type { GroupPosition } from './components/shared/group'
 

--- a/packages/blend-native/src/overlay/portal.tsx
+++ b/packages/blend-native/src/overlay/portal.tsx
@@ -53,16 +53,21 @@ export function Portal({ children }: PortalProps) {
         return () => registry.unmount(key)
     }, [registry, key, children])
 
-    if (!registry) {
-        if (!warnedNoProvider && typeof __DEV__ !== 'undefined' && __DEV__) {
+    // In an effect, not during render — warning inline would be a
+    // render-phase side effect (breaks under StrictMode double-render, the
+    // same class of bug Pressable's parse memoisation fixed).
+    useEffect(() => {
+        if (registry || warnedNoProvider) return
+        if (typeof __DEV__ !== 'undefined' && __DEV__) {
             warnedNoProvider = true
             console.warn(
                 '[blend-native] <Portal> used without BlendNativeProvider — ' +
                     'rendering inline. Overlays will not layer above the app.'
             )
         }
-        return <>{children}</>
-    }
+    }, [registry])
+
+    if (!registry) return <>{children}</>
 
     return null
 }

--- a/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
+++ b/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
@@ -1,0 +1,303 @@
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useState,
+} from 'react'
+import {
+    BackHandler,
+    Pressable,
+    StyleSheet,
+    useWindowDimensions,
+    View,
+    type LayoutChangeEvent,
+    type ViewStyle,
+} from 'react-native'
+import Animated, {
+    Easing,
+    runOnJS,
+    useAnimatedStyle,
+    useSharedValue,
+    withSpring,
+    withTiming,
+} from 'react-native-reanimated'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import { Portal } from '../portal'
+import { MOTION_DURATION, MOTION_EASING } from '../../motion/motion'
+import { useReduceMotion } from '../../motion/useReduceMotion'
+import {
+    clampSheetDrag,
+    resolveSheetMaxHeight,
+    shouldDismissSheet,
+    SHEET_MAX_HEIGHT_FRACTION,
+} from './sheetMath'
+
+/**
+ * BottomSheet — the gesture-driven sheet foundation.
+ *
+ * The native replacement for `vaul` and the phone presentation web already
+ * prescribes in its Mobile* variants (mobileModalV2, MobileSingleSelectV2,
+ * MobilePopoverV2): DrawerV2 and the phone modes of Select/Menu/Modal
+ * compose this primitive and pass their token values in — the sheet itself
+ * carries structure and physics, not design decisions, which is why its
+ * colour props have plain defaults instead of token lookups.
+ *
+ * Controlled: `open` drives it; every dismiss route (drag, backdrop, the
+ * Android back button) calls `onClose` and the owner flips `open` — the
+ * exit animation runs, then the sheet unmounts from the portal layer.
+ *
+ * Requirements: `react-native-reanimated` and `react-native-gesture-handler`
+ * (required peers), and a `GestureHandlerRootView` at the app root — apps
+ * using react-navigation already have one. `react-native-safe-area-context`
+ * is optional: with it (and its provider) mounted, the sheet pads itself
+ * past the home indicator; without it the bottom inset is 0.
+ *
+ * Reduce-motion: the slide collapses to a fade (`useReduceMotion`).
+ */
+
+export type BottomSheetProps = {
+    /** Whether the sheet is presented. */
+    open: boolean
+    /** Called whenever the sheet asks to close; the owner flips `open`. */
+    onClose: () => void
+    children?: React.ReactNode
+    /** Cap on sheet height as a fraction of the window. Default 0.9. */
+    maxHeightFraction?: number
+    /** Backdrop fill. Defaults to 50% black. */
+    backdropColor?: string
+    /** Sheet surface colour. Component layers pass their token value. */
+    backgroundColor?: string
+    /** Radius of the two top corners. */
+    topRadius?: number
+    /** Show the drag handle. Default true. */
+    showHandle?: boolean
+    handleColor?: string
+    /** Allow drag-down to dismiss. Default true. */
+    dragToDismiss?: boolean
+    /** Dismiss when the backdrop is pressed. Default true. */
+    dismissOnBackdropPress?: boolean
+    accessibilityLabel?: string
+    testID?: string
+    /** Style escape hatch for the sheet surface. */
+    style?: ViewStyle
+}
+
+// ---- Optional safe-area integration -------------------------------------
+// `useContext` needs *a* context unconditionally, so when the optional peer
+// is absent (or its provider is not mounted) a null-valued fallback stands
+// in. Same probe pattern as expo-linear-gradient in `Pressable`.
+type EdgeInsets = { top: number; bottom: number; left: number; right: number }
+const FallbackInsetsContext = createContext<EdgeInsets | null>(null)
+
+let SafeAreaInsetsContext: React.Context<EdgeInsets | null> =
+    FallbackInsetsContext
+try {
+    if (typeof require === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const safeArea = require('react-native-safe-area-context') as {
+            SafeAreaInsetsContext?: React.Context<EdgeInsets | null>
+        }
+        SafeAreaInsetsContext =
+            safeArea.SafeAreaInsetsContext ?? FallbackInsetsContext
+    }
+} catch {
+    SafeAreaInsetsContext = FallbackInsetsContext
+}
+
+const ENTER = {
+    duration: MOTION_DURATION.slow,
+    easing: Easing.bezier(...MOTION_EASING.decelerate),
+}
+const EXIT = {
+    duration: MOTION_DURATION.normal,
+    easing: Easing.bezier(...MOTION_EASING.accelerate),
+}
+
+export function BottomSheet({
+    open,
+    onClose,
+    children,
+    maxHeightFraction = SHEET_MAX_HEIGHT_FRACTION,
+    backdropColor = 'rgba(0, 0, 0, 0.5)',
+    backgroundColor = '#FFFFFF',
+    topRadius = 16,
+    showHandle = true,
+    handleColor = 'rgba(0, 0, 0, 0.2)',
+    dragToDismiss = true,
+    dismissOnBackdropPress = true,
+    accessibilityLabel,
+    testID,
+    style,
+}: BottomSheetProps) {
+    // Mounted outlives `open` by one exit animation.
+    const [mounted, setMounted] = useState(open)
+    const progress = useSharedValue(0)
+    const dragY = useSharedValue(0)
+    const sheetHeight = useSharedValue(0)
+    const window = useWindowDimensions()
+    const insets = useContext(SafeAreaInsetsContext)
+    const reduceMotion = useReduceMotion()
+
+    const unmount = useCallback(() => setMounted(false), [])
+
+    useEffect(() => {
+        if (open) {
+            setMounted(true)
+            progress.value = withTiming(1, ENTER)
+        } else {
+            // Drag offset folds into the exit so a gesture-dismissed sheet
+            // continues downward from wherever the finger left it.
+            dragY.value = withTiming(0, EXIT)
+            progress.value = withTiming(0, EXIT, (finished) => {
+                if (finished) runOnJS(unmount)()
+            })
+        }
+    }, [open, progress, dragY, unmount])
+
+    // Android hardware back closes the sheet instead of the screen.
+    useEffect(() => {
+        if (!open) return
+        const subscription = BackHandler.addEventListener(
+            'hardwareBackPress',
+            () => {
+                onClose()
+                return true
+            }
+        )
+        return () => subscription.remove()
+    }, [open, onClose])
+
+    const onSheetLayout = useCallback(
+        (event: LayoutChangeEvent) => {
+            sheetHeight.value = event.nativeEvent.layout.height
+        },
+        [sheetHeight]
+    )
+
+    const pan = Gesture.Pan()
+        .enabled(dragToDismiss)
+        .onChange((event) => {
+            dragY.value = clampSheetDrag(event.translationY)
+        })
+        .onEnd((event) => {
+            if (
+                shouldDismissSheet(
+                    event.translationY,
+                    event.velocityY,
+                    sheetHeight.value
+                )
+            ) {
+                runOnJS(onClose)()
+            } else {
+                dragY.value = withSpring(0, { damping: 22, stiffness: 320 })
+            }
+        })
+
+    const windowHeight = window.height
+    const sheetStyle = useAnimatedStyle(() => {
+        if (reduceMotion) {
+            return {
+                opacity: progress.value,
+                transform: [{ translateY: dragY.value }],
+            }
+        }
+        // Until the first layout lands, the full window height keeps the
+        // sheet parked off-screen instead of flashing in place.
+        const height = sheetHeight.value || windowHeight
+        return {
+            opacity: 1,
+            transform: [
+                { translateY: (1 - progress.value) * height + dragY.value },
+            ],
+        }
+    }, [reduceMotion, windowHeight])
+
+    const backdropStyle = useAnimatedStyle(() => ({
+        opacity: progress.value,
+    }))
+
+    if (!mounted) return null
+
+    const maxHeight = resolveSheetMaxHeight(
+        windowHeight,
+        insets?.top ?? 0,
+        maxHeightFraction
+    )
+
+    return (
+        <Portal>
+            <Animated.View
+                style={[
+                    StyleSheet.absoluteFill,
+                    { backgroundColor: backdropColor },
+                    backdropStyle,
+                ]}
+                testID={testID ? `${testID}-backdrop` : undefined}
+                // The sheet is the modal surface; VoiceOver skips the
+                // backdrop (it could not reach it past
+                // accessibilityViewIsModal anyway).
+                accessible={false}
+                importantForAccessibility="no-hide-descendants"
+            >
+                <Pressable
+                    style={StyleSheet.absoluteFill}
+                    onPress={dismissOnBackdropPress ? onClose : undefined}
+                />
+            </Animated.View>
+
+            <GestureDetector gesture={pan}>
+                <Animated.View
+                    onLayout={onSheetLayout}
+                    accessibilityViewIsModal
+                    accessibilityLabel={accessibilityLabel}
+                    testID={testID}
+                    style={[
+                        styles.sheet,
+                        {
+                            maxHeight,
+                            backgroundColor,
+                            borderTopLeftRadius: topRadius,
+                            borderTopRightRadius: topRadius,
+                            paddingBottom: insets?.bottom ?? 0,
+                        },
+                        sheetStyle,
+                        style,
+                    ]}
+                >
+                    {showHandle ? (
+                        <View
+                            style={[
+                                styles.handle,
+                                { backgroundColor: handleColor },
+                            ]}
+                        />
+                    ) : null}
+                    {children}
+                </Animated.View>
+            </GestureDetector>
+        </Portal>
+    )
+}
+
+BottomSheet.displayName = 'BottomSheet'
+
+const styles = StyleSheet.create({
+    sheet: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        overflow: 'hidden',
+    },
+    handle: {
+        alignSelf: 'center',
+        width: 36,
+        height: 4,
+        borderRadius: 2,
+        marginTop: 8,
+        marginBottom: 4,
+    },
+})
+
+export default BottomSheet

--- a/packages/blend-native/src/overlay/sheet/sheetMath.ts
+++ b/packages/blend-native/src/overlay/sheet/sheetMath.ts
@@ -1,0 +1,58 @@
+/**
+ * Bottom-sheet gesture arithmetic.
+ *
+ * Pure and RN-free (the `theme/breakpoint.ts` pattern) so the dismiss
+ * decision — the part of a sheet that feels wrong when it is wrong — is
+ * unit-testable under vitest. `BottomSheet` wires these into the pan
+ * gesture; they also run as Reanimated worklets, so nothing here may close
+ * over module state.
+ */
+
+/** Dragging past this fraction of the sheet's height dismisses on release. */
+export const SHEET_DISMISS_FRACTION = 0.25
+
+/** A downward fling at or above this velocity (pt/s) dismisses regardless. */
+export const SHEET_DISMISS_VELOCITY = 800
+
+/** Default cap: a sheet covers at most this fraction of the window. */
+export const SHEET_MAX_HEIGHT_FRACTION = 0.9
+
+/**
+ * The sheet follows the finger downward only — upward drag is pinned so the
+ * sheet feels anchored rather than lifting off its resting position.
+ */
+export function clampSheetDrag(translationY: number): number {
+    'worklet'
+    return Math.max(0, translationY)
+}
+
+/**
+ * Whether a released drag should dismiss the sheet: past the distance
+ * threshold, or a genuine downward fling. An upward fling never dismisses,
+ * whatever distance was covered first.
+ */
+export function shouldDismissSheet(
+    translationY: number,
+    velocityY: number,
+    sheetHeight: number
+): boolean {
+    'worklet'
+    if (velocityY <= -SHEET_DISMISS_VELOCITY) return false
+    if (velocityY >= SHEET_DISMISS_VELOCITY) return translationY > 0
+    return (
+        sheetHeight > 0 && translationY >= sheetHeight * SHEET_DISMISS_FRACTION
+    )
+}
+
+/**
+ * The tallest a sheet may grow: the capped fraction of the window, minus
+ * whatever top inset (status bar / notch) must stay visible above it.
+ */
+export function resolveSheetMaxHeight(
+    windowHeight: number,
+    topInset: number = 0,
+    maxHeightFraction: number = SHEET_MAX_HEIGHT_FRACTION
+): number {
+    const capped = windowHeight * maxHeightFraction
+    return Math.max(0, Math.min(capped, windowHeight - topInset))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,10 +109,10 @@ importers:
                 version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
             '@react-three/fiber':
                 specifier: ^9.5.0
-                version: 9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)
+                version: 9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)
             '@react-three/postprocessing':
                 specifier: ^3.0.4
-                version: 3.0.4(@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0))(@types/three@0.182.0)(react@19.2.3)(three@0.182.0)
+                version: 3.0.4(@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0))(@types/three@0.182.0)(react@19.2.3)(three@0.182.0)
             '@types/mdx':
                 specifier: ^2.0.13
                 version: 2.0.13
@@ -369,7 +369,7 @@ importers:
                 version: 5.1.1(firebase@11.10.0)(react@19.2.3)
             styled-components:
                 specifier: ^6.1.17
-                version: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+                version: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             zod:
                 specifier: ^3.25.76
                 version: 3.25.76
@@ -436,7 +436,7 @@ importers:
         dependencies:
             '@expo/metro-runtime':
                 specifier: ~56.0.20
-                version: 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@juspay/blend-design-system':
                 specifier: workspace:*
                 version: link:../../packages/blend
@@ -445,13 +445,13 @@ importers:
                 version: link:../../packages/blend-native
             expo:
                 specifier: ~56.0.12
-                version: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+                version: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             expo-linear-gradient:
                 specifier: ~56.0.4
-                version: 56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             lucide-react-native:
                 specifier: ^1.33.0
-                version: 1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react:
                 specifier: 19.2.3
                 version: 19.2.3
@@ -463,13 +463,25 @@ importers:
                 version: 19.2.3(react@19.2.3)
             react-native:
                 specifier: 0.85.3
-                version: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+                version: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            react-native-gesture-handler:
+                specifier: ~2.31.1
+                version: 2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-reanimated:
+                specifier: ~4.3.1
+                version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-safe-area-context:
+                specifier: ~5.7.0
+                version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-native-svg:
                 specifier: 15.15.5
-                version: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-native-web:
                 specifier: ~0.21.1
                 version: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+            react-native-worklets:
+                specifier: 0.8.3
+                version: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
         devDependencies:
             '@babel/core':
                 specifier: ^7.29.0
@@ -643,7 +655,7 @@ importers:
                 version: 19.2.3(react@19.2.3)
             styled-components:
                 specifier: ^6.4.0
-                version: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+                version: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
         devDependencies:
             '@types/react':
                 specifier: ^19.1.2
@@ -882,7 +894,7 @@ importers:
                 version: 0.85.3(@babel/core@7.29.7)(react@19.2.3)
             '@testing-library/react-native':
                 specifier: ^13.3.3
-                version: 13.3.3(jest@29.7.0(@types/node@22.19.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
+                version: 13.3.3(jest@29.7.0(@types/node@22.19.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
             '@types/jest':
                 specifier: ^30.0.0
                 version: 30.0.0
@@ -906,25 +918,37 @@ importers:
                 version: 5.2.0(eslint@9.39.2(jiti@2.7.0))
             expo-linear-gradient:
                 specifier: ~15.0.3
-                version: 15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             jest:
                 specifier: ^29.7.0
                 version: 29.7.0(@types/node@22.19.3)
             lucide-react-native:
                 specifier: ^1.33.0
-                version: 1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react:
                 specifier: 19.2.3
                 version: 19.2.3
             react-native:
                 specifier: 0.85.3
-                version: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+                version: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             react-native-builder-bob:
                 specifier: ^0.43.0
                 version: 0.43.0
+            react-native-gesture-handler:
+                specifier: 2.31.1
+                version: 2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-reanimated:
+                specifier: 4.3.1
+                version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-safe-area-context:
+                specifier: 5.7.0
+                version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-native-svg:
                 specifier: 15.15.5
-                version: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+                version: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-worklets:
+                specifier: 0.8.3
+                version: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-test-renderer:
                 specifier: 19.2.3
                 version: 19.2.3(react@19.2.3)
@@ -2772,6 +2796,13 @@ packages:
             }
         peerDependencies:
             react: '>=16.8.0'
+
+    '@egjs/hammerjs@2.0.17':
+        resolution:
+            {
+                integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==,
+            }
+        engines: { node: '>=0.8.0' }
 
     '@electric-sql/pglite-socket@0.1.1':
         resolution:
@@ -6480,6 +6511,15 @@ packages:
             }
         engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
+    '@react-native/babel-preset@0.85.3':
+        resolution:
+            {
+                integrity: sha512-fD7fxEhkJB/aF57tWoXjaAWpklfrExYZS3k6aXPP3BQ77DZY7gvf/b7dbirwjID6NVnP1JDRJyTuPBGr0K/vlw==,
+            }
+        engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+        peerDependencies:
+            '@babel/core': '*'
+
     '@react-native/codegen@0.85.3':
         resolution:
             {
@@ -6545,6 +6585,22 @@ packages:
         resolution:
             {
                 integrity: sha512-U2+aMshIXf1uFn77tpBb/xhHWB9vkVrMpt7kkucAugF8hJKYTDGB587X7WwelHduK2KBfhl4giSv0rzZGoef9A==,
+            }
+        engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
+    '@react-native/metro-babel-transformer@0.85.3':
+        resolution:
+            {
+                integrity: sha512-omuKq+r7jM4XvCMIlNMPP7Up3SyB8o5EAdZtF7YXniKyq7UOMBqhYHFqgsdOXr0lT+3ADf7VCJG3sb82jlBrrQ==,
+            }
+        engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+        peerDependencies:
+            '@babel/core': '*'
+
+    '@react-native/metro-config@0.85.3':
+        resolution:
+            {
+                integrity: sha512-sVo6HepUmCcpdfozEf91lA0FjpLNNZYu/Zi9FiYiAQTK8pzATXDVTqhvdxpFrQn435p5eUTSbllvbH/KN+bnyA==,
             }
         engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
@@ -8082,6 +8138,12 @@ packages:
                 integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==,
             }
 
+    '@types/hammerjs@2.0.46':
+        resolution:
+            {
+                integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==,
+            }
+
     '@types/hast@3.0.4':
         resolution:
             {
@@ -8263,6 +8325,12 @@ packages:
             }
         peerDependencies:
             '@types/react': '*'
+
+    '@types/react-test-renderer@19.1.0':
+        resolution:
+            {
+                integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==,
+            }
 
     '@types/react@19.1.17':
         resolution:
@@ -17617,6 +17685,43 @@ packages:
         engines: { node: ^20.19.0 || ^22.12.0 || >= 23.4.0 }
         hasBin: true
 
+    react-native-gesture-handler@2.31.1:
+        resolution:
+            {
+                integrity: sha512-wQDlECdEzHhYKTnQXFnSqWUtJ5TS3MGQi7EWvQczTnEVKfk6XVSBecnpWAoI/CqlYQ7IWMJEyutY6BxwEBoxeg==,
+            }
+        peerDependencies:
+            react: '*'
+            react-native: '*'
+
+    react-native-is-edge-to-edge@1.3.1:
+        resolution:
+            {
+                integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==,
+            }
+        peerDependencies:
+            react: '*'
+            react-native: '*'
+
+    react-native-reanimated@4.3.1:
+        resolution:
+            {
+                integrity: sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q==,
+            }
+        peerDependencies:
+            react: '*'
+            react-native: 0.81 - 0.85
+            react-native-worklets: 0.8.x
+
+    react-native-safe-area-context@5.7.0:
+        resolution:
+            {
+                integrity: sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==,
+            }
+        peerDependencies:
+            react: '*'
+            react-native: '*'
+
     react-native-svg@15.15.5:
         resolution:
             {
@@ -17634,6 +17739,17 @@ packages:
         peerDependencies:
             react: ^18.0.0 || ^19.0.0
             react-dom: ^18.0.0 || ^19.0.0
+
+    react-native-worklets@0.8.3:
+        resolution:
+            {
+                integrity: sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==,
+            }
+        peerDependencies:
+            '@babel/core': '*'
+            '@react-native/metro-config': '*'
+            react: '*'
+            react-native: 0.81 - 0.85
 
     react-native@0.85.3:
         resolution:
@@ -21764,9 +21880,19 @@ snapshots:
             '@babel/core': 7.28.5
             '@babel/helper-plugin-utils': 7.27.1
 
+    '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
+        dependencies:
+            '@babel/core': 7.29.7
+            '@babel/helper-plugin-utils': 7.27.1
+
     '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
         dependencies:
             '@babel/core': 7.28.5
+            '@babel/helper-plugin-utils': 7.27.1
+
+    '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
+        dependencies:
+            '@babel/core': 7.29.7
             '@babel/helper-plugin-utils': 7.27.1
 
     '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
@@ -22375,6 +22501,10 @@ snapshots:
             react: 19.2.3
             tslib: 2.8.1
 
+    '@egjs/hammerjs@2.0.17':
+        dependencies:
+            '@types/hammerjs': 2.0.46
+
     '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
         dependencies:
             '@electric-sql/pglite': 0.4.1
@@ -22622,7 +22752,7 @@ snapshots:
             '@eslint/core': 0.17.0
             levn: 0.4.1
 
-    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)':
+    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)':
         dependencies:
             '@expo/code-signing-certificates': 0.0.6
             '@expo/config': 56.0.13(typescript@5.8.3)
@@ -22632,7 +22762,7 @@ snapshots:
             '@expo/image-utils': 0.10.4(typescript@5.8.3)
             '@expo/inline-modules': 0.0.15(typescript@5.8.3)
             '@expo/json-file': 10.2.0
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@5.8.3)
             '@expo/metro-file-map': 56.0.3
@@ -22641,7 +22771,7 @@ snapshots:
             '@expo/plist': 0.7.0
             '@expo/prebuild-config': 56.0.22(typescript@5.8.3)
             '@expo/require-utils': 56.1.6(typescript@5.8.3)
-            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
             '@expo/schema-utils': 56.0.2
             '@expo/spawn-async': 1.8.0
             '@expo/ws-tunnel': 2.0.0(ws@8.18.3)
@@ -22658,7 +22788,7 @@ snapshots:
             connect: 3.7.0
             debug: 4.4.3
             dnssd-advertise: 1.1.6
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             expo-server: 56.0.6
             fetch-nodeshim: 0.4.10
             getenv: 2.0.0
@@ -22685,7 +22815,7 @@ snapshots:
             ws: 8.18.3
             zod: 3.25.76
         optionalDependencies:
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         transitivePeerDependencies:
             - '@expo/dom-webview'
             - '@expo/metro-runtime'
@@ -22699,7 +22829,7 @@ snapshots:
             - typescript
             - utf-8-validate
 
-    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
         dependencies:
             '@expo/code-signing-certificates': 0.0.6
             '@expo/config': 56.0.13(typescript@6.0.3)
@@ -22709,7 +22839,7 @@ snapshots:
             '@expo/image-utils': 0.10.4(typescript@6.0.3)
             '@expo/inline-modules': 0.0.15(typescript@6.0.3)
             '@expo/json-file': 10.2.0
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@6.0.3)
             '@expo/metro-file-map': 56.0.3
@@ -22718,7 +22848,7 @@ snapshots:
             '@expo/plist': 0.7.0
             '@expo/prebuild-config': 56.0.22(typescript@6.0.3)
             '@expo/require-utils': 56.1.6(typescript@6.0.3)
-            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
             '@expo/schema-utils': 56.0.2
             '@expo/spawn-async': 1.8.0
             '@expo/ws-tunnel': 2.0.0(ws@8.18.3)
@@ -22735,7 +22865,7 @@ snapshots:
             connect: 3.7.0
             debug: 4.4.3
             dnssd-advertise: 1.1.6
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             expo-server: 56.0.6
             fetch-nodeshim: 0.4.10
             getenv: 2.0.0
@@ -22762,7 +22892,7 @@ snapshots:
             ws: 8.18.3
             zod: 3.25.76
         optionalDependencies:
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         transitivePeerDependencies:
             - '@expo/dom-webview'
             - '@expo/metro-runtime'
@@ -22776,7 +22906,7 @@ snapshots:
             - typescript
             - utf-8-validate
 
-    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)':
+    '@expo/cli@56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)':
         dependencies:
             '@expo/code-signing-certificates': 0.0.6
             '@expo/config': 56.0.13(typescript@5.8.3)
@@ -22786,7 +22916,7 @@ snapshots:
             '@expo/image-utils': 0.10.4(typescript@5.8.3)
             '@expo/inline-modules': 0.0.15(typescript@5.8.3)
             '@expo/json-file': 10.2.0
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@5.8.3)
             '@expo/metro-file-map': 56.0.3
@@ -22795,7 +22925,7 @@ snapshots:
             '@expo/plist': 0.7.0
             '@expo/prebuild-config': 56.0.22(typescript@5.8.3)
             '@expo/require-utils': 56.1.6(typescript@5.8.3)
-            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+            '@expo/router-server': 56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
             '@expo/schema-utils': 56.0.2
             '@expo/spawn-async': 1.8.0
             '@expo/ws-tunnel': 2.0.0(ws@8.18.3)
@@ -22812,7 +22942,7 @@ snapshots:
             connect: 3.7.0
             debug: 4.4.3
             dnssd-advertise: 1.1.6
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             expo-server: 56.0.6
             fetch-nodeshim: 0.4.10
             getenv: 2.0.0
@@ -22839,7 +22969,7 @@ snapshots:
             ws: 8.18.3
             zod: 3.25.76
         optionalDependencies:
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - '@expo/dom-webview'
             - '@expo/metro-runtime'
@@ -22937,32 +23067,32 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
+    '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
             chalk: 4.1.2
         optionalDependencies:
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
+    '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
         dependencies:
             chalk: 4.1.2
         optionalDependencies:
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optional: true
 
-    '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
+    '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
+    '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optional: true
 
     '@expo/env@2.3.1':
@@ -23065,22 +23195,22 @@ snapshots:
             - supports-color
             - typescript
 
-    '@expo/log-box@56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
+    '@expo/log-box@56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             anser: 1.4.10
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             stacktrace-parser: 0.1.11
 
-    '@expo/log-box@56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
+    '@expo/log-box@56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             anser: 1.4.10
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
             stacktrace-parser: 0.1.11
         optional: true
 
@@ -23110,7 +23240,7 @@ snapshots:
             postcss: 8.5.15
             resolve-from: 5.0.0
         optionalDependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
         transitivePeerDependencies:
             - bufferutil
             - supports-color
@@ -23143,7 +23273,7 @@ snapshots:
             postcss: 8.5.15
             resolve-from: 5.0.0
         optionalDependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
         transitivePeerDependencies:
             - bufferutil
             - supports-color
@@ -23161,27 +23291,27 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@expo/metro-runtime@56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
+    '@expo/metro-runtime@56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             anser: 1.4.10
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             pretty-format: 29.7.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             stacktrace-parser: 0.1.11
             whatwg-fetch: 3.6.20
         optionalDependencies:
             react-dom: 19.2.3(react@19.2.3)
 
-    '@expo/metro-runtime@56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
+    '@expo/metro-runtime@56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
         dependencies:
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             anser: 1.4.10
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             pretty-format: 29.7.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
             stacktrace-parser: 0.1.11
             whatwg-fetch: 3.6.20
         optionalDependencies:
@@ -23280,30 +23410,30 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@expo/router-server@56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    '@expo/router-server@56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
         dependencies:
             debug: 4.4.3
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
-            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
+            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             expo-server: 56.0.6
             react: 19.2.3
         optionalDependencies:
-            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-dom: 19.2.3(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
 
-    '@expo/router-server@56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    '@expo/router-server@56.0.18(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo-server@56.0.6)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
         dependencies:
             debug: 4.4.3
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
-            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
+            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             expo-server: 56.0.6
             react: 19.2.3
         optionalDependencies:
-            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             react-dom: 19.2.3(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
@@ -25686,6 +25816,44 @@ snapshots:
             - '@babel/core'
             - supports-color
 
+    '@react-native/babel-preset@0.85.3(@babel/core@7.29.7)':
+        dependencies:
+            '@babel/core': 7.29.7
+            '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+            '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+            '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+            '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+            '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
+            '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7)
+            '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+            '@react-native/babel-plugin-codegen': 0.85.3(@babel/core@7.29.7)
+            babel-plugin-syntax-hermes-parser: 0.33.3
+            babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+            react-refresh: 0.14.2
+        transitivePeerDependencies:
+            - supports-color
+
     '@react-native/codegen@0.85.3(@babel/core@7.29.7)':
         dependencies:
             '@babel/core': 7.29.7
@@ -25696,7 +25864,7 @@ snapshots:
             tinyglobby: 0.2.15
             yargs: 17.7.2
 
-    '@react-native/community-cli-plugin@0.85.3':
+    '@react-native/community-cli-plugin@0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7))':
         dependencies:
             '@react-native/dev-middleware': 0.85.3
             debug: 4.4.3
@@ -25705,6 +25873,8 @@ snapshots:
             metro-config: 0.84.5
             metro-core: 0.84.5
             semver: 7.7.3
+        optionalDependencies:
+            '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
         transitivePeerDependencies:
             - bufferutil
             - supports-color
@@ -25755,30 +25925,51 @@ snapshots:
 
     '@react-native/js-polyfills@0.85.3': {}
 
+    '@react-native/metro-babel-transformer@0.85.3(@babel/core@7.29.7)':
+        dependencies:
+            '@babel/core': 7.29.7
+            '@react-native/babel-preset': 0.85.3(@babel/core@7.29.7)
+            hermes-parser: 0.33.3
+            nullthrows: 1.1.1
+        transitivePeerDependencies:
+            - supports-color
+
+    '@react-native/metro-config@0.85.3(@babel/core@7.29.7)':
+        dependencies:
+            '@react-native/js-polyfills': 0.85.3
+            '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
+            metro-config: 0.84.5
+            metro-runtime: 0.84.5
+        transitivePeerDependencies:
+            - '@babel/core'
+            - bufferutil
+            - supports-color
+            - utf-8-validate
+
     '@react-native/normalize-colors@0.74.89': {}
 
     '@react-native/normalize-colors@0.85.3': {}
 
-    '@react-native/virtualized-lists@0.85.3(@types/react@19.1.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
+    '@react-native/virtualized-lists@0.85.3(@types/react@19.1.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
             invariant: 2.2.4
             nullthrows: 1.1.1
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         optionalDependencies:
             '@types/react': 19.1.17
 
-    '@react-native/virtualized-lists@0.85.3(@types/react@19.2.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
+    '@react-native/virtualized-lists@0.85.3(@types/react@19.2.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
         dependencies:
             invariant: 2.2.4
             nullthrows: 1.1.1
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optionalDependencies:
             '@types/react': 19.2.7
         optional: true
 
-    '@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)':
+    '@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)':
         dependencies:
             '@babel/runtime': 7.28.4
             '@types/webxr': 0.5.24
@@ -25793,18 +25984,18 @@ snapshots:
             use-sync-external-store: 1.6.0(react@19.2.3)
             zustand: 5.0.11(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
         optionalDependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
             react-dom: 19.2.3(react@19.2.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - '@types/react'
             - immer
 
-    '@react-three/postprocessing@3.0.4(@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0))(@types/three@0.182.0)(react@19.2.3)(three@0.182.0)':
+    '@react-three/postprocessing@3.0.4(@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0))(@types/three@0.182.0)(react@19.2.3)(three@0.182.0)':
         dependencies:
-            '@react-three/fiber': 9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)
+            '@react-three/fiber': 9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)
             maath: 0.6.0(@types/three@0.182.0)(three@0.182.0)
             n8ao: 1.10.1(postprocessing@6.38.2(three@0.182.0))(three@0.182.0)
             postprocessing: 6.38.2(three@0.182.0)
@@ -26895,13 +27086,13 @@ snapshots:
             picocolors: 1.1.1
             redent: 3.0.0
 
-    '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)':
+    '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)':
         dependencies:
             jest-matcher-utils: 30.4.1
             picocolors: 1.1.1
             pretty-format: 30.4.1
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             react-test-renderer: 19.2.3(react@19.2.3)
             redent: 3.0.0
         optionalDependencies:
@@ -27083,6 +27274,8 @@ snapshots:
         dependencies:
             '@types/node': 22.19.3
 
+    '@types/hammerjs@2.0.46': {}
+
     '@types/hast@3.0.4':
         dependencies:
             '@types/unist': 3.0.3
@@ -27180,6 +27373,10 @@ snapshots:
             '@types/react': 19.2.7
 
     '@types/react-reconciler@0.33.0(@types/react@19.1.17)':
+        dependencies:
+            '@types/react': 19.1.17
+
+    '@types/react-test-renderer@19.1.0':
         dependencies:
             '@types/react': 19.1.17
 
@@ -27283,10 +27480,10 @@ snapshots:
         dependencies:
             '@types/yargs-parser': 21.0.3
 
-    '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
+    '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)':
         dependencies:
             '@eslint-community/regexpp': 4.12.2
-            '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+            '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
             '@typescript-eslint/scope-manager': 8.50.0
             '@typescript-eslint/type-utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
             '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
@@ -27687,7 +27884,7 @@ snapshots:
             sirv: 3.0.2
             tinyglobby: 0.2.15
             tinyrainbow: 2.0.0
-            vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.50.0)(tsx@4.21.0)(yaml@2.8.2)
+            vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.27)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.50.0)(tsx@4.21.0)(yaml@2.8.2)
 
     '@vitest/utils@2.0.5':
         dependencies:
@@ -28254,7 +28451,7 @@ snapshots:
             react-refresh: 0.14.2
         optionalDependencies:
             '@babel/runtime': 7.28.4
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
         transitivePeerDependencies:
             - '@babel/core'
             - supports-color
@@ -29765,99 +29962,99 @@ snapshots:
             jest-mock: 30.4.1
             jest-util: 30.4.1
 
-    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
+    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
         dependencies:
             '@expo/image-utils': 0.10.4(typescript@5.8.3)
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
             - typescript
 
-    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
         dependencies:
             '@expo/image-utils': 0.10.4(typescript@6.0.3)
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
             - typescript
 
-    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
+    expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
         dependencies:
             '@expo/image-utils': 0.10.4(typescript@5.8.3)
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
             - typescript
         optional: true
 
-    expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)):
+    expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
             '@expo/env': 2.3.1
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
 
-    expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)):
+    expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)):
         dependencies:
             '@expo/env': 2.3.1
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
         optional: true
 
-    expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)):
+    expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)):
+    expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optional: true
 
-    expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             fontfaceobserver: 2.3.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+    expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             fontfaceobserver: 2.3.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optional: true
 
     expo-keep-awake@56.0.3(expo@56.0.20)(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             react: 19.2.3
 
-    expo-linear-gradient@15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    expo-linear-gradient@15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    expo-linear-gradient@56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    expo-linear-gradient@56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
     expo-modules-autolinking@56.0.22(typescript@5.8.3):
         dependencies:
@@ -29879,63 +30076,67 @@ snapshots:
             - supports-color
             - typescript
 
-    expo-modules-core@56.0.24(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    expo-modules-core@56.0.24(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
             '@expo/expo-modules-macros-plugin': 0.2.2
-            expo-modules-jsi: 56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
+            expo-modules-jsi: 56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
             invariant: 2.2.4
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+        optionalDependencies:
+            react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
 
-    expo-modules-core@56.0.24(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+    expo-modules-core@56.0.24(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
         dependencies:
             '@expo/expo-modules-macros-plugin': 0.2.2
-            expo-modules-jsi: 56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
+            expo-modules-jsi: 56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
             invariant: 2.2.4
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optionalDependencies:
+            react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
         optional: true
 
-    expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)):
+    expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
-    expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)):
+    expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)):
         dependencies:
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optional: true
 
     expo-server@56.0.6: {}
 
-    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
+    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
         dependencies:
             '@babel/runtime': 7.28.4
-            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             '@expo/config': 56.0.13(typescript@5.8.3)
             '@expo/config-plugins': 56.0.15(typescript@5.8.3)
-            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/fingerprint': 0.19.9
             '@expo/local-build-cache-provider': 56.0.11(typescript@5.8.3)
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@5.8.3)
             '@ungap/structured-clone': 1.3.0
             babel-preset-expo: 56.0.19(@babel/core@7.29.7)(@babel/runtime@7.28.4)(expo@56.0.20)(react-refresh@0.14.2)
-            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
-            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
-            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
+            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
+            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             expo-keep-awake: 56.0.3(expo@56.0.20)(react@19.2.3)
             expo-modules-autolinking: 56.0.22(typescript@5.8.3)
-            expo-modules-core: 56.0.24(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            expo-modules-core: 56.0.24(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             pretty-format: 29.7.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             react-refresh: 0.14.2
             whatwg-url-minimum: 0.1.2
         optionalDependencies:
-            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
-            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-dom: 19.2.3(react@19.2.3)
             react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
         transitivePeerDependencies:
@@ -29949,35 +30150,35 @@ snapshots:
             - typescript
             - utf-8-validate
 
-    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
         dependencies:
             '@babel/runtime': 7.28.4
-            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             '@expo/config': 56.0.13(typescript@6.0.3)
             '@expo/config-plugins': 56.0.15(typescript@6.0.3)
-            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/fingerprint': 0.19.9
             '@expo/local-build-cache-provider': 56.0.11(typescript@6.0.3)
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@6.0.3)
             '@ungap/structured-clone': 1.3.0
             babel-preset-expo: 56.0.19(@babel/core@7.29.7)(@babel/runtime@7.28.4)(expo@56.0.20)(react-refresh@0.14.2)
-            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
-            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))
-            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
+            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))
+            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             expo-keep-awake: 56.0.3(expo@56.0.20)(react@19.2.3)
             expo-modules-autolinking: 56.0.22(typescript@6.0.3)
-            expo-modules-core: 56.0.24(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            expo-modules-core: 56.0.24(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             pretty-format: 29.7.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
             react-refresh: 0.14.2
             whatwg-url-minimum: 0.1.2
         optionalDependencies:
-            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
-            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             react-dom: 19.2.3(react@19.2.3)
             react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
         transitivePeerDependencies:
@@ -29991,35 +30192,35 @@ snapshots:
             - typescript
             - utf-8-validate
 
-    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
+    expo@56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3):
         dependencies:
             '@babel/runtime': 7.28.4
-            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            '@expo/cli': 56.1.24(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             '@expo/config': 56.0.13(typescript@5.8.3)
             '@expo/config-plugins': 56.0.15(typescript@5.8.3)
-            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             '@expo/fingerprint': 0.19.9
             '@expo/local-build-cache-provider': 56.0.11(typescript@5.8.3)
-            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             '@expo/metro': 56.0.0
             '@expo/metro-config': 56.0.18(expo@56.0.20)(typescript@5.8.3)
             '@ungap/structured-clone': 1.3.0
             babel-preset-expo: 56.0.19(@babel/core@7.29.7)(@babel/runtime@7.28.4)(expo@56.0.20)(react-refresh@0.14.2)
-            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
-            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
-            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))
-            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            expo-asset: 56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo-constants: 56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
+            expo-file-system: 56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))
+            expo-font: 56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             expo-keep-awake: 56.0.3(expo@56.0.20)(react@19.2.3)
             expo-modules-autolinking: 56.0.22(typescript@5.8.3)
-            expo-modules-core: 56.0.24(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            expo-modules-core: 56.0.24(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             pretty-format: 29.7.0
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
             react-refresh: 0.14.2
             whatwg-url-minimum: 0.1.2
         optionalDependencies:
-            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
-            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/dom-webview': 56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@expo/metro-runtime': 56.0.20(@expo/log-box@56.0.14)(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             react-dom: 19.2.3(react@19.2.3)
             react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
         transitivePeerDependencies:
@@ -32330,11 +32531,11 @@ snapshots:
 
     lru.min@1.1.4: {}
 
-    lucide-react-native@1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    lucide-react-native@1.33.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
-            react-native-svg: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            react-native-svg: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
 
     lucide-react@0.511.0(react@19.2.3):
         dependencies:
@@ -34402,12 +34603,39 @@ snapshots:
             - babel-plugin-macros
             - supports-color
 
-    react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+    react-native-gesture-handler@2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            '@egjs/hammerjs': 2.0.17
+            '@types/react-test-renderer': 19.1.0
+            hoist-non-react-statics: 3.3.2
+            invariant: 2.2.4
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+
+    react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+
+    react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            semver: 7.7.3
+
+    react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+
+    react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
             css-select: 5.2.2
             css-tree: 1.1.3
             react: 19.2.3
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
     react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
         dependencies:
@@ -34424,15 +34652,56 @@ snapshots:
         transitivePeerDependencies:
             - encoding
 
-    react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3):
+    react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            '@babel/core': 7.29.7
+            '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+            '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+            '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+            convert-source-map: 2.0.0
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            semver: 7.7.3
+        transitivePeerDependencies:
+            - supports-color
+
+    react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            '@babel/core': 7.29.7
+            '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
+            '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+            '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+            '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+            convert-source-map: 2.0.0
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+            semver: 7.7.3
+        transitivePeerDependencies:
+            - supports-color
+        optional: true
+
+    react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3):
         dependencies:
             '@react-native/assets-registry': 0.85.3
             '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-            '@react-native/community-cli-plugin': 0.85.3
+            '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7))
             '@react-native/gradle-plugin': 0.85.3
             '@react-native/js-polyfills': 0.85.3
             '@react-native/normalize-colors': 0.85.3
-            '@react-native/virtualized-lists': 0.85.3(@types/react@19.1.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            '@react-native/virtualized-lists': 0.85.3(@types/react@19.1.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             abort-controller: 3.0.0
             anser: 1.4.10
             ansi-regex: 5.0.1
@@ -34470,15 +34739,15 @@ snapshots:
             - supports-color
             - utf-8-validate
 
-    react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3):
+    react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3):
         dependencies:
             '@react-native/assets-registry': 0.85.3
             '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-            '@react-native/community-cli-plugin': 0.85.3
+            '@react-native/community-cli-plugin': 0.85.3(@react-native/metro-config@0.85.3(@babel/core@7.29.7))
             '@react-native/gradle-plugin': 0.85.3
             '@react-native/js-polyfills': 0.85.3
             '@react-native/normalize-colors': 0.85.3
-            '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+            '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
             abort-controller: 3.0.0
             anser: 1.4.10
             ansi-regex: 5.0.1
@@ -35494,7 +35763,7 @@ snapshots:
             stylis: 4.3.2
             tslib: 2.6.2
 
-    styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+    styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
         dependencies:
             '@emotion/is-prop-valid': 1.4.0
             csstype: 3.2.3
@@ -35503,7 +35772,7 @@ snapshots:
         optionalDependencies:
             css-to-react-native: 3.2.0
             react-dom: 19.2.3(react@19.2.3)
-            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
 
     styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
         dependencies:
@@ -36066,7 +36335,7 @@ snapshots:
 
     typescript-eslint@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3):
         dependencies:
-            '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
+            '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
             '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)
             '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.8.3)
             '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.8.3)


### PR DESCRIPTION
## Summary

**Stacked on #1713** (phase 2a). The bottom-sheet foundation — the native replacement for `vaul` and the phone presentation web already prescribes in its Mobile* variants (`mobileModalV2`, `MobileSingleSelectV2`, `MobilePopoverV2`). DrawerV2 and the phone modes of Select/Menu/Modal will compose this primitive and pass their token values in; the sheet carries structure and physics, not design decisions.

### The component (`src/overlay/sheet/`)
- Controlled `open`/`onClose`; exit animation runs before unmounting from the portal layer
- Reanimated enter/exit through the phase-2a motion presets; **reduce-motion collapses the slide to a fade**
- Pan-to-dismiss with pure, worklet-safe arithmetic in `sheetMath.ts` — distance threshold (25%), fling velocity (800 pt/s), and an upward-fling rescue — fully unit-tested under vitest
- Backdrop dismissal, Android hardware-back handling, 90% height cap that respects the top inset
- `accessibilityViewIsModal` on the surface; backdrop hidden from assistive tech
- Optional safe-area insets via a context probe (no throw when `react-native-safe-area-context` or its provider is absent)

### Dependencies (per the locked foundation decision)
`react-native-reanimated` (>=3.16) and `react-native-gesture-handler` (>=2.20) become **required peers**; `react-native-safe-area-context` (>=4.10) is optional. Dev versions pin to Expo SDK 56's bundle (4.3.1 / 2.31.1 / 5.7.0 + worklets 0.8.3). Consumers need a `GestureHandlerRootView` at the root — react-navigation apps already have one; documented on the component.

### Test infrastructure
Jest gains Reanimated's synchronous mock (animations resolve immediately — exit-unmount flows assert without timers), Gesture Handler's `jestSetup`, and the worklets jest resolver (swaps native modules for JS fallbacks).

### native-site
A **Sheet** tab exercising drag-dismiss, backdrop, back button, and the height cap, with the on-device verification checklist in the component. The app now wraps in `GestureHandlerRootView`.

## Test plan
- 14 new sheetMath vitest cases + 8 BottomSheet render tests (mount/unmount lifecycle, backdrop dismissal + opt-out, modal a11y posture) — full suite: 17 vitest files, 34 jest tests green
- typecheck (blend-native + native-site), lint, and all three bob build targets green
- Gesture feel and reduce-motion behavior need the simulator/device runbook — the showcase tab lists what to check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS