### PR TITLE
feat(blend-native): phase 2c — PrimitiveInput, field chrome, TextInput

### DIFF
--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -14,9 +14,10 @@ import ButtonShowcase from './components/ButtonShowcase'
 import TagShowcase from './components/TagShowcase'
 import AlertShowcase from './components/AlertShowcase'
 import SheetShowcase from './components/SheetShowcase'
+import InputShowcase from './components/InputShowcase'
 import PlatformPreview from './components/PlatformPreview'
 
-type Tab = 'alert' | 'tag' | 'button' | 'sheet'
+type Tab = 'alert' | 'tag' | 'button' | 'sheet' | 'input'
 
 export default function App() {
     const [theme, setTheme] = useState<Theme>(Theme.LIGHT)
@@ -54,7 +55,13 @@ export default function App() {
 
                             <View style={styles.controls}>
                                 {(
-                                    ['alert', 'tag', 'button', 'sheet'] as Tab[]
+                                    [
+                                        'alert',
+                                        'tag',
+                                        'button',
+                                        'sheet',
+                                        'input',
+                                    ] as Tab[]
                                 ).map((value) => (
                                     <Pressable
                                         key={value}
@@ -97,6 +104,7 @@ export default function App() {
                             {tab === 'tag' ? <TagShowcase /> : null}
                             {tab === 'button' ? <ButtonShowcase /> : null}
                             {tab === 'sheet' ? <SheetShowcase /> : null}
+                            {tab === 'input' ? <InputShowcase /> : null}
                         </ScrollView>
                     </SafeAreaView>
                 </BlendNativeProvider>

--- a/apps/native-site/components/InputShowcase.tsx
+++ b/apps/native-site/components/InputShowcase.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { StyleSheet, Text as RNText, View } from 'react-native'
+import { Search, Eye } from 'lucide-react-native'
+import { InputSize, TextInput } from '@juspay/blend-native'
+
+/**
+ * TextInput verification. On device, check:
+ *
+ * - the border re-resolves on focus (blue) and error (red, wins over focus)
+ * - placeholder colour differs from the value colour
+ * - the keyboard does not clip descenders at any size
+ * - OS font scaling grows the field instead of clipping (package policy)
+ */
+export default function InputShowcase() {
+    const [name, setName] = useState('')
+    const [email, setEmail] = useState('not-an-email')
+    const [password, setPassword] = useState('')
+
+    return (
+        <View style={styles.column}>
+            <RNText style={styles.heading}>Sizes</RNText>
+            {[InputSize.SM, InputSize.MD, InputSize.LG].map((size) => (
+                <TextInput
+                    key={size}
+                    size={size}
+                    label={`Name (${size})`}
+                    subLabel="as on ID"
+                    hintText="Shown on your profile"
+                    placeholder="Jane Doe"
+                    value={name}
+                    onChangeText={setName}
+                    required
+                />
+            ))}
+
+            <RNText style={styles.heading}>States</RNText>
+            <TextInput
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+                error={{ show: true, message: 'Enter a valid email address' }}
+                keyboardType="email-address"
+                autoCapitalize="none"
+            />
+            <TextInput
+                label="Disabled"
+                value="read only"
+                disabled
+                hintText="Cannot be edited"
+            />
+
+            <RNText style={styles.heading}>Slots</RNText>
+            <TextInput
+                label="Search"
+                placeholder="Search components"
+                value={name}
+                onChangeText={setName}
+                leftSlot={{ slot: <Search size={16} color="#717784" /> }}
+            />
+            <TextInput
+                label="Password"
+                placeholder="••••••••"
+                value={password}
+                onChangeText={setPassword}
+                secureTextEntry
+                rightSlot={{ slot: <Eye size={16} color="#717784" /> }}
+            />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    column: { gap: 14 },
+    heading: {
+        fontSize: 15,
+        fontWeight: '600',
+        color: '#717784',
+        marginTop: 8,
+    },
+})

--- a/packages/blend-native/__tests__/TextInput.render.test.tsx
+++ b/packages/blend-native/__tests__/TextInput.render.test.tsx
@@ -1,0 +1,122 @@
+import {
+    FOUNDATION_THEME,
+    InputStateV2,
+    getTextInputV2Tokens,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import { BlendNativeProvider } from '../src/theme/BlendNativeProvider'
+import { TextInput } from '../src/components/TextInput'
+import { parseBorder } from '../src/adapters/cssStringAdapter'
+
+/**
+ * TextInput render behaviour: the chrome renders, focus re-resolves the
+ * container against the FOCUS tokens, error replaces the hint, and the
+ * disabled field blocks editing.
+ */
+
+const tokens = getTextInputV2Tokens(FOUNDATION_THEME)
+    .sm as TextInputV2TokensType
+
+const renderInput = (
+    props: Partial<React.ComponentProps<typeof TextInput>> = {}
+) =>
+    render(
+        <BlendNativeProvider>
+            <TextInput
+                value="hello"
+                label="Name"
+                hintText="As on your ID"
+                testID="field"
+                {...props}
+            />
+        </BlendNativeProvider>
+    )
+
+const flatten = (style: unknown) =>
+    Object.assign({}, ...(Array.isArray(style) ? style.flat() : [style]))
+
+describe('TextInput rendering', () => {
+    it('renders label, value and hint', () => {
+        renderInput()
+        expect(screen.getByText('Name')).toBeTruthy()
+        expect(screen.getByDisplayValue('hello')).toBeTruthy()
+        expect(screen.getByText('As on your ID')).toBeTruthy()
+    })
+
+    it('shows the error message instead of the hint', () => {
+        renderInput({ error: { show: true, message: 'Required field' } })
+        expect(screen.getByText('Required field')).toBeTruthy()
+        expect(screen.queryByText('As on your ID')).toBeNull()
+    })
+
+    it('renders the required marker', () => {
+        renderInput({ required: true })
+        expect(
+            screen.getByText('*', { includeHiddenElements: true })
+        ).toBeTruthy()
+    })
+
+    it('renders the sublabel in parentheses', () => {
+        renderInput({ subLabel: 'optional' })
+        expect(screen.getByText('(optional)')).toBeTruthy()
+    })
+})
+
+describe('TextInput interaction', () => {
+    it('propagates text changes', () => {
+        const onChangeText = jest.fn()
+        renderInput({ onChangeText })
+        fireEvent.changeText(screen.getByTestId('field-input'), 'world')
+        expect(onChangeText).toHaveBeenCalledWith('world')
+    })
+
+    it('re-resolves the container border on focus', () => {
+        renderInput()
+        const input = screen.getByTestId('field-input')
+        const containerStyle = () =>
+            flatten(screen.getByTestId('field-container').props.style)
+
+        const defaultBorder = parseBorder(
+            String(tokens.inputContainer.border[InputStateV2.DEFAULT])
+        )
+        const focusBorder = parseBorder(
+            String(tokens.inputContainer.border[InputStateV2.FOCUS])
+        )
+        // Guard: the assertion below is meaningless if these match.
+        expect(focusBorder.borderColor).not.toBe(defaultBorder.borderColor)
+
+        expect(containerStyle().borderColor).toBe(defaultBorder.borderColor)
+        fireEvent(input, 'focus')
+        expect(containerStyle().borderColor).toBe(focusBorder.borderColor)
+        fireEvent(input, 'blur')
+        expect(containerStyle().borderColor).toBe(defaultBorder.borderColor)
+    })
+
+    it('keeps the error border while focused', () => {
+        renderInput({ error: { show: true, message: 'Required' } })
+        const input = screen.getByTestId('field-input')
+        const errorBorder = parseBorder(
+            String(tokens.inputContainer.border[InputStateV2.ERROR])
+        )
+        fireEvent(input, 'focus')
+        expect(
+            flatten(screen.getByTestId('field-container').props.style)
+                .borderColor
+        ).toBe(errorBorder.borderColor)
+    })
+
+    it('blocks editing when disabled', () => {
+        renderInput({ disabled: true })
+        const input = screen.getByTestId('field-input')
+        expect(input.props.editable).toBe(false)
+        expect(input.props.accessibilityState).toMatchObject({
+            disabled: true,
+        })
+    })
+
+    it('defaults the accessible name to the label', () => {
+        renderInput()
+        expect(screen.getByLabelText('Name')).toBeTruthy()
+    })
+})

--- a/packages/blend-native/__tests__/fieldState.test.ts
+++ b/packages/blend-native/__tests__/fieldState.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { InputStateV2 } from '@juspay/blend-design-system/node'
+import {
+    getFieldState,
+    getFieldVisualState,
+} from '../src/components/shared/field/fieldState'
+
+const err = { show: true, message: 'Required' }
+const hiddenErr = { show: false, message: 'Required' }
+
+describe('getFieldState (labels/footer)', () => {
+    it('error beats disabled beats default', () => {
+        expect(getFieldState(err, true)).toBe(InputStateV2.ERROR)
+        expect(getFieldState(err, false)).toBe(InputStateV2.ERROR)
+        expect(getFieldState(undefined, true)).toBe(InputStateV2.DISABLED)
+        expect(getFieldState(undefined, false)).toBe(InputStateV2.DEFAULT)
+    })
+
+    it('a non-showing error is no error', () => {
+        expect(getFieldState(hiddenErr, false)).toBe(InputStateV2.DEFAULT)
+    })
+})
+
+describe('getFieldVisualState (container)', () => {
+    it('error > disabled > focus > default', () => {
+        expect(getFieldVisualState(err, true, true)).toBe(InputStateV2.ERROR)
+        expect(getFieldVisualState(undefined, true, true)).toBe(
+            InputStateV2.DISABLED
+        )
+        expect(getFieldVisualState(undefined, false, true)).toBe(
+            InputStateV2.FOCUS
+        )
+        expect(getFieldVisualState(undefined, false, false)).toBe(
+            InputStateV2.DEFAULT
+        )
+    })
+
+    it('focus never applies to an erroring field', () => {
+        // Web keeps the error border while focused; the truth table must too.
+        expect(getFieldVisualState(err, false, true)).toBe(InputStateV2.ERROR)
+    })
+})

--- a/packages/blend-native/__tests__/textInput.test.ts
+++ b/packages/blend-native/__tests__/textInput.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+    FOUNDATION_THEME,
+    InputSizeV2,
+    InputStateV2,
+    Theme,
+    getTextInputV2Tokens,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+import { getTextInputNativeStyles } from '../src/components/TextInput/textInput.utils'
+import { resolveSurfaceStyle } from '../src/adapters/surfaceStyle'
+
+/**
+ * Variant matrix for the native TextInput style resolver: every size ×
+ * visual state × theme resolves to usable RN values — no `undefined`,
+ * `NaN`, or `"undefined"` strings reach a style.
+ */
+
+const SIZES = Object.values(InputSizeV2)
+const STATES = Object.values(InputStateV2)
+
+const lightTokens = getTextInputV2Tokens(FOUNDATION_THEME, Theme.LIGHT)
+    .sm as TextInputV2TokensType
+const darkTokens = getTextInputV2Tokens(FOUNDATION_THEME, Theme.DARK)
+    .sm as TextInputV2TokensType
+
+const MATRIX = SIZES.flatMap((size) => STATES.map((state) => ({ size, state })))
+
+describe.each([
+    ['light', lightTokens],
+    ['dark', darkTokens],
+])('TextInput styles, %s theme', (_label, tokens) => {
+    it.each(MATRIX)('resolves $size/$state cleanly', ({ size, state }) => {
+        const styles = getTextInputNativeStyles(tokens, size, state)
+
+        const flat = {
+            columnGap: styles.gap,
+            ...styles.container,
+            ...styles.text,
+            placeholderColor: styles.placeholderColor,
+        }
+        for (const [key, value] of Object.entries(flat)) {
+            expect(value, key).toBeDefined()
+            expect(value, key).not.toBe('undefined')
+        }
+
+        // And the container survives the surface adapter: real border and
+        // background, numeric padding, no NaN.
+        const surface = resolveSurfaceStyle({
+            border: styles.container.border,
+            backgroundColor: styles.container.backgroundColor,
+            borderRadius: styles.container.borderRadius,
+            gap: styles.container.gap,
+            paddingTop: styles.container.paddingTop,
+            paddingRight: styles.container.paddingRight,
+            paddingBottom: styles.container.paddingBottom,
+            paddingLeft: styles.container.paddingLeft,
+        })
+        expect(surface.borderWidth).toBeGreaterThan(0)
+        expect(typeof surface.backgroundColor).toBe('string')
+        for (const value of Object.values(surface)) {
+            if (typeof value === 'number') {
+                expect(Number.isNaN(value)).toBe(false)
+            }
+        }
+    })
+})
+
+describe('state differentiation', () => {
+    it('error, focus and default borders are distinct', () => {
+        const border = (state: InputStateV2) =>
+            getTextInputNativeStyles(lightTokens, InputSizeV2.MD, state)
+                .container.border
+        expect(border(InputStateV2.ERROR)).not.toBe(
+            border(InputStateV2.DEFAULT)
+        )
+        expect(border(InputStateV2.FOCUS)).not.toBe(
+            border(InputStateV2.DEFAULT)
+        )
+    })
+
+    it('light and dark resolve different container backgrounds', () => {
+        const light = getTextInputNativeStyles(
+            lightTokens,
+            InputSizeV2.MD,
+            InputStateV2.DEFAULT
+        )
+        const dark = getTextInputNativeStyles(
+            darkTokens,
+            InputSizeV2.MD,
+            InputStateV2.DEFAULT
+        )
+        expect(light.container.backgroundColor).not.toBe(
+            dark.container.backgroundColor
+        )
+    })
+})

--- a/packages/blend-native/__tests__/theme.test.ts
+++ b/packages/blend-native/__tests__/theme.test.ts
@@ -53,6 +53,7 @@ describe('nativeTokenRegistry', () => {
             'ALERTV2',
             'BUTTONV2',
             'TAGV2',
+            'TEXT_INPUTV2',
         ])
     })
 

--- a/packages/blend-native/src/components/TextInput/TextInput.tsx
+++ b/packages/blend-native/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,165 @@
+import { forwardRef, useCallback, useMemo, useState } from 'react'
+import type {
+    TextInputProps as RNTextInputProps,
+    View as RNView,
+} from 'react-native'
+import {
+    InputSizeV2,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+import { useNativeTokens } from '../../theme/useNativeTokens'
+import { Block } from '../../primitives/Block'
+import { PrimitiveInput } from '../../primitives/PrimitiveInput'
+import { Slot } from '../../primitives/Slot'
+import { FieldLabels } from '../shared/field/FieldLabels'
+import { FieldFooter } from '../shared/field/FieldFooter'
+import { getFieldState, getFieldVisualState } from '../shared/field/fieldState'
+import { getTextInputNativeStyles } from './textInput.utils'
+import type { TextInputNativeProps } from './textInput.types'
+
+/**
+ * TextInput — React Native implementation of web's `TextInputV2`, and the
+ * reference consumer of the shared field chrome (`FieldLabels`,
+ * `FieldFooter`, `PrimitiveInput`) the rest of the InputsV2 family will
+ * reuse.
+ *
+ * Anatomy matches web: a column of label row, bordered field row (left
+ * slot / input / right slot), and footer — all resolved from the
+ * `TEXT_INPUTV2` token slot. Focus is component state re-resolving the
+ * container against the FOCUS tokens, replacing web's `_focus` pseudo
+ * object; the spread-only focus ring has no RN equivalent and is dropped.
+ */
+const TextInput = forwardRef<RNView, TextInputNativeProps>(function TextInput(
+    {
+        value,
+        onChangeText,
+        label,
+        subLabel,
+        size = InputSizeV2.SM,
+        error,
+        hintText,
+        required = false,
+        disabled = false,
+        leftSlot,
+        rightSlot,
+        testID,
+        accessibilityLabel,
+        style,
+        inputRef,
+        onFocus,
+        onBlur,
+        ...rest
+    },
+    ref
+) {
+    const tokens = useNativeTokens<TextInputV2TokensType>('TEXT_INPUTV2')
+    const [focused, setFocused] = useState(false)
+
+    // Labels/footer track error+disabled; the container also tracks focus.
+    const fieldState = getFieldState(error, disabled)
+    const visualState = getFieldVisualState(error, disabled, focused)
+
+    const styles = useMemo(
+        () => getTextInputNativeStyles(tokens, size, visualState),
+        [tokens, size, visualState]
+    )
+
+    // Event types come from RN's own prop signatures — they changed shape
+    // across RN versions (FocusEvent/BlurEvent), so deriving keeps us
+    // correct on every supported peer.
+    const handleFocus = useCallback<NonNullable<RNTextInputProps['onFocus']>>(
+        (event) => {
+            setFocused(true)
+            onFocus?.(event)
+        },
+        [onFocus]
+    )
+    const handleBlur = useCallback<NonNullable<RNTextInputProps['onBlur']>>(
+        (event) => {
+            setFocused(false)
+            onBlur?.(event)
+        },
+        [onBlur]
+    )
+
+    return (
+        <Block ref={ref} gap={styles.gap} style={style} testID={testID}>
+            <FieldLabels
+                label={label}
+                sublabel={subLabel}
+                required={required}
+                size={size}
+                state={fieldState}
+                tokens={tokens.topContainer}
+                testID={testID ? `${testID}-labels` : undefined}
+            />
+
+            <Block
+                flexDirection="row"
+                alignItems="center"
+                width="100%"
+                testID={testID ? `${testID}-container` : undefined}
+                border={styles.container.border}
+                backgroundColor={styles.container.backgroundColor}
+                borderRadius={styles.container.borderRadius}
+                gap={styles.container.gap}
+                paddingTop={styles.container.paddingTop}
+                paddingRight={styles.container.paddingRight}
+                paddingBottom={styles.container.paddingBottom}
+                paddingLeft={styles.container.paddingLeft}
+            >
+                {leftSlot?.slot ? (
+                    <Slot
+                        maxHeight={leftSlot.maxHeight}
+                        // Decorative next to the labelled input, matching
+                        // web's aria-hidden on input slots.
+                        hidden
+                        testID={testID ? `${testID}-left-slot` : undefined}
+                    >
+                        {leftSlot.slot}
+                    </Slot>
+                ) : null}
+
+                <PrimitiveInput
+                    ref={inputRef}
+                    value={value}
+                    onChangeText={onChangeText}
+                    editable={!disabled}
+                    fontSize={styles.text.fontSize}
+                    fontWeight={styles.text.fontWeight}
+                    lineHeight={styles.text.lineHeight}
+                    color={styles.text.color}
+                    placeholderColor={styles.placeholderColor}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                    accessibilityLabel={accessibilityLabel ?? label}
+                    accessibilityState={{ disabled }}
+                    testID={testID ? `${testID}-input` : undefined}
+                    {...rest}
+                />
+
+                {rightSlot?.slot ? (
+                    <Slot
+                        maxHeight={rightSlot.maxHeight}
+                        hidden
+                        testID={testID ? `${testID}-right-slot` : undefined}
+                    >
+                        {rightSlot.slot}
+                    </Slot>
+                ) : null}
+            </Block>
+
+            <FieldFooter
+                error={error}
+                hintText={hintText}
+                size={size}
+                tokens={tokens.bottomContainer}
+                testID={testID ? `${testID}-footer` : undefined}
+            />
+        </Block>
+    )
+})
+
+TextInput.displayName = 'TextInput'
+
+export default TextInput

--- a/packages/blend-native/src/components/TextInput/index.ts
+++ b/packages/blend-native/src/components/TextInput/index.ts
@@ -1,0 +1,2 @@
+export { default as TextInput } from './TextInput'
+export type { TextInputNativeProps, TextInputSlot } from './textInput.types'

--- a/packages/blend-native/src/components/TextInput/textInput.types.ts
+++ b/packages/blend-native/src/components/TextInput/textInput.types.ts
@@ -1,0 +1,54 @@
+import type React from 'react'
+import type {
+    TextInput as RNTextInput,
+    TextInputProps as RNTextInputProps,
+    ViewStyle,
+} from 'react-native'
+import type { InputSizeV2 } from '@juspay/blend-design-system/node'
+import type { FieldError } from '../shared/field/fieldState'
+
+/**
+ * Props for the native `TextInput` — the port of web's `TextInputV2`.
+ *
+ * Web pieces swapped for RN ones: `onChange` on a DOM input becomes RN's
+ * `onChangeText`, `data-testid` becomes `testID`, and the HTML-attribute
+ * passthrough becomes RN `TextInputProps` (which supplies `placeholder`,
+ * `keyboardType`, `autoCapitalize`, `secureTextEntry`, ... for free).
+ *
+ * Deliberately omitted rather than accepted-and-ignored (the `skeleton`
+ * precedent — passing them should be a compile error, not a no-op):
+ *
+ * - `dropdown` — the embedded SingleSelect needs the native Select family.
+ * - `helpIconText` — needs a native Tooltip.
+ * - The floating-label mode (web floats the label into `lg` inputs on
+ *   phones) — deferred until the field pattern settles on native.
+ */
+
+export type TextInputSlot = {
+    slot: React.ReactElement
+    maxHeight?: string | number
+}
+
+export type TextInputNativeProps = {
+    value: string
+    onChangeText?: (text: string) => void
+    label?: string
+    subLabel?: string
+    size?: InputSizeV2
+    error?: FieldError
+    hintText?: string
+    required?: boolean
+    disabled?: boolean
+    leftSlot?: TextInputSlot
+    rightSlot?: TextInputSlot
+    testID?: string
+    /** Screen-reader name; defaults to `label`. */
+    accessibilityLabel?: string
+    /** Escape hatch for the outer column (label + field + footer). */
+    style?: ViewStyle
+    /** Ref to the underlying RN TextInput (focus/blur/clear). */
+    inputRef?: React.Ref<RNTextInput>
+} & Omit<
+    RNTextInputProps,
+    'value' | 'onChangeText' | 'style' | 'editable' | 'placeholderTextColor'
+>

--- a/packages/blend-native/src/components/TextInput/textInput.utils.ts
+++ b/packages/blend-native/src/components/TextInput/textInput.utils.ts
@@ -1,0 +1,68 @@
+import {
+    InputSizeV2,
+    InputStateV2,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+
+/**
+ * Native TextInputV2 style resolver.
+ *
+ * Reimplements the inline resolution `TextInputV2.tsx` performs for RN. Web
+ * expresses hover/focus through styled-components pseudo-state objects; on
+ * native the field re-resolves against the current visual state (focus
+ * tracked in component state), so this returns plain token strings for one
+ * state at a time — the pattern `getButtonNativeStyles` set.
+ */
+
+export type TextInputNativeStyles = {
+    /** Outer column: label / field / footer. */
+    gap: string
+    /** The bordered field row. */
+    container: {
+        border: string
+        backgroundColor: string
+        borderRadius: string
+        gap: string
+        paddingTop: string
+        paddingRight: string
+        paddingBottom: string
+        paddingLeft: string
+    }
+    /** The editable text. */
+    text: {
+        fontSize: string
+        fontWeight: string
+        lineHeight: string
+        color: string
+    }
+    placeholderColor: string
+}
+
+export function getTextInputNativeStyles(
+    tokens: TextInputV2TokensType,
+    size: InputSizeV2,
+    visualState: InputStateV2
+): TextInputNativeStyles {
+    const container = tokens.inputContainer
+
+    return {
+        gap: String(tokens.gap),
+        container: {
+            border: String(container.border[visualState]),
+            backgroundColor: String(container.backgroundColor[visualState]),
+            borderRadius: String(container.borderRadius[size]),
+            gap: String(container.gap),
+            paddingTop: String(container.padding.top[size]),
+            paddingRight: String(container.padding.right[size]),
+            paddingBottom: String(container.padding.bottom[size]),
+            paddingLeft: String(container.padding.left[size]),
+        },
+        text: {
+            fontSize: String(container.inputText.fontSize[size]),
+            fontWeight: String(container.inputText.fontWeight[size]),
+            lineHeight: String(container.inputText.lineHeight[size]),
+            color: String(container.inputText.color[visualState]),
+        },
+        placeholderColor: String(container.placeholder.color[visualState]),
+    }
+}

--- a/packages/blend-native/src/components/shared/field/FieldFooter.tsx
+++ b/packages/blend-native/src/components/shared/field/FieldFooter.tsx
@@ -1,0 +1,66 @@
+import {
+    InputSizeV2,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+import { Block } from '../../../primitives/Block'
+import { Text } from '../../../primitives/Text'
+import { useLiveRegionAnnounce } from '../../../a11y/useLiveRegion'
+import type { FieldError } from './fieldState'
+
+/**
+ * Footer under a field: the error message when erroring, else the hint.
+ *
+ * Ports web's `InputFooterV2` against the same `bottomContainer` token
+ * shape. Web marks the error `role="alert"` + `aria-live="polite"`; the
+ * native split is the Alert pattern — `accessibilityLiveRegion` for
+ * Android, an imperative announcement for iOS.
+ */
+
+export type FieldFooterProps = {
+    error?: FieldError
+    hintText?: string
+    size?: InputSizeV2
+    tokens: TextInputV2TokensType['bottomContainer']
+    testID?: string
+}
+
+export function FieldFooter({
+    error,
+    hintText,
+    size = InputSizeV2.SM,
+    tokens,
+    testID,
+}: FieldFooterProps) {
+    const showError = Boolean(error?.show && error.message)
+
+    useLiveRegionAnnounce(showError ? error?.message : undefined, showError)
+
+    if (!showError && !hintText) return null
+
+    return (
+        <Block width="100%" testID={testID}>
+            {showError ? (
+                <Text
+                    accessibilityLiveRegion="polite"
+                    color={String(tokens.errorMessage.color)}
+                    fontSize={tokens.errorMessage.fontSize[size]}
+                    fontWeight={tokens.errorMessage.fontWeight[size]}
+                    lineHeight={tokens.errorMessage.lineHeight[size]}
+                >
+                    {error?.message}
+                </Text>
+            ) : (
+                <Text
+                    color={String(tokens.hintText.color.default)}
+                    fontSize={tokens.hintText.fontSize[size]}
+                    fontWeight={tokens.hintText.fontWeight[size]}
+                    lineHeight={tokens.hintText.lineHeight[size]}
+                >
+                    {hintText}
+                </Text>
+            )}
+        </Block>
+    )
+}
+
+FieldFooter.displayName = 'FieldFooter'

--- a/packages/blend-native/src/components/shared/field/FieldLabels.tsx
+++ b/packages/blend-native/src/components/shared/field/FieldLabels.tsx
@@ -1,0 +1,86 @@
+import {
+    InputSizeV2,
+    InputStateV2,
+    type TextInputV2TokensType,
+} from '@juspay/blend-design-system/node'
+import { Block } from '../../../primitives/Block'
+import { Text } from '../../../primitives/Text'
+
+/**
+ * Label row above a field: label, required marker, sublabel.
+ *
+ * Ports web's `InputLabelsV2` against the same `topContainer` token shape,
+ * with two deliberate omissions:
+ *
+ * - `helpIconText` — web wraps a help icon in `Tooltip`; native has no
+ *   tooltip yet, so the prop does not exist rather than silently doing
+ *   nothing (the `skeleton` precedent).
+ * - `as="label"`/`htmlFor` — no DOM. The field component instead puts the
+ *   label text into the input's `accessibilityLabel`.
+ */
+
+export type FieldLabelsProps = {
+    label?: string
+    sublabel?: string
+    required?: boolean
+    size?: InputSizeV2
+    state?: InputStateV2
+    tokens: TextInputV2TokensType['topContainer']
+    testID?: string
+}
+
+export function FieldLabels({
+    label,
+    sublabel,
+    required = false,
+    size = InputSizeV2.SM,
+    state = InputStateV2.DEFAULT,
+    tokens,
+    testID,
+}: FieldLabelsProps) {
+    if (!label) return null
+
+    return (
+        <Block
+            flexDirection="row"
+            alignItems="center"
+            gap={4}
+            width="100%"
+            testID={testID}
+        >
+            <Text
+                fontWeight={tokens.label.fontWeight[size]}
+                fontSize={tokens.label.fontSize[size]}
+                color={String(tokens.label.color[state])}
+                lineHeight={tokens.label.lineHeight[size]}
+            >
+                {label}
+            </Text>
+            {required ? (
+                // Web renders <sup aria-hidden>*</sup>; the accessible
+                // "required" semantics live on the input's a11y props, so
+                // the marker stays visual-only here too.
+                <Text
+                    color={String(tokens.required.color)}
+                    fontSize={tokens.label.fontSize[size]}
+                    accessibilityElementsHidden
+                    importantForAccessibility="no-hide-descendants"
+                >
+                    *
+                </Text>
+            ) : null}
+            {sublabel ? (
+                <Text
+                    fontWeight={tokens.subLabel.fontWeight[size]}
+                    fontSize={tokens.subLabel.fontSize[size]}
+                    color={String(tokens.subLabel.color[state])}
+                    lineHeight={tokens.subLabel.lineHeight[size]}
+                >
+                    ({sublabel})
+                </Text>
+            ) : null}
+        </Block>
+    )
+}
+
+FieldLabels.displayName = 'FieldLabels'

--- a/packages/blend-native/src/components/shared/field/fieldState.ts
+++ b/packages/blend-native/src/components/shared/field/fieldState.ts
@@ -1,0 +1,39 @@
+import { InputStateV2 } from '@juspay/blend-design-system/node'
+
+/**
+ * Input state derivation, shared by every field component.
+ *
+ * Mirrors web's `getInputState` (`InputsV2/TextInputV2/utils.ts`) and the
+ * per-variant resolution `TextInputV2.tsx` performs inline: error always
+ * wins, then disabled, and focus applies only when nothing stronger does.
+ * `HOVER` exists in the enum but has no touch counterpart.
+ *
+ * Pure and RN-free so the whole truth table unit-tests under vitest.
+ */
+
+export type FieldError = { show: boolean; message?: string } | undefined
+
+/** The state driving label/footer colours — web's `getInputState`. */
+export function getFieldState(
+    error: FieldError,
+    disabled?: boolean
+): InputStateV2 {
+    if (error?.show) return InputStateV2.ERROR
+    if (disabled) return InputStateV2.DISABLED
+    return InputStateV2.DEFAULT
+}
+
+/**
+ * The state driving the input container's border/background/text, which
+ * unlike the label state also reflects focus.
+ */
+export function getFieldVisualState(
+    error: FieldError,
+    disabled: boolean | undefined,
+    focused: boolean
+): InputStateV2 {
+    if (error?.show) return InputStateV2.ERROR
+    if (disabled) return InputStateV2.DISABLED
+    if (focused) return InputStateV2.FOCUS
+    return InputStateV2.DEFAULT
+}

--- a/packages/blend-native/src/index.ts
+++ b/packages/blend-native/src/index.ts
@@ -21,6 +21,11 @@
 export { Alert } from './components/Alert'
 export { Button } from './components/Button'
 export { Tag } from './components/Tag'
+export { TextInput } from './components/TextInput'
+export type {
+    TextInputNativeProps,
+    TextInputSlot,
+} from './components/TextInput'
 
 export type {
     AlertNativeProps,
@@ -67,6 +72,8 @@ export { Pressable } from './primitives/Pressable'
 export { Text } from './primitives/Text'
 export { Slot } from './primitives/Slot'
 export { Separator } from './primitives/Separator'
+export { PrimitiveInput } from './primitives/PrimitiveInput'
+export type { PrimitiveInputProps } from './primitives/PrimitiveInput'
 
 export type { BlockProps } from './primitives/Block'
 export type { PrimitivePressableProps } from './primitives/Pressable'
@@ -120,6 +127,8 @@ export {
     ButtonV2Size as ButtonSize,
     ButtonV2SubType as ButtonSubType,
     ButtonV2State as ButtonState,
+    InputSizeV2 as InputSize,
+    InputStateV2 as InputState,
     TagV2Type as TagType,
     TagV2Size as TagSize,
     TagV2SubType as TagSubType,

--- a/packages/blend-native/src/primitives/PrimitiveInput.tsx
+++ b/packages/blend-native/src/primitives/PrimitiveInput.tsx
@@ -1,0 +1,87 @@
+import { forwardRef, memo, useContext } from 'react'
+import {
+    TextInput as RNTextInput,
+    StyleSheet,
+    type TextInputProps as RNTextInputProps,
+    type TextStyle,
+} from 'react-native'
+import { parseDimension } from '../adapters/cssStringAdapter'
+import { resolveFontWeight } from './textStyle'
+import { BlendNativeThemeContext } from '../theme/BlendNativeProvider'
+
+/**
+ * Native `PrimitiveInput` — a bare RN `TextInput` driven by token-shaped
+ * text props, the input counterpart of `Text`.
+ *
+ * Deliberately *only* the text field: web's `PrimitiveInput` styles the
+ * `<input>` element itself with border and padding, but RN inputs carry
+ * leading/trailing slots, so the bordered container is a `Block` row that
+ * the field component owns and this primitive sits inside with `flex: 1`.
+ *
+ * Font family comes from the provider's role map (`body`), matching `Text`,
+ * and OS font scaling stays on per the package policy.
+ */
+
+export type PrimitiveInputProps = {
+    /** CSS string like `"14px"` or a number. */
+    fontSize?: string | number
+    /** CSS font-weight keyword or numeric string (`"500"`). */
+    fontWeight?: string | number
+    /** Text colour for the current state. */
+    color?: string
+    /** CSS line-height like `"20px"` or a number. */
+    lineHeight?: string | number
+    /** Placeholder colour for the current state. */
+    placeholderColor?: string
+    style?: TextStyle
+} & Omit<RNTextInputProps, 'style' | 'placeholderTextColor'>
+
+const PrimitiveInputImpl = forwardRef<RNTextInput, PrimitiveInputProps>(
+    function PrimitiveInput(
+        {
+            fontSize,
+            fontWeight,
+            color,
+            lineHeight,
+            placeholderColor,
+            style,
+            ...rest
+        },
+        ref
+    ) {
+        const { fontFamily } = useContext(BlendNativeThemeContext)
+
+        const resolved: TextStyle = {
+            fontSize: parseDimension(fontSize),
+            fontWeight: resolveFontWeight(fontWeight),
+            color,
+            lineHeight: parseDimension(lineHeight),
+            fontFamily: fontFamily.body ?? undefined,
+        }
+
+        return (
+            <RNTextInput
+                ref={ref}
+                style={StyleSheet.flatten([baseStyle.input, resolved, style])}
+                placeholderTextColor={placeholderColor}
+                {...rest}
+            />
+        )
+    }
+)
+
+/** Memoised — see the note on `Block`. */
+export const PrimitiveInput = memo(PrimitiveInputImpl)
+PrimitiveInput.displayName = 'PrimitiveInput'
+
+const baseStyle = StyleSheet.create({
+    input: {
+        // The field row owns padding; RN inputs default to platform padding
+        // that would double up with the container's token padding.
+        flex: 1,
+        paddingVertical: 0,
+        paddingHorizontal: 0,
+    },
+})
+
+export default PrimitiveInput

--- a/packages/blend-native/src/primitives/Text.tsx
+++ b/packages/blend-native/src/primitives/Text.tsx
@@ -6,6 +6,7 @@ import {
     type TextStyle,
 } from 'react-native'
 import { parseDimension } from '../adapters/cssStringAdapter'
+import { resolveFontWeight } from './textStyle'
 import { BlendNativeThemeContext } from '../theme/BlendNativeProvider'
 import type { NativeFontRole } from '../theme/fonts'
 
@@ -52,22 +53,6 @@ export type BlendTextProps = {
 } & Omit<RNTextProps, 'style'> & {
         style?: TextStyle
     }
-
-/**
- * Resolve a CSS font-weight value to a RN-compatible `TextStyle['fontWeight']`.
- * RN accepts `'normal' | 'bold' | '100'..'900'` (as string or number).
- */
-function resolveFontWeight(
-    w: string | number | undefined
-): TextStyle['fontWeight'] {
-    if (w === undefined) return undefined
-    if (typeof w === 'number') return String(w) as TextStyle['fontWeight']
-    // Token values are numeric strings like `"500"`.
-    if (/^\d+$/.test(w)) return w as TextStyle['fontWeight']
-    const lower = w.toLowerCase()
-    if (lower === 'normal' || lower === 'bold') return lower
-    return undefined
-}
 
 function TextImpl({
     children,

--- a/packages/blend-native/src/primitives/textStyle.ts
+++ b/packages/blend-native/src/primitives/textStyle.ts
@@ -1,0 +1,24 @@
+import type { TextStyle } from 'react-native'
+
+/**
+ * Shared text-style resolution for `Text` and `PrimitiveInput`.
+ *
+ * Leaf module with only a type import from `react-native`, so it stays
+ * vitest-testable — the `theme/breakpoint.ts` pattern.
+ */
+
+/**
+ * Resolve a CSS font-weight value to a RN-compatible `TextStyle['fontWeight']`.
+ * RN accepts `'normal' | 'bold' | '100'..'900'` (as string or number).
+ */
+export function resolveFontWeight(
+    w: string | number | undefined
+): TextStyle['fontWeight'] {
+    if (w === undefined) return undefined
+    if (typeof w === 'number') return String(w) as TextStyle['fontWeight']
+    // Token values are numeric strings like `"500"`.
+    if (/^\d+$/.test(w)) return w as TextStyle['fontWeight']
+    const lower = w.toLowerCase()
+    if (lower === 'normal' || lower === 'bold') return lower
+    return undefined
+}

--- a/packages/blend-native/src/theme/nativeTokenRegistry.ts
+++ b/packages/blend-native/src/theme/nativeTokenRegistry.ts
@@ -4,6 +4,7 @@ import {
     getAlertV2Tokens,
     getButtonV2Tokens,
     getTagV2Tokens,
+    getTextInputV2Tokens,
     type BreakpointType,
 } from '@juspay/blend-design-system/node'
 
@@ -25,6 +26,7 @@ export const NATIVE_TOKEN_REGISTRY = {
     ALERTV2: getAlertV2Tokens,
     BUTTONV2: getButtonV2Tokens,
     TAGV2: getTagV2Tokens,
+    TEXT_INPUTV2: getTextInputV2Tokens,
 } as const
 
 /** Every component slot native can resolve. Derived, never hand-written. */

--- a/packages/blend/lib/node.ts
+++ b/packages/blend/lib/node.ts
@@ -57,6 +57,10 @@ export type {
     ResponsiveTagV2Tokens,
 } from './components/TagV2/tagV2.tokens'
 export { getTextInputV2Tokens } from './components/InputsV2/TextInputV2/TextInputV2.tokens'
+export type {
+    TextInputV2TokensType,
+    ResponsiveTextInputV2Tokens,
+} from './components/InputsV2/TextInputV2/TextInputV2.tokens.types'
 export { getUploadV2Tokens } from './components/InputsV2/UploadV2/UploadV2.tokens'
 
 export { getTimelineTokens } from './components/Timeline/timeline.token'
@@ -94,3 +98,5 @@ export {
     TagV2Color,
     TagV2PaddingDirection,
 } from './components/TagV2/TagV2.types'
+
+export { InputSizeV2, InputStateV2 } from './components/InputsV2/inputV2.types'


### PR DESCRIPTION
## Summary

**Stacked on #1714** (phase 2b). The field foundation the entire InputsV2 family will reuse — with `TextInput` (the `TextInputV2` port) shipped as its reference consumer, so the chrome is validated end to end rather than landing speculative.

### Node entry (`packages/blend`)
`InputSizeV2`, `InputStateV2`, `TextInputV2TokensType` + responsive wrapper join `lib/node.ts` (two string enums + type-only — zero runtime weight). The phase-1 contract test extends itself automatically to cover them.

### Field foundation (`packages/blend-native`)
- **`PrimitiveInput`** — bare RN `TextInput` driven by token-shaped text props (font family from the provider role map, scaling on per policy). The bordered container is a `Block` row the field owns, because RN inputs carry slots the web `<input>` cannot.
- **`FieldLabels` / `FieldFooter`** — ports of `InputLabelsV2`/`InputFooterV2` against the same `topContainer`/`bottomContainer` token shapes; error messages announce through the Alert live-region pattern (Android `accessibilityLiveRegion`, iOS imperative).
- **`fieldState`** — pure truth tables mirroring web's `getInputState`: labels track error > disabled > default; the container additionally tracks focus, with the error border winning over focus exactly as web renders it.

### TextInput component
`TEXT_INPUTV2` slot (registry entry #4), full size × state matrix, slots hidden from AT beside the labelled input, `accessibilityLabel` defaulting to the label, RN `TextInputProps` passthrough (keyboardType, secureTextEntry, …). Deliberately **omitted rather than ignored** (compile errors, the `skeleton` precedent): the embedded `dropdown` (needs native Select), `helpIconText` (needs Tooltip), and the floating-label phone mode.

### native-site
An **Input** tab: three sizes, focus/error/disabled states, slot variants, with the on-device checklist.

## Test plan
- vitest: fieldState truth tables + a 15-case size×state×theme matrix that also pushes every container through the surface adapter (no NaN/undefined) — 19 files green
- jest: 9 TextInput render tests including focus→FOCUS-border→blur round-trip and error-beats-focus — 43 tests green
- typecheck (blend-native + native-site after `pnpm build:blend`), lint, all three bob targets green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS