### PR TITLE
feat(blend-native): phase 2d — Skeleton and the toast host

### DIFF
--- a/.github/workflows/publish-native-npm.yml
+++ b/.github/workflows/publish-native-npm.yml
@@ -108,6 +108,15 @@ jobs:
               env:
                   CI: true
 
+            # The workspace build always has the newest /node exports, so CI
+            # stays green while the PUBLISHED version a consumer installs may
+            # predate them. This asserts the declared peer floor really
+            # exports everything blend-native imports — without it we can
+            # ship a package that crashes on first render.
+            - name: Verify the peer floor exports what we import
+              if: steps.check_published.outputs.already_published != 'true'
+              run: pnpm --filter @juspay/blend-native check:peer
+
             - name: Build @juspay/blend-native
               if: steps.check_published.outputs.already_published != 'true'
               run: pnpm --filter @juspay/blend-native build

--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -15,9 +15,10 @@ import TagShowcase from './components/TagShowcase'
 import AlertShowcase from './components/AlertShowcase'
 import SheetShowcase from './components/SheetShowcase'
 import InputShowcase from './components/InputShowcase'
+import LoadingShowcase from './components/LoadingShowcase'
 import PlatformPreview from './components/PlatformPreview'
 
-type Tab = 'alert' | 'tag' | 'button' | 'sheet' | 'input'
+type Tab = 'alert' | 'tag' | 'button' | 'sheet' | 'input' | 'loading'
 
 export default function App() {
     const [theme, setTheme] = useState<Theme>(Theme.LIGHT)
@@ -105,6 +106,7 @@ export default function App() {
                             {tab === 'button' ? <ButtonShowcase /> : null}
                             {tab === 'sheet' ? <SheetShowcase /> : null}
                             {tab === 'input' ? <InputShowcase /> : null}
+                            {tab === 'loading' ? <LoadingShowcase /> : null}
                         </ScrollView>
                     </SafeAreaView>
                 </BlendNativeProvider>

--- a/apps/native-site/components/LoadingShowcase.tsx
+++ b/apps/native-site/components/LoadingShowcase.tsx
@@ -1,0 +1,112 @@
+import { StyleSheet, Text as RNText, View } from 'react-native'
+import {
+    Button,
+    ButtonType,
+    dismissToast,
+    Skeleton,
+    showToast,
+    Tag,
+    TagColor,
+    TagType,
+} from '@juspay/blend-native'
+
+/**
+ * Skeleton + toast verification. On device, check:
+ *
+ * - pulse breathes; wave sweeps left→right (needs expo-linear-gradient,
+ *   otherwise it degrades to pulse)
+ * - OS reduce-motion freezes skeletons to the static base colour
+ * - wrapped content sizes its skeleton exactly, nothing peeks through
+ * - toasts stack bottom-up, cap at three, and clear the home indicator
+ */
+export default function LoadingShowcase() {
+    return (
+        <View style={styles.column}>
+            <RNText style={styles.heading}>Skeleton blocks</RNText>
+            <Skeleton width={220} height={16} />
+            <Skeleton width={160} height={16} variant="wave" />
+            <Skeleton width={48} height={48} shape="circle" />
+            <Skeleton width={120} height={32} shape="rounded" />
+
+            <RNText style={styles.heading}>Wrapping live content</RNText>
+            <Skeleton>
+                <Button buttonType={ButtonType.PRIMARY} text="Hidden button" />
+            </Skeleton>
+            <Skeleton>
+                <Tag
+                    text="Hidden tag"
+                    type={TagType.SUBTLE}
+                    color={TagColor.PRIMARY}
+                />
+            </Skeleton>
+
+            <RNText style={styles.heading}>Toasts</RNText>
+            <Button
+                buttonType={ButtonType.PRIMARY}
+                text="Show toast"
+                onPress={() =>
+                    showToast({
+                        content: (
+                            <View style={styles.toast}>
+                                <RNText style={styles.toastText}>
+                                    Payment link copied
+                                </RNText>
+                            </View>
+                        ),
+                        announcement: 'Payment link copied',
+                    })
+                }
+            />
+            <Button
+                buttonType={ButtonType.SECONDARY}
+                text="Sticky toast with undo"
+                onPress={() =>
+                    showToast({
+                        duration: null,
+                        content: (dismiss) => (
+                            <View style={styles.toast}>
+                                <RNText style={styles.toastText}>
+                                    Message archived
+                                </RNText>
+                                <RNText
+                                    style={styles.toastAction}
+                                    onPress={dismiss}
+                                >
+                                    Undo
+                                </RNText>
+                            </View>
+                        ),
+                    })
+                }
+            />
+            <Button
+                buttonType={ButtonType.DANGER}
+                text="Dismiss all"
+                onPress={() => dismissToast()}
+            />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    column: { gap: 12 },
+    heading: {
+        fontSize: 15,
+        fontWeight: '600',
+        color: '#717784',
+        marginTop: 8,
+    },
+    // Toast chrome is the caller's job until SnackbarV2 lands — the host
+    // only stacks, times and animates.
+    toast: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 16,
+        backgroundColor: '#1A1C23',
+        paddingVertical: 12,
+        paddingHorizontal: 16,
+        borderRadius: 10,
+    },
+    toastText: { color: '#F5F6F7', fontSize: 14 },
+    toastAction: { color: '#8DB2FA', fontSize: 14, fontWeight: '600' },
+})

--- a/packages/blend-native/README.md
+++ b/packages/blend-native/README.md
@@ -334,7 +334,33 @@ module graph (Reanimated worklets, gesture handler, portals) compiles.
 `@juspay/blend-design-system`; compatibility is declared through the peer
 range. Publishing runs through the **Publish Native to NPM** workflow
 (`.github/workflows/publish-native-npm.yml`), which gates on branch,
-version format, and a green lint/typecheck/test/build before `npm publish`.
+version format, a green lint/typecheck/test/build, and the peer-export
+check below, before `npm publish`.
+
+### Publish the web package first — always
+
+This package imports its whole token system from
+`@juspay/blend-design-system/node`. The workspace build always has the
+newest exports, so **local checks and CI cannot tell you whether the
+version consumers will install has them**. A new native component almost
+always adds an export to `packages/blend/lib/node.ts`, and until a web
+version containing it is on npm, publishing native ships a package that
+crashes on first render with an unrelated `undefined`.
+
+```bash
+pnpm --filter @juspay/blend-native check:peer
+```
+
+resolves the floor version out of the declared peer range, fetches that
+exact version from the registry, and asserts every value import exists in
+it. Run it before any release; the publish workflow runs it too. When it
+fails, the fix is always the same order:
+
+1. Publish a `@juspay/blend-design-system` version whose `lib/node.ts`
+   carries the new exports (its own beta workflow runs from `staging`).
+2. Raise `peerDependencies["@juspay/blend-design-system"]` here to that
+   version.
+3. Re-run `check:peer` — then publish native.
 
 ### Beta
 

--- a/packages/blend-native/README.md
+++ b/packages/blend-native/README.md
@@ -300,6 +300,63 @@ value of `flexShrink`.
 simulators and physical devices for both platforms, capturing screenshots,
 capturing pressed states, and the Expo Go SDK ceiling on Android.
 
+## Verifying as a consumer
+
+`apps/native-site` consumes this package through the workspace link (raw
+`src/`), which is right for development but is **not** what npm consumers
+receive. Before a release, smoke-test the publish artifact itself:
+
+```bash
+# 1. Build and pack — the tarball is byte-for-byte what npm publish uploads
+pnpm --filter @juspay/blend-native build
+pnpm --filter @juspay/blend-native pack --pack-destination /tmp
+
+# 2. Point native-site at the tarball instead of the workspace:
+#    - apps/native-site/package.json: "@juspay/blend-native": "file:/tmp/juspay-blend-native-<version>.tgz"
+#    - apps/native-site/tsconfig.json: REMOVE the "@juspay/blend-native" paths entry
+pnpm install --filter native-site
+
+# 3. Consumer checks
+pnpm --filter native-site typecheck        # published d.ts via the exports map
+cd apps/native-site && npx expo export --platform android   # full Metro bundle
+npx expo start                             # then verify on a simulator/device
+
+# 4. Revert package.json + tsconfig.json to the workspace state and reinstall
+```
+
+The typecheck proves the `types` conditions resolve; the export proves Metro
+resolves the `react-native` condition into the shipped `src/` and the whole
+module graph (Reanimated worklets, gesture handler, portals) compiles.
+
+## Publishing
+
+`@juspay/blend-native` versions **independently** of
+`@juspay/blend-design-system`; compatibility is declared through the peer
+range. Publishing runs through the **Publish Native to NPM** workflow
+(`.github/workflows/publish-native-npm.yml`), which gates on branch,
+version format, and a green lint/typecheck/test/build before `npm publish`.
+
+### Beta
+
+1. Bump `version` in `packages/blend-native/package.json` to `X.Y.Z-beta.N`
+   (e.g. `0.0.1-beta.1`) in a PR and merge it to `dev`.
+2. GitHub → Actions → **Publish Native to NPM** → Run workflow **from
+   `dev`** (or `staging`), `dist_tag: beta`, type `PUBLISH` to confirm.
+3. The workflow refuses a non-beta version, an already-published version,
+   or a red check; on success it verifies the tag on the registry.
+4. Consumers install with `npm install @juspay/blend-native@beta`.
+
+### Stable
+
+1. Bump `version` to plain `X.Y.Z` (drop the `-beta.N`) in a PR; land it on
+   `main` through the usual `dev → staging → main` train.
+2. Run the same workflow **from `main`**, `dist_tag: latest`, confirm
+   `PUBLISH`. The workflow refuses `latest` from any other branch.
+3. Consumers on `npm install @juspay/blend-native` now get this version.
+
+Iterating a beta: bump to `-beta.N+1`, merge, run the workflow again — the
+already-published gate makes re-running for a published version a no-op.
+
 ## Adding a new component
 
 1. Ensure the token factory, its types, and its enums are exported from `@juspay/blend-design-system/node` (edit `packages/blend/lib/node.ts`), then `pnpm build:blend`.

--- a/packages/blend-native/__tests__/SkeletonToast.render.test.tsx
+++ b/packages/blend-native/__tests__/SkeletonToast.render.test.tsx
@@ -1,0 +1,156 @@
+import { Text } from 'react-native'
+import { act, render, screen } from '@testing-library/react-native'
+import { BlendNativeProvider } from '../src/theme/BlendNativeProvider'
+import { Skeleton } from '../src/components/Skeleton'
+import {
+    dismissToast,
+    resetToasts,
+    showToast,
+} from '../src/overlay/toast/toastStore'
+
+/**
+ * Render coverage for the loading-state foundations: Skeleton's two usage
+ * modes and their AT posture, and the provider-mounted toast outlet's
+ * lifecycle (show, replace, auto-dismiss, cap).
+ */
+
+const q = { includeHiddenElements: true } as const
+
+describe('Skeleton', () => {
+    it('renders a standalone box hidden from assistive tech', () => {
+        render(
+            <BlendNativeProvider>
+                <Skeleton width={120} height={16} testID="sk" />
+            </BlendNativeProvider>
+        )
+        const root = screen.getByTestId('sk', q)
+        expect(root.props.importantForAccessibility).toBe('no-hide-descendants')
+        const surface = screen.getByTestId('sk-surface', q)
+        const style = Object.assign({}, ...[surface.props.style].flat(Infinity))
+        expect(style.width).toBe(120)
+        expect(style.height).toBe(16)
+        expect(typeof style.backgroundColor).toBe('string')
+    })
+
+    it('wrap mode keeps the content in the tree but invisible', () => {
+        render(
+            <BlendNativeProvider>
+                <Skeleton testID="sk">
+                    <Text>Loaded content</Text>
+                </Skeleton>
+            </BlendNativeProvider>
+        )
+        // Content still lays the box out...
+        expect(screen.getByText('Loaded content', q)).toBeTruthy()
+        // ...but its wrapper renders at opacity 0 with the surface above.
+        const root = screen.getByTestId('sk', q)
+        const contentWrapper = root.children[0] as {
+            props: { style?: unknown }
+        }
+        const style = Object.assign(
+            {},
+            ...[contentWrapper.props.style].flat(Infinity)
+        )
+        expect(style.opacity).toBe(0)
+        expect(screen.getByTestId('sk-surface', q)).toBeTruthy()
+    })
+})
+
+describe('toast outlet', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        resetToasts()
+    })
+    afterEach(() => {
+        act(() => {
+            dismissToast()
+        })
+        jest.useRealTimers()
+    })
+
+    const mount = () =>
+        render(
+            <BlendNativeProvider>
+                <Text>app</Text>
+            </BlendNativeProvider>
+        )
+
+    it('renders nothing until a toast is shown, then shows it', () => {
+        mount()
+        expect(screen.queryByTestId('blend-toast-outlet')).toBeNull()
+        act(() => {
+            showToast({ content: <Text>Saved</Text> })
+        })
+        expect(screen.getByText('Saved')).toBeTruthy()
+    })
+
+    it('auto-dismisses after its duration', () => {
+        mount()
+        act(() => {
+            showToast({ content: <Text>Bye</Text>, duration: 1000 })
+        })
+        expect(screen.getByText('Bye')).toBeTruthy()
+        act(() => {
+            jest.advanceTimersByTime(1100)
+        })
+        expect(screen.queryByText('Bye')).toBeNull()
+    })
+
+    it('a sticky toast survives until dismissed', () => {
+        mount()
+        let id = ''
+        act(() => {
+            id = showToast({ content: <Text>Stay</Text>, duration: null })
+        })
+        act(() => {
+            jest.advanceTimersByTime(60_000)
+        })
+        expect(screen.getByText('Stay')).toBeTruthy()
+        act(() => {
+            dismissToast(id)
+        })
+        expect(screen.queryByText('Stay')).toBeNull()
+    })
+
+    it('replaces content in place when the id is reused', () => {
+        mount()
+        act(() => {
+            showToast({ id: 'save', content: <Text>Saving…</Text> })
+        })
+        act(() => {
+            showToast({ id: 'save', content: <Text>Saved</Text> })
+        })
+        expect(screen.queryByText('Saving…')).toBeNull()
+        expect(screen.getByText('Saved')).toBeTruthy()
+    })
+
+    it('function content receives a working dismiss', () => {
+        mount()
+        let dismissFn: (() => void) | undefined
+        act(() => {
+            showToast({
+                content: (dismiss) => {
+                    dismissFn = dismiss
+                    return <Text>Undo</Text>
+                },
+                duration: null,
+            })
+        })
+        expect(screen.getByText('Undo')).toBeTruthy()
+        act(() => dismissFn?.())
+        expect(screen.queryByText('Undo')).toBeNull()
+    })
+
+    it('shows only the newest three at once', () => {
+        mount()
+        act(() => {
+            for (let i = 1; i <= 5; i++) {
+                showToast({ content: <Text>{`toast-${i}`}</Text> })
+            }
+        })
+        expect(screen.queryByText('toast-1')).toBeNull()
+        expect(screen.queryByText('toast-2')).toBeNull()
+        expect(screen.getByText('toast-3')).toBeTruthy()
+        expect(screen.getByText('toast-5')).toBeTruthy()
+    })
+})

--- a/packages/blend-native/__tests__/publicApi.test.ts
+++ b/packages/blend-native/__tests__/publicApi.test.ts
@@ -96,7 +96,8 @@ describe('public API surface', () => {
         // A guard against drift, not a hard architectural limit — if this
         // trips, decide deliberately whether the additions are public API.
         // Raised from 30 when the overlay foundation (Portal, BottomSheet,
-        // useReduceMotion) became public.
-        expect(exported.size).toBeLessThanOrEqual(36)
+        // useReduceMotion) became public, then to 40 for the field layer
+        // (TextInput, PrimitiveInput, input enums) and the toast pair.
+        expect(exported.size).toBeLessThanOrEqual(40)
     })
 })

--- a/packages/blend-native/__tests__/skeleton.test.ts
+++ b/packages/blend-native/__tests__/skeleton.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import {
+    FOUNDATION_THEME,
+    Theme,
+    getSkeletonTokens,
+    type SkeletonTokensType,
+} from '@juspay/blend-design-system/node'
+import { parseDuration } from '../src/adapters/cssStringAdapter'
+import {
+    SKELETON_FALLBACK_DURATION,
+    resolveSkeletonDuration,
+    resolveSkeletonRadius,
+} from '../src/components/Skeleton/skeleton.utils'
+
+const light = getSkeletonTokens(FOUNDATION_THEME, Theme.LIGHT)
+    .sm as SkeletonTokensType
+const dark = getSkeletonTokens(FOUNDATION_THEME, Theme.DARK)
+    .sm as SkeletonTokensType
+
+describe('parseDuration', () => {
+    it.each([
+        ['1.5s', 1500],
+        ['200ms', 200],
+        ['0s', 0],
+        [800, 800],
+    ] as const)('parses %s → %d', (input, expected) => {
+        expect(parseDuration(input)).toBe(expected)
+    })
+
+    it('rejects unitless strings and junk', () => {
+        expect(parseDuration('1500')).toBeUndefined()
+        expect(parseDuration('fast')).toBeUndefined()
+        expect(parseDuration(undefined)).toBeUndefined()
+        expect(parseDuration(Number.NaN)).toBeUndefined()
+    })
+})
+
+describe('resolveSkeletonDuration', () => {
+    it('parses the token duration to milliseconds', () => {
+        const duration = resolveSkeletonDuration(light)
+        expect(duration).toBeGreaterThan(0)
+        expect(Number.isFinite(duration)).toBe(true)
+    })
+
+    it('falls back when the token is unparseable', () => {
+        const broken = {
+            ...light,
+            animation: { ...light.animation, duration: 'oops' },
+        } as SkeletonTokensType
+        expect(resolveSkeletonDuration(broken)).toBe(SKELETON_FALLBACK_DURATION)
+    })
+})
+
+describe('resolveSkeletonRadius', () => {
+    it('resolves numeric radii for rectangle and rounded', () => {
+        for (const shape of ['rectangle', 'rounded'] as const) {
+            const radius = resolveSkeletonRadius(shape, light)
+            expect(Number.isFinite(radius)).toBe(true)
+            expect(radius).toBeGreaterThanOrEqual(0)
+        }
+    })
+
+    it('circle uses half the smaller numeric dimension', () => {
+        expect(resolveSkeletonRadius('circle', light, 40, 40)).toBe(20)
+        expect(resolveSkeletonRadius('circle', light, 60, 40)).toBe(20)
+    })
+
+    it('circle falls back to a pill radius for unknown sizes', () => {
+        // The CSS token is "50%", which RN cannot express as a radius.
+        expect(resolveSkeletonRadius('circle', light, '100%', 40)).toBe(9999)
+        expect(resolveSkeletonRadius('circle', light)).toBe(9999)
+    })
+})
+
+describe('skeleton theming', () => {
+    it('light and dark base colours differ', () => {
+        expect(String(light.colors.base)).not.toBe(String(dark.colors.base))
+    })
+})

--- a/packages/blend-native/__tests__/theme.test.ts
+++ b/packages/blend-native/__tests__/theme.test.ts
@@ -52,6 +52,7 @@ describe('nativeTokenRegistry', () => {
         expect(NATIVE_TOKEN_SLOTS.slice().sort()).toEqual([
             'ALERTV2',
             'BUTTONV2',
+            'SKELETON',
             'TAGV2',
             'TEXT_INPUTV2',
         ])

--- a/packages/blend-native/__tests__/toastStore.test.ts
+++ b/packages/blend-native/__tests__/toastStore.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+    DEFAULT_TOAST_DURATION,
+    MAX_VISIBLE_TOASTS,
+    dismissToast,
+    getToasts,
+    getVisibleToasts,
+    resetToasts,
+    showToast,
+    subscribeToasts,
+} from '../src/overlay/toast/toastStore'
+
+beforeEach(() => resetToasts())
+
+describe('toast queue', () => {
+    it('appends toasts and returns generated ids', () => {
+        const a = showToast({ content: 'a' })
+        const b = showToast({ content: 'b' })
+        expect(a).not.toBe(b)
+        expect(getToasts().map((t) => t.content)).toEqual(['a', 'b'])
+    })
+
+    it('applies the default duration and honours null (sticky)', () => {
+        showToast({ content: 'a' })
+        showToast({ content: 'b', duration: null })
+        showToast({ content: 'c', duration: 1000 })
+        expect(getToasts().map((t) => t.duration)).toEqual([
+            DEFAULT_TOAST_DURATION,
+            null,
+            1000,
+        ])
+    })
+
+    it('replaces a toast in place when the id is reused', () => {
+        showToast({ id: 'save', content: 'saving' })
+        showToast({ content: 'other' })
+        showToast({ id: 'save', content: 'saved' })
+        expect(getToasts().map((t) => t.content)).toEqual(['saved', 'other'])
+    })
+
+    it('dismisses one by id, or all with no id', () => {
+        const a = showToast({ content: 'a' })
+        showToast({ content: 'b' })
+        dismissToast(a)
+        expect(getToasts().map((t) => t.content)).toEqual(['b'])
+        dismissToast()
+        expect(getToasts()).toEqual([])
+    })
+
+    it('caps the visible slice to the newest MAX_VISIBLE_TOASTS', () => {
+        for (let i = 0; i < MAX_VISIBLE_TOASTS + 2; i++) {
+            showToast({ content: `t${i}` })
+        }
+        const visible = getVisibleToasts()
+        expect(visible).toHaveLength(MAX_VISIBLE_TOASTS)
+        expect(visible[visible.length - 1].content).toBe(
+            `t${MAX_VISIBLE_TOASTS + 1}`
+        )
+    })
+
+    it('notifies subscribers and stops after unsubscribe', () => {
+        const listener = vi.fn()
+        const unsubscribe = subscribeToasts(listener)
+        showToast({ content: 'a' })
+        expect(listener).toHaveBeenCalledTimes(1)
+        unsubscribe()
+        showToast({ content: 'b' })
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+})

--- a/packages/blend-native/package.json
+++ b/packages/blend-native/package.json
@@ -29,6 +29,7 @@
     },
     "scripts": {
         "build": "bob build",
+        "check:peer": "node scripts/check-peer-exports.mjs",
         "clean": "rm -rf lib",
         "lint": "eslint .",
         "prepublishOnly": "bob build",

--- a/packages/blend-native/scripts/check-peer-exports.mjs
+++ b/packages/blend-native/scripts/check-peer-exports.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Release gate: does the declared peer floor actually export what we import?
+ *
+ * `@juspay/blend-native` consumes the web token system through
+ * `@juspay/blend-design-system/node`, and declares which versions it works
+ * with as a peer range. Nothing else checks that claim: the workspace build
+ * always has the newest exports, so CI stays green while the *published*
+ * version a consumer installs may predate them — and the failure surfaces
+ * in their app as an unrelated runtime `undefined`.
+ *
+ * That is not hypothetical. At the time this script was written, blend-native
+ * declared `>=0.0.37` while the published 0.0.37 and 0.0.38-beta.1 were both
+ * missing 17 of the 23 values it imports (BREAKPOINTS, mergeTokenTree, every
+ * component enum, ...). Publishing against that range would have shipped a
+ * package that crashed on first render for every consumer.
+ *
+ * So: resolve the floor version out of the peer range, fetch that exact
+ * version from the registry, and assert every value import resolves. Run it
+ * before publishing (the publish workflow does).
+ *
+ * Usage:
+ *   node scripts/check-peer-exports.mjs            # check the declared floor
+ *   node scripts/check-peer-exports.mjs 0.0.38-beta.2   # check a specific version
+ */
+
+import { execFileSync } from 'node:child_process'
+import {
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    statSync,
+    rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { pathToFileURL } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PKG_ROOT = resolve(HERE, '..')
+const SRC = join(PKG_ROOT, 'src')
+const DEP = '@juspay/blend-design-system'
+const SPECIFIER = `${DEP}/node`
+
+/** Value names imported from the node entry across src/ (types are erased). */
+function collectValueImports() {
+    const used = new Map()
+    const walk = (dir) =>
+        readdirSync(dir).flatMap((name) => {
+            const path = join(dir, name)
+            return statSync(path).isDirectory()
+                ? walk(path)
+                : /\.tsx?$/.test(name)
+                  ? [path]
+                  : []
+        })
+
+    for (const file of walk(SRC)) {
+        const source = readFileSync(file, 'utf8')
+        for (const [, typeOnly, names, spec] of source.matchAll(
+            /import\s+(type\s+)?\{([^}]*)\}\s*from\s*'([^']+)'/g
+        )) {
+            if (spec !== SPECIFIER || typeOnly) continue
+            for (const entry of names.split(',')) {
+                const trimmed = entry.trim()
+                if (!trimmed || trimmed.startsWith('type ')) continue
+                const name = trimmed.split(/\s+as\s+/)[0].trim()
+                const files = used.get(name) ?? []
+                files.push(file.slice(SRC.length + 1))
+                used.set(name, files)
+            }
+        }
+    }
+    return used
+}
+
+/** The lowest version the declared peer range admits. */
+function resolveFloor() {
+    const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8'))
+    const range = pkg.peerDependencies?.[DEP]
+    if (!range) {
+        throw new Error(`No peer dependency on ${DEP} declared.`)
+    }
+    const match = range.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/)
+    if (!match) {
+        throw new Error(
+            `Cannot resolve a floor version from peer range "${range}".`
+        )
+    }
+    return { range, version: match[1] }
+}
+
+const { range, version } = (() => {
+    const explicit = process.argv[2]
+    if (explicit) return { range: `(explicit) ${explicit}`, version: explicit }
+    return resolveFloor()
+})()
+
+console.log(`Peer range:      ${range}`)
+console.log(`Checking against ${DEP}@${version} from the registry\n`)
+
+const work = mkdtempSync(join(tmpdir(), 'blend-peer-'))
+try {
+    execFileSync('npm', ['pack', `${DEP}@${version}`, '--silent'], {
+        cwd: work,
+        stdio: ['ignore', 'ignore', 'inherit'],
+    })
+    const tarball = readdirSync(work).find((f) => f.endsWith('.tgz'))
+    if (!tarball) throw new Error(`npm pack produced no tarball for ${version}`)
+    execFileSync('tar', ['-xzf', tarball], { cwd: work })
+
+    const nodeEntry = join(work, 'package', 'dist', 'node.js')
+    const published = await import(pathToFileURL(nodeEntry).href)
+
+    const used = collectValueImports()
+    const missing = []
+    for (const [name, files] of used) {
+        if (published[name] === undefined) {
+            missing.push({ name, files })
+        }
+    }
+
+    if (missing.length > 0) {
+        console.error(
+            `✖ ${missing.length} of ${used.size} imported values are missing ` +
+                `from the published ${DEP}@${version}:\n`
+        )
+        for (const { name, files } of missing) {
+            console.error(`  ${name}  — used by ${files.join(', ')}`)
+        }
+        console.error(
+            `\nPublishing against this peer floor would crash consumers at runtime.` +
+                `\nFix: publish a ${DEP} version whose lib/node.ts exports these,` +
+                `\nthen raise the peer range in packages/blend-native/package.json.`
+        )
+        process.exit(1)
+    }
+
+    console.log(
+        `✔ all ${used.size} imported values resolve in ${DEP}@${version}`
+    )
+} finally {
+    rmSync(work, { recursive: true, force: true })
+}

--- a/packages/blend-native/src/adapters/cssStringAdapter.ts
+++ b/packages/blend-native/src/adapters/cssStringAdapter.ts
@@ -128,6 +128,27 @@ export function parseSize(
 }
 
 /**
+ * Parse a CSS time value (`"1.5s"`, `"200ms"`, `1500`) into milliseconds.
+ * Returns `undefined` for unparseable input so callers fall back to their
+ * own default duration.
+ *
+ * `parseDuration('1.5s') → 1500`
+ * `parseDuration('200ms') → 200`
+ */
+export function parseDuration(
+    value: string | number | undefined
+): number | undefined {
+    if (value === undefined || value === null) return undefined
+    if (typeof value === 'number')
+        return Number.isFinite(value) ? value : undefined
+    const match = value.trim().match(new RegExp(`^(${NUMBER})(ms|s)$`))
+    if (!match) return undefined
+    const n = parseFloat(match[1])
+    if (Number.isNaN(n)) return undefined
+    return match[2] === 's' ? n * 1000 : n
+}
+
+/**
  * Parse a CSS `border` shorthand (`"1px solid #E1E4EA"`) into RN border props.
  * Returns `{ borderWidth, borderColor }` — the only two border properties RN
  * supports uniformly across iOS/Android.

--- a/packages/blend-native/src/adapters/optionalGradient.ts
+++ b/packages/blend-native/src/adapters/optionalGradient.ts
@@ -1,0 +1,40 @@
+import type React from 'react'
+import type { ViewStyle } from 'react-native'
+
+/**
+ * Optional `expo-linear-gradient` probe, shared by every surface that can
+ * render a gradient (Pressable's gradient buttons, Skeleton's wave sweep).
+ *
+ * The probe must survive every build target this package ships:
+ *
+ * - **Metro (`react-native` condition, raw `src/`)** and the **CJS build**
+ *   (`require`/`default` conditions): `require` exists, the module loads
+ *   when installed, and the `catch` absorbs its absence.
+ * - **The ESM build** (`import` condition): there is no `require` in module
+ *   scope. The `typeof` guard makes the degradation explicit — gradient
+ *   surfaces fall back to a flat fill — instead of relying on a caught
+ *   `ReferenceError`. Bundlers that polyfill `require` in ESM (webpack)
+ *   still resolve the real module.
+ */
+
+export type GradientComponent = React.ComponentType<{
+    colors: readonly string[]
+    locations?: readonly number[]
+    start?: { x: number; y: number }
+    end?: { x: number; y: number }
+    style?: ViewStyle
+}>
+
+export let LinearGradient: GradientComponent | null = null
+try {
+    if (typeof require === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        LinearGradient = (
+            require('expo-linear-gradient') as {
+                LinearGradient: GradientComponent
+            }
+        ).LinearGradient
+    }
+} catch {
+    LinearGradient = null
+}

--- a/packages/blend-native/src/adapters/optionalGradient.ts
+++ b/packages/blend-native/src/adapters/optionalGradient.ts
@@ -25,15 +25,14 @@ export type GradientComponent = React.ComponentType<{
     style?: ViewStyle
 }>
 
+type GradientModule = { LinearGradient: GradientComponent }
+
 export let LinearGradient: GradientComponent | null = null
 try {
     if (typeof require === 'function') {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
-        LinearGradient = (
-            require('expo-linear-gradient') as {
-                LinearGradient: GradientComponent
-            }
-        ).LinearGradient
+        const mod: GradientModule = require('expo-linear-gradient')
+        LinearGradient = mod.LinearGradient
     }
 } catch {
     LinearGradient = null

--- a/packages/blend-native/src/components/Skeleton/Skeleton.tsx
+++ b/packages/blend-native/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,196 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+    StyleSheet,
+    View,
+    type LayoutChangeEvent,
+    type ViewStyle,
+} from 'react-native'
+import Animated, {
+    Easing,
+    cancelAnimation,
+    useAnimatedStyle,
+    useSharedValue,
+    withRepeat,
+    withTiming,
+} from 'react-native-reanimated'
+import type {
+    SkeletonShape,
+    SkeletonTokensType,
+    SkeletonVariant,
+} from '@juspay/blend-design-system/node'
+import { useNativeTokens } from '../../theme/useNativeTokens'
+import { useReduceMotion } from '../../motion/useReduceMotion'
+import { LinearGradient } from '../../adapters/optionalGradient'
+import { parseSize } from '../../adapters/cssStringAdapter'
+import {
+    resolveSkeletonDuration,
+    resolveSkeletonRadius,
+} from './skeleton.utils'
+import type { SkeletonNativeProps } from './skeleton.types'
+
+/**
+ * Skeleton — React Native implementation of web's `Skeleton`, resolving the
+ * same themed `SKELETON` token slot (base/highlight colours, duration).
+ *
+ * Two usages, matching web:
+ *
+ * - **Block**: `<Skeleton width={120} height={16} />` — a placeholder box.
+ * - **Wrap**: `<Skeleton>{content}</Skeleton>` — the content keeps its
+ *   layout but renders invisible, with the skeleton surface painted over
+ *   it. This is what restores the `skeleton` prop parity on Button and Tag.
+ *
+ * Variants: `pulse` animates opacity between highlight and base; `wave` and
+ * `shimmer` sweep a highlight gradient across the box (requiring the
+ * optional `expo-linear-gradient` — absent, they degrade to pulse; web's
+ * `::after` sweep has no other RN expression). OS reduce-motion renders a
+ * static base-coloured box.
+ *
+ * Hidden from assistive tech: a skeleton is a visual placeholder, and the
+ * owning component announces its loading state (the Button/Alert pattern).
+ */
+const SkeletonImpl = ({
+    variant = 'pulse',
+    shape = 'rectangle',
+    width,
+    height,
+    borderRadius,
+    children,
+    style,
+    testID,
+}: SkeletonNativeProps) => {
+    const tokens = useNativeTokens<SkeletonTokensType>('SKELETON')
+    const reduceMotion = useReduceMotion()
+
+    const duration = resolveSkeletonDuration(tokens)
+    const baseColor = String(tokens.colors.base)
+    const highlightColor = String(tokens.colors.highlight)
+
+    const radius =
+        borderRadius ?? resolveSkeletonRadius(shape, tokens, width, height)
+
+    // Sweep needs the measured box; pulse does not.
+    const [measuredWidth, setMeasuredWidth] = useState(0)
+    const onLayout = useCallback((event: LayoutChangeEvent) => {
+        setMeasuredWidth(event.nativeEvent.layout.width)
+    }, [])
+
+    const canSweep =
+        (variant === 'wave' || variant === 'shimmer') &&
+        LinearGradient !== null &&
+        !reduceMotion
+    const pulses = !reduceMotion && !canSweep
+
+    const progress = useSharedValue(0)
+    useEffect(() => {
+        if (reduceMotion) {
+            cancelAnimation(progress)
+            progress.value = 0
+            return
+        }
+        progress.value = 0
+        progress.value = withRepeat(
+            withTiming(1, { duration, easing: Easing.inOut(Easing.ease) }),
+            -1,
+            // Pulse breathes in and out; the sweep restarts from the left.
+            !canSweep
+        )
+        return () => cancelAnimation(progress)
+    }, [progress, duration, reduceMotion, canSweep])
+
+    const pulseStyle = useAnimatedStyle(
+        () => ({
+            opacity: pulses ? 1 - progress.value * 0.5 : 1,
+        }),
+        [pulses]
+    )
+
+    const sweepStyle = useAnimatedStyle(
+        () => ({
+            transform: [
+                {
+                    translateX: canSweep
+                        ? -measuredWidth + progress.value * 2 * measuredWidth
+                        : 0,
+                },
+            ],
+        }),
+        [canSweep, measuredWidth]
+    )
+
+    const boxStyle = useMemo<ViewStyle>(
+        () => ({
+            backgroundColor: baseColor,
+            borderRadius: radius,
+            overflow: 'hidden',
+            ...(children
+                ? null
+                : {
+                      width: parseSize(width) ?? undefined,
+                      height: parseSize(height) ?? undefined,
+                  }),
+        }),
+        [baseColor, radius, children, width, height]
+    )
+
+    const surface = (
+        <Animated.View
+            pointerEvents="none"
+            onLayout={canSweep ? onLayout : undefined}
+            style={[children ? styles.fill : null, boxStyle, pulseStyle]}
+            testID={testID ? `${testID}-surface` : undefined}
+        >
+            {canSweep && measuredWidth > 0 && LinearGradient ? (
+                <Animated.View style={[StyleSheet.absoluteFill, sweepStyle]}>
+                    <LinearGradient
+                        colors={[baseColor, highlightColor, baseColor]}
+                        locations={[0.2, 0.5, 0.8]}
+                        start={{ x: 0, y: 0.5 }}
+                        end={{ x: 1, y: 0.5 }}
+                        style={styles.fill}
+                    />
+                </Animated.View>
+            ) : null}
+        </Animated.View>
+    )
+
+    if (!children) {
+        return (
+            <View
+                testID={testID}
+                style={style}
+                accessible={false}
+                importantForAccessibility="no-hide-descendants"
+                accessibilityElementsHidden
+            >
+                {surface}
+            </View>
+        )
+    }
+
+    return (
+        <View
+            testID={testID}
+            style={style}
+            pointerEvents="none"
+            accessible={false}
+            importantForAccessibility="no-hide-descendants"
+            accessibilityElementsHidden
+        >
+            {/* The content sizes the box but stays invisible. */}
+            <View style={styles.hiddenContent}>{children}</View>
+            {surface}
+        </View>
+    )
+}
+
+export const Skeleton = React.memo(SkeletonImpl)
+Skeleton.displayName = 'Skeleton'
+
+const styles = StyleSheet.create({
+    hiddenContent: { opacity: 0 },
+    fill: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
+})
+
+export default Skeleton
+
+export type { SkeletonShape, SkeletonVariant }

--- a/packages/blend-native/src/components/Skeleton/index.ts
+++ b/packages/blend-native/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton, default } from './Skeleton'
+export type { SkeletonNativeProps } from './skeleton.types'

--- a/packages/blend-native/src/components/Skeleton/skeleton.types.ts
+++ b/packages/blend-native/src/components/Skeleton/skeleton.types.ts
@@ -1,0 +1,28 @@
+import type React from 'react'
+import type { ViewStyle } from 'react-native'
+import type {
+    SkeletonShape,
+    SkeletonVariant,
+} from '@juspay/blend-design-system/node'
+
+/**
+ * Props for the native `Skeleton`.
+ *
+ * Either a placeholder box (`width`/`height`) or a wrapper
+ * (`children` size the box and render invisible underneath the surface).
+ */
+export type SkeletonNativeProps = {
+    /** `pulse` (default) breathes; `wave`/`shimmer` sweep a gradient. */
+    variant?: SkeletonVariant
+    /** Drives the token border radius; `circle` resolves a numeric half. */
+    shape?: SkeletonShape
+    /** Box width for standalone use. Token strings (`"120px"`) accepted. */
+    width?: string | number
+    height?: string | number
+    /** Explicit radius override (wins over `shape`). */
+    borderRadius?: number
+    /** Wrap mode: content keeps its layout, renders invisible. */
+    children?: React.ReactNode
+    style?: ViewStyle
+    testID?: string
+}

--- a/packages/blend-native/src/components/Skeleton/skeleton.utils.ts
+++ b/packages/blend-native/src/components/Skeleton/skeleton.utils.ts
@@ -1,0 +1,56 @@
+import type {
+    SkeletonShape,
+    SkeletonTokensType,
+} from '@juspay/blend-design-system/node'
+import {
+    parseBorderRadius,
+    parseDuration,
+    parseSize,
+} from '../../adapters/cssStringAdapter'
+
+/**
+ * Pure resolution for the native Skeleton — vitest-testable, worklet-free.
+ */
+
+/** Default when the token duration cannot be parsed. */
+export const SKELETON_FALLBACK_DURATION = 1500
+
+/**
+ * Animation cycle length in milliseconds, from the token's CSS duration
+ * string (`"1.5s"`).
+ */
+export function resolveSkeletonDuration(tokens: SkeletonTokensType): number {
+    return (
+        parseDuration(tokens.animation.duration as string | number) ??
+        SKELETON_FALLBACK_DURATION
+    )
+}
+
+/**
+ * Border radius for a shape.
+ *
+ * The `circle` token is CSS `"50%"`, which RN cannot express — a circle
+ * needs a numeric radius of half the box. When the box size is unknown
+ * (string sizes, wrap mode) a large radius produces the same pill/circle
+ * silhouette, the same trick web's `radius.full` relies on.
+ */
+export function resolveSkeletonRadius(
+    shape: SkeletonShape,
+    tokens: SkeletonTokensType,
+    width?: string | number,
+    height?: string | number
+): number {
+    if (shape === 'circle') {
+        const w = typeof width === 'number' ? width : parseSize(String(width))
+        const h =
+            typeof height === 'number' ? height : parseSize(String(height))
+        if (typeof w === 'number' && typeof h === 'number') {
+            return Math.min(w, h) / 2
+        }
+        return 9999
+    }
+    const parsed = parseBorderRadius(
+        tokens.borderRadius[shape] as string | number
+    )
+    return typeof parsed === 'number' ? parsed : 0
+}

--- a/packages/blend-native/src/index.ts
+++ b/packages/blend-native/src/index.ts
@@ -26,6 +26,8 @@ export type {
     TextInputNativeProps,
     TextInputSlot,
 } from './components/TextInput'
+export { Skeleton } from './components/Skeleton'
+export type { SkeletonNativeProps } from './components/Skeleton'
 
 export type {
     AlertNativeProps,
@@ -105,6 +107,11 @@ export { useReduceMotion } from './motion/useReduceMotion'
 // Select/Menu/Modal compose it; also public for consumer-built sheets.
 export { BottomSheet } from './overlay/sheet/BottomSheet'
 export type { BottomSheetProps } from './overlay/sheet/BottomSheet'
+
+// The toast host: the provider mounts the outlet, this pair drives it.
+// SnackbarV2 will layer token styling on top when it lands.
+export { showToast, dismissToast } from './overlay/toast/toastStore'
+export type { ToastOptions } from './overlay/toast/toastStore'
 
 /** Position of a control within a button or tag group. */
 export type { GroupPosition } from './components/shared/group'

--- a/packages/blend-native/src/overlay/safeAreaInsets.ts
+++ b/packages/blend-native/src/overlay/safeAreaInsets.ts
@@ -1,0 +1,36 @@
+import React, { createContext } from 'react'
+
+/**
+ * Optional `react-native-safe-area-context` integration, shared by every
+ * overlay that must respect the home indicator or notch (BottomSheet, the
+ * toast outlet).
+ *
+ * `useContext` needs *a* context unconditionally, so when the optional peer
+ * is absent — or its provider is not mounted — a null-valued fallback
+ * stands in and insets resolve to zero. Same probe pattern as
+ * expo-linear-gradient.
+ */
+
+export type EdgeInsets = {
+    top: number
+    bottom: number
+    left: number
+    right: number
+}
+
+const FallbackInsetsContext = createContext<EdgeInsets | null>(null)
+
+export let SafeAreaInsetsContext: React.Context<EdgeInsets | null> =
+    FallbackInsetsContext
+try {
+    if (typeof require === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const safeArea = require('react-native-safe-area-context') as {
+            SafeAreaInsetsContext?: React.Context<EdgeInsets | null>
+        }
+        SafeAreaInsetsContext =
+            safeArea.SafeAreaInsetsContext ?? FallbackInsetsContext
+    }
+} catch {
+    SafeAreaInsetsContext = FallbackInsetsContext
+}

--- a/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
+++ b/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
@@ -1,10 +1,4 @@
-import React, {
-    createContext,
-    useCallback,
-    useContext,
-    useEffect,
-    useState,
-} from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import {
     BackHandler,
     Pressable,
@@ -24,6 +18,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { Portal } from '../portal'
+import { SafeAreaInsetsContext } from '../safeAreaInsets'
 import { MOTION_DURATION, MOTION_EASING } from '../../motion/motion'
 import { useReduceMotion } from '../../motion/useReduceMotion'
 import {
@@ -81,28 +76,6 @@ export type BottomSheetProps = {
     testID?: string
     /** Style escape hatch for the sheet surface. */
     style?: ViewStyle
-}
-
-// ---- Optional safe-area integration -------------------------------------
-// `useContext` needs *a* context unconditionally, so when the optional peer
-// is absent (or its provider is not mounted) a null-valued fallback stands
-// in. Same probe pattern as expo-linear-gradient in `Pressable`.
-type EdgeInsets = { top: number; bottom: number; left: number; right: number }
-const FallbackInsetsContext = createContext<EdgeInsets | null>(null)
-
-let SafeAreaInsetsContext: React.Context<EdgeInsets | null> =
-    FallbackInsetsContext
-try {
-    if (typeof require === 'function') {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const safeArea = require('react-native-safe-area-context') as {
-            SafeAreaInsetsContext?: React.Context<EdgeInsets | null>
-        }
-        SafeAreaInsetsContext =
-            safeArea.SafeAreaInsetsContext ?? FallbackInsetsContext
-    }
-} catch {
-    SafeAreaInsetsContext = FallbackInsetsContext
 }
 
 const ENTER = {

--- a/packages/blend-native/src/overlay/toast/ToastOutlet.tsx
+++ b/packages/blend-native/src/overlay/toast/ToastOutlet.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useContext, useEffect, useSyncExternalStore } from 'react'
+import { StyleSheet, View } from 'react-native'
+import Animated, {
+    Easing,
+    useAnimatedStyle,
+    useSharedValue,
+    withTiming,
+} from 'react-native-reanimated'
+import { Portal } from '../portal'
+import { SafeAreaInsetsContext } from '../safeAreaInsets'
+import {
+    MOTION_DURATION,
+    MOTION_EASING,
+    MOTION_PRESETS,
+} from '../../motion/motion'
+import { useReduceMotion } from '../../motion/useReduceMotion'
+import { useLiveRegionAnnounce } from '../../a11y/useLiveRegion'
+import {
+    dismissToast,
+    getToasts,
+    getVisibleToasts,
+    subscribeToasts,
+    type ToastEntry,
+} from './toastStore'
+
+/**
+ * The toast rendering surface, mounted once by `BlendNativeProvider`.
+ *
+ * Subscribes to the store and renders the newest `MAX_VISIBLE_TOASTS`
+ * bottom-stacked above everything through a `Portal`. Each toast slides up
+ * on entry (a fade under reduce-motion), owns its auto-dismiss timer, and
+ * announces itself to assistive tech when asked.
+ */
+export function ToastOutlet() {
+    const toasts = useSyncExternalStore(subscribeToasts, getToasts, getToasts)
+    const insets = useContext(SafeAreaInsetsContext)
+
+    const visible = getVisibleToasts(toasts)
+    if (visible.length === 0) return null
+
+    return (
+        <Portal>
+            <View
+                style={[
+                    styles.stack,
+                    { paddingBottom: (insets?.bottom ?? 0) + 16 },
+                ]}
+                pointerEvents="box-none"
+                testID="blend-toast-outlet"
+            >
+                {visible.map((toast) => (
+                    <ToastItem key={toast.id} toast={toast} />
+                ))}
+            </View>
+        </Portal>
+    )
+}
+
+ToastOutlet.displayName = 'ToastOutlet'
+
+function ToastItem({ toast }: { toast: ToastEntry }) {
+    const reduceMotion = useReduceMotion()
+    const progress = useSharedValue(0)
+
+    const dismiss = useCallback(() => dismissToast(toast.id), [toast.id])
+
+    // Enter animation once per toast id.
+    useEffect(() => {
+        progress.value = withTiming(1, {
+            duration: MOTION_PRESETS.slideUp.duration,
+            easing: Easing.bezier(...MOTION_EASING.decelerate),
+        })
+    }, [progress])
+
+    // Auto-dismiss owns its timer; content replacement (same id) restarts it.
+    useEffect(() => {
+        if (toast.duration === null) return
+        const timer = setTimeout(dismiss, toast.duration)
+        return () => clearTimeout(timer)
+    }, [toast.id, toast.duration, toast.content, dismiss])
+
+    useLiveRegionAnnounce(toast.announcement, Boolean(toast.announcement))
+
+    const animatedStyle = useAnimatedStyle(() => {
+        if (reduceMotion) {
+            return { opacity: progress.value, transform: [{ translateY: 0 }] }
+        }
+        return {
+            opacity: progress.value,
+            transform: [
+                {
+                    translateY:
+                        (1 - progress.value) *
+                        (MOTION_PRESETS.slideUp.from.translateY ?? 16),
+                },
+            ],
+        }
+    }, [reduceMotion])
+
+    return (
+        <Animated.View
+            style={animatedStyle}
+            accessibilityLiveRegion={toast.announcement ? 'polite' : 'none'}
+        >
+            {typeof toast.content === 'function'
+                ? toast.content(dismiss)
+                : toast.content}
+        </Animated.View>
+    )
+}
+
+/** Exit duration is not modelled yet — dismissal unmounts immediately;
+ * SnackbarV2 will own richer exit choreography when it lands. Kept simple
+ * so the host stays predictable under the synchronous test mock. */
+export const TOAST_EXIT_DURATION = MOTION_DURATION.fast
+
+const styles = StyleSheet.create({
+    stack: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        alignItems: 'center',
+        gap: 8,
+        paddingHorizontal: 16,
+    },
+})

--- a/packages/blend-native/src/overlay/toast/toastStore.ts
+++ b/packages/blend-native/src/overlay/toast/toastStore.ts
@@ -1,0 +1,96 @@
+import type React from 'react'
+
+/**
+ * Toast queue — the sonner role, minus the styling.
+ *
+ * A module-level store with an imperative `showToast`/`dismissToast` API,
+ * so any code (not just components) can raise a toast; the outlet the
+ * provider mounts subscribes and renders. SnackbarV2 will layer its token
+ * styling on top of this host; the host itself owns only queueing,
+ * stacking, timing, and announcements.
+ *
+ * RN-free (a `React.ReactNode` type is the only React surface) so queue
+ * semantics unit-test under vitest.
+ */
+
+export type ToastOptions = {
+    /** Reusing an id replaces that toast's content in place. */
+    id?: string
+    /** The rendered toast; a function receives its own dismiss. */
+    content: React.ReactNode | ((dismiss: () => void) => React.ReactNode)
+    /** Auto-dismiss delay in ms; `null` keeps the toast until dismissed. */
+    duration?: number | null
+    /** Spoken to assistive tech when the toast appears. */
+    announcement?: string
+}
+
+export type ToastEntry = Required<Pick<ToastOptions, 'content'>> & {
+    id: string
+    duration: number | null
+    announcement?: string
+}
+
+/** How many toasts render at once; older ones wait in the queue. */
+export const MAX_VISIBLE_TOASTS = 3
+
+/** Default auto-dismiss delay, matching sonner's. */
+export const DEFAULT_TOAST_DURATION = 4000
+
+type Listener = (toasts: readonly ToastEntry[]) => void
+
+let toasts: ToastEntry[] = []
+const listeners = new Set<Listener>()
+let counter = 0
+
+function emit() {
+    for (const listener of listeners) listener(toasts)
+}
+
+/** Raise a toast; returns its id. */
+export function showToast(options: ToastOptions): string {
+    const id = options.id ?? `blend-toast-${++counter}`
+    const entry: ToastEntry = {
+        id,
+        content: options.content,
+        duration:
+            options.duration === null
+                ? null
+                : (options.duration ?? DEFAULT_TOAST_DURATION),
+        announcement: options.announcement,
+    }
+    const existing = toasts.findIndex((t) => t.id === id)
+    toasts =
+        existing === -1
+            ? [...toasts, entry]
+            : toasts.map((t, i) => (i === existing ? entry : t))
+    emit()
+    return id
+}
+
+/** Dismiss one toast, or every toast when no id is given. */
+export function dismissToast(id?: string): void {
+    toasts = id === undefined ? [] : toasts.filter((t) => t.id !== id)
+    emit()
+}
+
+export function getToasts(): readonly ToastEntry[] {
+    return toasts
+}
+
+/** The slice the outlet renders: the newest MAX_VISIBLE. */
+export function getVisibleToasts(
+    all: readonly ToastEntry[] = toasts
+): readonly ToastEntry[] {
+    return all.slice(-MAX_VISIBLE_TOASTS)
+}
+
+export function subscribeToasts(listener: Listener): () => void {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+}
+
+/** Test hook — clears the queue without notifying. */
+export function resetToasts(): void {
+    toasts = []
+    counter = 0
+}

--- a/packages/blend-native/src/primitives/Pressable.tsx
+++ b/packages/blend-native/src/primitives/Pressable.tsx
@@ -20,6 +20,10 @@ import {
     type SurfaceStyleProps,
 } from '../adapters/surfaceStyle'
 import {
+    LinearGradient,
+    type GradientComponent,
+} from '../adapters/optionalGradient'
+import {
     MIN_TOUCH_TARGET,
     resolveHitSlop,
     sameHitSlop,
@@ -46,44 +50,12 @@ export { MIN_TOUCH_TARGET }
  */
 
 /**
- * `expo-linear-gradient` is an **optional** peer.
- *
- * Requiring it outright would mean every consumer must adopt Expo modules
- * just to render a gradient variant. When it is absent the surface falls back
- * to the gradient's first colour, which `resolveSurfaceStyle` already
- * supplies as `backgroundColor` — so a gradient button degrades to a solid
- * one rather than rendering transparent.
+ * `expo-linear-gradient` is an **optional** peer (probe shared with
+ * Skeleton in `adapters/optionalGradient`). When it is absent the surface
+ * falls back to the gradient's first colour, which `resolveSurfaceStyle`
+ * already supplies as `backgroundColor` — so a gradient button degrades to
+ * a solid one rather than rendering transparent.
  */
-type GradientComponent = React.ComponentType<{
-    colors: readonly string[]
-    locations?: readonly number[]
-    start?: { x: number; y: number }
-    end?: { x: number; y: number }
-    style?: ViewStyle
-}>
-
-/**
- * The probe must survive every build target this package ships:
- *
- * - **Metro (`react-native` condition, raw `src/`)** and the **CJS build**
- *   (`require`/`default` conditions): `require` exists, the module loads when
- *   installed, and the `catch` absorbs its absence.
- * - **The ESM build** (`import` condition): there is no `require` in module
- *   scope. The `typeof` guard makes the degradation explicit — gradients fall
- *   back to the first-stop flat fill `resolveSurfaceStyle` already supplies —
- *   instead of relying on a caught `ReferenceError`. Bundlers that polyfill
- *   `require` in ESM (webpack) still resolve the real module.
- */
-let LinearGradient: GradientComponent | null = null
-try {
-    if (typeof require === 'function') {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        LinearGradient = require('expo-linear-gradient')
-            .LinearGradient as GradientComponent
-    }
-} catch {
-    LinearGradient = null
-}
 
 /**
  * Note this extends `SurfaceStyleProps`, exactly as `BlockProps` does.

--- a/packages/blend-native/src/theme/BlendNativeProvider.tsx
+++ b/packages/blend-native/src/theme/BlendNativeProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from '@juspay/blend-design-system/node'
 import type { NativeComponentTokenOverrides } from './nativeTokenRegistry'
 import { PortalArea } from '../overlay/portal'
+import { ToastOutlet } from '../overlay/toast/ToastOutlet'
 import {
     resolveFontFamilies,
     type NativeFontFamilies,
@@ -128,8 +129,13 @@ export function BlendNativeProvider({
         <BlendNativeThemeContext.Provider value={value}>
             {/* Portal layers render after (above) the app's children — mount
                 the provider at a screen-filling root so overlays cover the
-                screen. See overlay/portal.tsx. */}
-            <PortalArea>{children}</PortalArea>
+                screen. See overlay/portal.tsx. The toast outlet subscribes
+                to the imperative showToast queue and renders nothing while
+                it is empty. */}
+            <PortalArea>
+                {children}
+                <ToastOutlet />
+            </PortalArea>
         </BlendNativeThemeContext.Provider>
     )
 }

--- a/packages/blend-native/src/theme/nativeTokenRegistry.ts
+++ b/packages/blend-native/src/theme/nativeTokenRegistry.ts
@@ -3,6 +3,7 @@ import {
     Theme,
     getAlertV2Tokens,
     getButtonV2Tokens,
+    getSkeletonTokens,
     getTagV2Tokens,
     getTextInputV2Tokens,
     type BreakpointType,
@@ -25,6 +26,7 @@ import {
 export const NATIVE_TOKEN_REGISTRY = {
     ALERTV2: getAlertV2Tokens,
     BUTTONV2: getButtonV2Tokens,
+    SKELETON: getSkeletonTokens,
     TAGV2: getTagV2Tokens,
     TEXT_INPUTV2: getTextInputV2Tokens,
 } as const

--- a/packages/blend/lib/node.ts
+++ b/packages/blend/lib/node.ts
@@ -63,6 +63,13 @@ export type {
 } from './components/InputsV2/TextInputV2/TextInputV2.tokens.types'
 export { getUploadV2Tokens } from './components/InputsV2/UploadV2/UploadV2.tokens'
 
+export { getSkeletonTokens } from './components/Skeleton/skeleton.tokens'
+export type {
+    SkeletonTokensType,
+    ResponsiveSkeletonTokens,
+    SkeletonVariant,
+    SkeletonShape,
+} from './components/Skeleton/skeleton.tokens.types'
 export { getTimelineTokens } from './components/Timeline/timeline.token'
 export { getTopbarTokens } from './components/Topbar/topbar.tokens'
 export { getSidebarTokens } from './components/Sidebar/sidebar.tokens'


### PR DESCRIPTION
## Summary

**Stacked on #1715** (phase 2c). The final Phase 2 foundations — the loading-state layer.

### Skeleton
Resolves the same themed `SKELETON` token slot as web (factory + types newly exported from `lib/node.ts`), in both web usages:
- **Block**: `<Skeleton width={120} height={16} />`
- **Wrap**: `<Skeleton>{content}</Skeleton>` — content keeps its layout but renders invisible under the surface. This is the piece that will restore the `skeleton` prop Button and Tag currently `Omit`.

`pulse` breathes on Reanimated; `wave`/`shimmer` sweep a token-highlight gradient through the shared optional `expo-linear-gradient` probe and **degrade to pulse without it** (web's `::after` sweep has no other RN expression); OS reduce-motion freezes to the static base colour. Hidden from assistive tech — the owning component announces loading, per the existing Button/Alert pattern. The CSS `"50%"` circle radius resolves to a numeric half (or a pill fallback), since RN has no percentage radii.

### Toast host
The sonner role minus the styling — SnackbarV2 layers token chrome on top when it lands:
- Imperative `showToast`/`dismissToast` module store (callable outside components), with replace-by-id, timed and sticky (`duration: null`) dismissal, and a newest-three visible cap
- `BlendNativeProvider` mounts the outlet automatically; it renders nothing while the queue is empty, and stacks toasts above everything through a `Portal` with safe-area bottom padding
- Function content receives its own `dismiss` (undo patterns); optional `announcement` speaks through the live-region pattern

### Shared extractions
`optionalGradient` (Pressable + Skeleton) and `safeAreaInsets` (BottomSheet + toasts) probes deduplicated; `parseDuration` joins the CSS adapters for the token animation duration.

## Test plan
- vitest: toast queue semantics (7 cases), skeleton duration/radius resolution + `parseDuration`, registry updated — 21 files green
- jest: Skeleton block/wrap AT posture + 6 toast lifecycle tests under fake timers (show, auto-dismiss, sticky, replace, dismiss-from-content, cap) — 51 tests green
- typecheck (both packages), lint, all three bob targets green
- native-site gains a **Loading** tab with the on-device checklist (sweep, reduce-motion, wrap sizing, toast stacking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS