### PR TITLE
chore(blend-native): raise the peer floor to 0.0.38-beta.2

### DIFF
--- a/packages/blend-native/README.md
+++ b/packages/blend-native/README.md
@@ -188,12 +188,12 @@ pnpm add expo-linear-gradient
 
 ### Peer dependencies
 
-| Package                       | Version    | Required                                          |
-| ----------------------------- | ---------- | ------------------------------------------------- |
-| `@juspay/blend-design-system` | `>=0.0.37` | yes                                               |
-| `react`                       | `>=18.2.0` | yes                                               |
-| `react-native`                | `>=0.74.0` | yes                                               |
-| `expo-linear-gradient`        | `>=15.0.0` | **optional** — gradients fall back to a flat fill |
+| Package                       | Version           | Required                                          |
+| ----------------------------- | ----------------- | ------------------------------------------------- |
+| `@juspay/blend-design-system` | `>=0.0.38-beta.2` | yes                                               |
+| `react`                       | `>=18.2.0`        | yes                                               |
+| `react-native`                | `>=0.74.0`        | yes                                               |
+| `expo-linear-gradient`        | `>=15.0.0`        | **optional** — gradients fall back to a flat fill |
 
 ## Usage
 

--- a/packages/blend-native/package.json
+++ b/packages/blend-native/package.json
@@ -40,7 +40,7 @@
         "typecheck": "tsc --noEmit"
     },
     "peerDependencies": {
-        "@juspay/blend-design-system": ">=0.0.37",
+        "@juspay/blend-design-system": ">=0.0.38-beta.2",
         "expo-linear-gradient": ">=15.0.0",
         "lucide-react-native": ">=1.0.0",
         "react": ">=18.2.0",


### PR DESCRIPTION
## Summary

Step 4 of the native publish plan. `@juspay/blend-design-system@0.0.38-beta.2` is now on npm carrying the `/node` exports blend-native needs, so the declared peer floor is raised to match reality.

Before this, the declared `>=0.0.37` was a false claim: both published versions (`0.0.37`, `0.0.38-beta.1`) were missing **17 of the 23** values blend-native imports — `BREAKPOINTS`, `mergeTokenTree`, every component enum, `getSkeletonTokens`, the input enums. Installing against them crashes on first render.

## Verification

```
$ pnpm --filter @juspay/blend-native check:peer
Peer range:      >=0.0.38-beta.2
Checking against @juspay/blend-design-system@0.0.38-beta.2 from the registry

✔ all 23 imported values resolve in @juspay/blend-design-system@0.0.38-beta.2
```

Also green: typecheck, 21 vitest files / 51 jest render tests, all three bob build targets. The README peer table is updated (Prettier realigned the column widths).

## What this unblocks

The first publish of `@juspay/blend-native@0.0.1-beta.0` via **Publish Native to NPM** from `dev`, `dist_tag: beta`.

**Note on trusted publishing:** the repo moved the web package to OIDC in #1721, but [npm cannot use OIDC for a package's first publish](https://docs.npmjs.com/trusted-publishers/) — a trusted publisher can only be added to a package that already exists. So this first native release uses the existing `NPM_TOKEN` path (still present in the `npm` environment), after which the native workflow can migrate to OIDC like the web one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS