### PR TITLE
chore(blend-native): rename the package to unscoped blend-native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,17 +143,17 @@ jobs:
 
             - name: Lint and typecheck
               run: |
-                  pnpm --filter @juspay/blend-native lint
-                  pnpm --filter @juspay/blend-native typecheck
+                  pnpm --filter blend-native lint
+                  pnpm --filter blend-native typecheck
                   pnpm --filter native-site typecheck
 
             - name: Run tests (vitest + jest)
-              run: pnpm --filter @juspay/blend-native test
+              run: pnpm --filter blend-native test
               env:
                   CI: true
 
             - name: Build package
-              run: pnpm --filter @juspay/blend-native build
+              run: pnpm --filter blend-native build
 
     preview:
         name: Publish preview to pkg.pr.new
@@ -184,8 +184,8 @@ jobs:
 
             # pkg-pr-new packs without running prepublishOnly, so build
             # blend-native's lib/ output explicitly first.
-            - name: Build @juspay/blend-native
-              run: pnpm --filter @juspay/blend-native build
+            - name: Build blend-native
+              run: pnpm --filter blend-native build
 
             - name: Publish preview
               run: pnpm dlx pkg-pr-new publish --pnpm './packages/blend' './packages/blend-native'

--- a/.github/workflows/publish-native-npm.yml
+++ b/.github/workflows/publish-native-npm.yml
@@ -1,6 +1,6 @@
 name: Publish Native to NPM
 
-# Publishes @juspay/blend-native on its own version line, independent of
+# Publishes blend-native on its own version line, independent of
 # @juspay/blend-design-system (compatibility is declared through the peer
 # range instead). Beta publishes run from dev or staging; stable from main.
 
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
     publish-native:
-        name: Publish @juspay/blend-native
+        name: Publish blend-native
         runs-on: ubuntu-latest
         environment: npm
         if: github.event.inputs.confirm_publish == 'PUBLISH'
@@ -89,9 +89,9 @@ jobs:
               id: check_published
               run: |
                   VERSION="${{ steps.version.outputs.version }}"
-                  if npm view "@juspay/blend-native@$VERSION" version 2>/dev/null >/dev/null; then
+                  if npm view "blend-native@$VERSION" version 2>/dev/null >/dev/null; then
                     echo "already_published=true" >> $GITHUB_OUTPUT
-                    echo "⚠️ @juspay/blend-native@$VERSION already exists on NPM — skipping"
+                    echo "⚠️ blend-native@$VERSION already exists on NPM — skipping"
                   else
                     echo "already_published=false" >> $GITHUB_OUTPUT
                     echo "✅ Version $VERSION is not yet published"
@@ -108,9 +108,9 @@ jobs:
             - name: Lint, typecheck and test
               if: steps.check_published.outputs.already_published != 'true'
               run: |
-                  pnpm --filter @juspay/blend-native lint
-                  pnpm --filter @juspay/blend-native typecheck
-                  pnpm --filter @juspay/blend-native test
+                  pnpm --filter blend-native lint
+                  pnpm --filter blend-native typecheck
+                  pnpm --filter blend-native test
               env:
                   CI: true
 
@@ -121,11 +121,11 @@ jobs:
             # ship a package that crashes on first render.
             - name: Verify the peer floor exports what we import
               if: steps.check_published.outputs.already_published != 'true'
-              run: pnpm --filter @juspay/blend-native check:peer
+              run: pnpm --filter blend-native check:peer
 
-            - name: Build @juspay/blend-native
+            - name: Build blend-native
               if: steps.check_published.outputs.already_published != 'true'
-              run: pnpm --filter @juspay/blend-native build
+              run: pnpm --filter blend-native build
 
             - name: Publish to NPM
               if: steps.check_published.outputs.already_published != 'true'
@@ -141,16 +141,16 @@ jobs:
                   VERSION="${{ steps.version.outputs.version }}"
                   TAG="${{ github.event.inputs.dist_tag }}"
                   sleep 10  # NPM propagation
-                  PUBLISHED=$(npm view "@juspay/blend-native@$TAG" version 2>/dev/null || echo "")
+                  PUBLISHED=$(npm view "blend-native@$TAG" version 2>/dev/null || echo "")
                   if [[ "$PUBLISHED" == "$VERSION" ]]; then
-                    echo "✅ @juspay/blend-native@$VERSION is live under dist-tag $TAG"
+                    echo "✅ blend-native@$VERSION is live under dist-tag $TAG"
                   else
                     echo "⚠️ Expected $VERSION but NPM shows '$PUBLISHED' for tag $TAG (may be propagation delay)"
                   fi
-                  echo "## 🎉 @juspay/blend-native published" >> $GITHUB_STEP_SUMMARY
+                  echo "## 🎉 blend-native published" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Version**: \`$VERSION\` · **Tag**: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo '```bash' >> $GITHUB_STEP_SUMMARY
-                  echo "npm install @juspay/blend-native@$TAG" >> $GITHUB_STEP_SUMMARY
+                  echo "npm install blend-native@$TAG" >> $GITHUB_STEP_SUMMARY
                   echo '```' >> $GITHUB_STEP_SUMMARY

--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -9,7 +9,7 @@ import {
     View,
 } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
-import { BlendNativeProvider, Theme } from '@juspay/blend-native'
+import { BlendNativeProvider, Theme } from 'blend-native'
 import ButtonShowcase from './components/ButtonShowcase'
 import TagShowcase from './components/TagShowcase'
 import AlertShowcase from './components/AlertShowcase'

--- a/apps/native-site/README.md
+++ b/apps/native-site/README.md
@@ -1,6 +1,6 @@
 # Blend Native Site
 
-Expo demo app for [`@juspay/blend-native`](../../packages/blend-native).
+Expo demo app for [`blend-native`](../../packages/blend-native).
 
 It renders every variant of every shipped native component so they can be
 checked against the web originals: **Alert**, **Tag** and **Button**, each with
@@ -21,7 +21,7 @@ cd apps/native-site
 pnpm start                  # then press i / a / w
 ```
 
-`pnpm build:blend` is not optional. `@juspay/blend-native` imports tokens from
+`pnpm build:blend` is not optional. `blend-native` imports tokens from
 `@juspay/blend-design-system/node`, which resolves to that package's **built**
 `dist/`. If you have just changed `packages/blend/lib/node.ts`, the new exports
 are missing until you rebuild, and the failure looks like an unrelated
@@ -128,7 +128,7 @@ these shipped green on the browser target and was broken on a device:
 
 The unit suites could not catch any of them: they verify a resolved style
 object, not what reached the screen. Render tests (`pnpm --filter
-@juspay/blend-native test:render`) now cover behaviour and accessibility, but
+blend-native test:render`) now cover behaviour and accessibility, but
 **visual correctness still needs eyes on a device.**
 
 ## Folder structure
@@ -166,7 +166,7 @@ exist.
 **`Project is incompatible with this version of Expo Go`**
 See [Android — Expo Go will probably not work](#android--expo-go-will-probably-not-work). Build with `npx expo run:android`.
 
-**Metro can't find `@juspay/blend-native`**
+**Metro can't find `blend-native`**
 Run `pnpm install` from the repo root to link workspace packages, then
 `pnpm start --clear` to drop Metro's cache.
 
@@ -188,6 +188,6 @@ gradients fall back to their first colour. Install it, and check
 `parseBackground` in `cssStringAdapter.ts` is parsing the token.
 
 **TypeScript errors in `blend-native` source**
-Type-check the package on its own: `pnpm --filter @juspay/blend-native typecheck`.
+Type-check the package on its own: `pnpm --filter blend-native typecheck`.
 This app's `tsconfig.json` extends `expo/tsconfig.base`, which has different
 strictness settings.

--- a/apps/native-site/components/AlertShowcase.tsx
+++ b/apps/native-site/components/AlertShowcase.tsx
@@ -4,7 +4,7 @@ import {
     AlertActionPosition,
     AlertSubType,
     AlertType,
-} from '@juspay/blend-native'
+} from 'blend-native'
 import { Info, TriangleAlert } from 'lucide-react-native'
 
 /**

--- a/apps/native-site/components/ButtonShowcase.tsx
+++ b/apps/native-site/components/ButtonShowcase.tsx
@@ -1,10 +1,5 @@
 import { View, StyleSheet, Text as RNText } from 'react-native'
-import {
-    Button,
-    ButtonType,
-    ButtonSize,
-    ButtonSubType,
-} from '@juspay/blend-native'
+import { Button, ButtonType, ButtonSize, ButtonSubType } from 'blend-native'
 
 function Section({
     title,

--- a/apps/native-site/components/InputShowcase.tsx
+++ b/apps/native-site/components/InputShowcase.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { StyleSheet, Text as RNText, View } from 'react-native'
 import { Search, Eye } from 'lucide-react-native'
-import { InputSize, TextInput } from '@juspay/blend-native'
+import { InputSize, TextInput } from 'blend-native'
 
 /**
  * TextInput verification. On device, check:

--- a/apps/native-site/components/LoadingShowcase.tsx
+++ b/apps/native-site/components/LoadingShowcase.tsx
@@ -8,7 +8,7 @@ import {
     Tag,
     TagColor,
     TagType,
-} from '@juspay/blend-native'
+} from 'blend-native'
 
 /**
  * Skeleton + toast verification. On device, check:

--- a/apps/native-site/components/SheetShowcase.tsx
+++ b/apps/native-site/components/SheetShowcase.tsx
@@ -7,7 +7,7 @@ import {
     Tag,
     TagColor,
     TagType,
-} from '@juspay/blend-native'
+} from 'blend-native'
 
 /**
  * BottomSheet verification: open/dismiss via drag, backdrop, and the

--- a/apps/native-site/components/TagShowcase.tsx
+++ b/apps/native-site/components/TagShowcase.tsx
@@ -1,12 +1,6 @@
 import { View, Text as RNText, StyleSheet } from 'react-native'
 import { Circle } from 'lucide-react-native'
-import {
-    Tag,
-    TagColor,
-    TagSize,
-    TagSubType,
-    TagType,
-} from '@juspay/blend-native'
+import { Tag, TagColor, TagSize, TagSubType, TagType } from 'blend-native'
 
 /**
  * Visual parity harness for the native `Tag`.

--- a/apps/native-site/metro.config.js
+++ b/apps/native-site/metro.config.js
@@ -5,7 +5,7 @@ const path = require('path')
 const config = getDefaultConfig(__dirname)
 
 // pnpm uses symlinks for workspace dependencies. Metro needs to follow those
-// symlinks into the workspace packages so `@juspay/blend-native` and
+// symlinks into the workspace packages so `blend-native` and
 // `@juspay/blend-design-system` source is transpiled directly.
 config.watchFolders = [
     path.resolve(__dirname, '../../packages/blend-native'),

--- a/apps/native-site/package.json
+++ b/apps/native-site/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@expo/metro-runtime": "~56.0.20",
         "@juspay/blend-design-system": "workspace:*",
-        "@juspay/blend-native": "workspace:*",
+        "blend-native": "workspace:*",
         "expo": "~56.0.12",
         "expo-linear-gradient": "~56.0.4",
         "lucide-react-native": "^1.33.0",

--- a/apps/native-site/tsconfig.json
+++ b/apps/native-site/tsconfig.json
@@ -4,9 +4,7 @@
         "strict": true,
         "moduleSuffixes": ["", ".native"],
         "paths": {
-            "@juspay/blend-native": [
-                "../../packages/blend-native/src/index.ts"
-            ],
+            "blend-native": ["../../packages/blend-native/src/index.ts"],
             "@juspay/blend-design-system/node": [
                 "../../packages/blend/lib/node.ts"
             ]

--- a/packages/blend-native/README.md
+++ b/packages/blend-native/README.md
@@ -1,4 +1,4 @@
-# @juspay/blend-native
+# blend-native
 
 React Native components for the [Blend Design System](https://github.com/juspay/blend-design-system).
 
@@ -69,7 +69,7 @@ RN Pressable (+ LinearGradient when the background is a gradient)
 Theme and per-slot token overrides come from context, mirroring web's `ThemeProvider`:
 
 ```tsx
-import { BlendNativeProvider, Theme } from '@juspay/blend-native'
+import { BlendNativeProvider, Theme } from 'blend-native'
 ;<BlendNativeProvider
     theme={Theme.DARK}
     componentTokens={{
@@ -181,7 +181,7 @@ Files are named plainly. `.native.tsx` / `.ios.tsx` / `.web.tsx` are Metro **res
 ## Installation
 
 ```bash
-pnpm add @juspay/blend-native @juspay/blend-design-system react react-native
+pnpm add blend-native @juspay/blend-design-system react react-native
 # only if you use gradient variants (Button primary):
 pnpm add expo-linear-gradient
 ```
@@ -205,7 +205,7 @@ import {
     Tag,
     TagType,
     TagColor,
-} from '@juspay/blend-native'
+} from 'blend-native'
 
 function Example() {
     return (
@@ -276,9 +276,9 @@ Plus any `PressableProps` (`onLongPress`, `onPressIn`, `hitSlop`, `accessibility
 ## Development
 
 ```bash
-pnpm --filter @juspay/blend-native typecheck
-pnpm --filter @juspay/blend-native lint
-pnpm --filter @juspay/blend-native test
+pnpm --filter blend-native typecheck
+pnpm --filter blend-native lint
+pnpm --filter blend-native test
 ```
 
 `@juspay/blend-design-system/node` resolves to the workspace package, which serves built `dist/`. Run `pnpm build:blend` after changing `packages/blend/lib/node.ts`, or the new exports will be missing at runtime.
@@ -308,12 +308,12 @@ receive. Before a release, smoke-test the publish artifact itself:
 
 ```bash
 # 1. Build and pack — the tarball is byte-for-byte what npm publish uploads
-pnpm --filter @juspay/blend-native build
-pnpm --filter @juspay/blend-native pack --pack-destination /tmp
+pnpm --filter blend-native build
+pnpm --filter blend-native pack --pack-destination /tmp
 
 # 2. Point native-site at the tarball instead of the workspace:
-#    - apps/native-site/package.json: "@juspay/blend-native": "file:/tmp/juspay-blend-native-<version>.tgz"
-#    - apps/native-site/tsconfig.json: REMOVE the "@juspay/blend-native" paths entry
+#    - apps/native-site/package.json: "blend-native": "file:/tmp/juspay-blend-native-<version>.tgz"
+#    - apps/native-site/tsconfig.json: REMOVE the "blend-native" paths entry
 pnpm install --filter native-site
 
 # 3. Consumer checks
@@ -330,7 +330,7 @@ module graph (Reanimated worklets, gesture handler, portals) compiles.
 
 ## Publishing
 
-`@juspay/blend-native` versions **independently** of
+`blend-native` versions **independently** of
 `@juspay/blend-design-system`; compatibility is declared through the peer
 range. Publishing runs through the **Publish Native to NPM** workflow
 (`.github/workflows/publish-native-npm.yml`), which gates on branch,
@@ -348,7 +348,7 @@ version containing it is on npm, publishing native ships a package that
 crashes on first render with an unrelated `undefined`.
 
 ```bash
-pnpm --filter @juspay/blend-native check:peer
+pnpm --filter blend-native check:peer
 ```
 
 resolves the floor version out of the declared peer range, fetches that
@@ -370,7 +370,7 @@ fails, the fix is always the same order:
    `dev`** (or `staging`), `dist_tag: beta`, type `PUBLISH` to confirm.
 3. The workflow refuses a non-beta version, an already-published version,
    or a red check; on success it verifies the tag on the registry.
-4. Consumers install with `npm install @juspay/blend-native@beta`.
+4. Consumers install with `npm install blend-native@beta`.
 
 ### Stable
 
@@ -378,7 +378,7 @@ fails, the fix is always the same order:
    `main` through the usual `dev → staging → main` train.
 2. Run the same workflow **from `main`**, `dist_tag: latest`, confirm
    `PUBLISH`. The workflow refuses `latest` from any other branch.
-3. Consumers on `npm install @juspay/blend-native` now get this version.
+3. Consumers on `npm install blend-native` now get this version.
 
 Iterating a beta: bump to `-beta.N+1`, merge, run the workflow again — the
 already-published gate makes re-running for a published version a no-op.

--- a/packages/blend-native/package.json
+++ b/packages/blend-native/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@juspay/blend-native",
+    "name": "blend-native",
     "version": "0.0.1-beta.0",
     "description": "React Native components for Blend Design System",
     "type": "module",

--- a/packages/blend-native/src/index.ts
+++ b/packages/blend-native/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @juspay/blend-native — React Native components for Blend Design System.
+ * blend-native — React Native components for Blend Design System.
  *
  * Consumes Blend's token system via the React-free
  * `@juspay/blend-design-system/node` entry and translates CSS-string token

--- a/packages/blend-native/src/theme/BlendNativeProvider.tsx
+++ b/packages/blend-native/src/theme/BlendNativeProvider.tsx
@@ -21,7 +21,7 @@ import {
 } from './systemTheme'
 
 /**
- * Theme context for `@juspay/blend-native`.
+ * Theme context for `blend-native`.
  *
  * Replaces the per-component `theme` prop the package shipped with. A prop
  * meant no app-wide dark mode (every call site had to thread it), no nested

--- a/packages/blend-native/vitest.config.ts
+++ b/packages/blend-native/vitest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config'
 
 /**
- * Test config for `@juspay/blend-native`.
+ * Test config for `blend-native`.
  *
  * These suites cover the package's **pure** layer: the CSS-string adapters,
  * the surface-style resolver, the per-component style/utility functions, and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,7 +440,7 @@ importers:
             '@juspay/blend-design-system':
                 specifier: workspace:*
                 version: link:../../packages/blend
-            '@juspay/blend-native':
+            blend-native:
                 specifier: workspace:*
                 version: link:../../packages/blend-native
             expo:
@@ -22982,7 +22982,6 @@ snapshots:
             - supports-color
             - typescript
             - utf-8-validate
-        optional: true
 
     '@expo/code-signing-certificates@0.0.6':
         dependencies:
@@ -23080,7 +23079,6 @@ snapshots:
         optionalDependencies:
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
-        optional: true
 
     '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
@@ -23093,7 +23091,6 @@ snapshots:
             expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
-        optional: true
 
     '@expo/env@2.3.1':
         dependencies:
@@ -23212,7 +23209,6 @@ snapshots:
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
             stacktrace-parser: 0.1.11
-        optional: true
 
     '@expo/metro-config@56.0.18(expo@56.0.20)(typescript@5.8.3)':
         dependencies:
@@ -23437,7 +23433,6 @@ snapshots:
             react-dom: 19.2.3(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
-        optional: true
 
     '@expo/schema-utils@56.0.2': {}
 
@@ -25942,9 +25937,7 @@ snapshots:
             metro-runtime: 0.84.5
         transitivePeerDependencies:
             - '@babel/core'
-            - bufferutil
             - supports-color
-            - utf-8-validate
 
     '@react-native/normalize-colors@0.74.89': {}
 
@@ -25967,7 +25960,6 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optionalDependencies:
             '@types/react': 19.2.7
-        optional: true
 
     '@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)':
         dependencies:
@@ -28451,7 +28443,7 @@ snapshots:
             react-refresh: 0.14.2
         optionalDependencies:
             '@babel/runtime': 7.28.4
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
         transitivePeerDependencies:
             - '@babel/core'
             - supports-color
@@ -29994,7 +29986,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
             - typescript
-        optional: true
 
     expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30011,7 +30002,6 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
-        optional: true
 
     expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30022,7 +30012,6 @@ snapshots:
         dependencies:
             expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
-        optional: true
 
     expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
@@ -30037,11 +30026,10 @@ snapshots:
             fontfaceobserver: 2.3.0
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
-        optional: true
 
     expo-keep-awake@56.0.3(expo@56.0.20)(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
 
     expo-linear-gradient@15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
@@ -30095,7 +30083,6 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optionalDependencies:
             react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
-        optional: true
 
     expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30104,7 +30091,6 @@ snapshots:
     expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)):
         dependencies:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
-        optional: true
 
     expo-server@56.0.6: {}
 
@@ -30233,7 +30219,6 @@ snapshots:
             - supports-color
             - typescript
             - utf-8-validate
-        optional: true
 
     exponential-backoff@3.1.3: {}
 
@@ -34784,7 +34769,6 @@ snapshots:
             - bufferutil
             - supports-color
             - utf-8-validate
-        optional: true
 
     react-phone-input-2@2.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
         dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
             "dependsOn": ["^lint"]
         },
         "typecheck": {},
-        "@juspay/blend-native#test": {
+        "blend-native#test": {
             "dependsOn": ["@juspay/blend-design-system#build"]
         },
         "dev": {


### PR DESCRIPTION
## Summary

Renames the package from `@juspay/blend-native` to unscoped **`blend-native`** so the first beta can be published from a personal npm account while the `@juspay` org scope is arranged. Follows the existing unscoped precedent in this repo (`blend-studio`, the token CLI).

The name is confirmed available on npm (as are the near-miss variants npm's similarity check would block against).

## Scope of the change

Renamed in 19 files: the package manifest, native-site's dependency + imports + tsconfig paths + metro config, the turbo task id (`blend-native#test`), the CI and publish workflows, and the docs.

**Unchanged:** the peer dependency on `@juspay/blend-design-system` — only this package's own name moved. `check-peer-exports.mjs` still targets the web package correctly.

## Verification

- `check:peer` → `✔ all 23 imported values resolve in @juspay/blend-design-system@0.0.38-beta.2`
- typecheck (blend-native + native-site), lint, 21 vitest files / 51 jest render tests, all three bob build targets
- `prettier --check .` clean

## Why unscoped rather than a personal scope

Chosen deliberately: an unscoped name avoids rewriting every import twice (once now, once on the move to `@juspay`). Note the tradeoff — npm cannot rename a published package, so moving to `@juspay/blend-native` later means publishing under the new name and deprecating `blend-native`, pointing at the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG8s1bUDRmuRiG7qrBSdS