### PR TITLE
chore(blend-native): W0 hardening — grammar contract, StyleProp, base props

### DIFF
--- a/packages/blend-native/__tests__/TextInput.render.test.tsx
+++ b/packages/blend-native/__tests__/TextInput.render.test.tsx
@@ -34,7 +34,10 @@ const renderInput = (
     )
 
 const flatten = (style: unknown) =>
-    Object.assign({}, ...(Array.isArray(style) ? style.flat() : [style]))
+    Object.assign(
+        {},
+        ...(Array.isArray(style) ? style.flat(Infinity) : [style])
+    )
 
 describe('TextInput rendering', () => {
     it('renders label, value and hint', () => {

--- a/packages/blend-native/__tests__/ThemePolicies.render.test.tsx
+++ b/packages/blend-native/__tests__/ThemePolicies.render.test.tsx
@@ -25,7 +25,10 @@ jest.mock('react-native/Libraries/Utilities/useColorScheme', () => ({
 const BODY_FAMILY = String(FOUNDATION_THEME.font.family.body)
 
 const flatten = (style: unknown) =>
-    Object.assign({}, ...(Array.isArray(style) ? style.flat() : [style]))
+    Object.assign(
+        {},
+        ...(Array.isArray(style) ? style.flat(Infinity) : [style])
+    )
 
 describe('font family policy', () => {
     it('applies the token body family by default', () => {

--- a/packages/blend-native/__tests__/cssStringAdapter.test.ts
+++ b/packages/blend-native/__tests__/cssStringAdapter.test.ts
@@ -147,6 +147,13 @@ describe('parseBorderRadius', () => {
             expect(parseBorderRadius(input)).toBeUndefined()
         }
     )
+
+    it.each([['50%'], ['12abc'], ['10px 50% 0 0']])(
+        'refuses non-length corners like %o instead of parseFloat-ing them',
+        (input) => {
+            expect(parseBorderRadius(input)).toBeUndefined()
+        }
+    )
 })
 
 describe('parseBoxShadow', () => {
@@ -199,8 +206,73 @@ describe('parseBackground', () => {
         expect(parsed.locations).toEqual([0, 1])
     })
 
+    it.each([['-90deg'], ['180.5deg']])(
+        'accepts a %s angle, not just positive integers',
+        (angle) => {
+            const parsed = parseBackground(
+                `linear-gradient(${angle}, #000000, #FFFFFF)`
+            )
+            expect(parsed?.type).toBe('gradient')
+        }
+    )
+
+    it('keeps explicit 0% stops instead of redistributing them', () => {
+        const parsed = parseBackground(
+            'linear-gradient(180deg, #000000 0%, #FFFFFF 0%)'
+        )
+        if (parsed?.type !== 'gradient') throw new Error('expected gradient')
+        expect(parsed.locations).toEqual([0, 0])
+    })
+
+    it('resolves mixed specified/unspecified stops the way CSS does', () => {
+        const parsed = parseBackground(
+            'linear-gradient(180deg, #000000 20%, #FFFFFF)'
+        )
+        if (parsed?.type !== 'gradient') throw new Error('expected gradient')
+        expect(parsed.locations).toEqual([0.2, 1])
+    })
+
+    it('interpolates an interior unspecified stop between its neighbours', () => {
+        const parsed = parseBackground(
+            'linear-gradient(180deg, #000000 0%, #888888, #FFFFFF 100%)'
+        )
+        if (parsed?.type !== 'gradient') throw new Error('expected gradient')
+        expect(parsed.locations).toEqual([0, 0.5, 1])
+    })
+
+    it('raises out-of-order stops to the running maximum, per CSS', () => {
+        const parsed = parseBackground(
+            'linear-gradient(180deg, #000000 80%, #FFFFFF 20%)'
+        )
+        if (parsed?.type !== 'gradient') throw new Error('expected gradient')
+        expect(parsed.locations).toEqual([0.8, 0.8])
+    })
+
+    it('degrades an unsupported gradient form to its first color stop', () => {
+        expect(
+            parseBackground('linear-gradient(to top, #1A56DB, #2563EB)')
+        ).toEqual({ type: 'flat', color: '#1A56DB' })
+        expect(
+            parseBackground('radial-gradient(circle, rgba(0,0,0,0.5), #FFF)')
+        ).toEqual({ type: 'flat', color: 'rgba(0,0,0,0.5)' })
+    })
+
+    it('never returns a gradient string as a flat "color"', () => {
+        const parsed = parseBackground('linear-gradient(to top, red, blue)')
+        if (parsed?.type === 'flat') {
+            expect(parsed.color).not.toContain('gradient')
+        }
+    })
+
     it.each([[undefined], ['none'], ['transparent']])(
         'returns null for %o',
+        (input) => {
+            expect(parseBackground(input)).toBeNull()
+        }
+    )
+
+    it.each([['ease-in-out'], ['url(x.png)'], ['inherit'], ['1px solid #000']])(
+        'returns null for the non-color value %o',
         (input) => {
             expect(parseBackground(input)).toBeNull()
         }

--- a/packages/blend-native/__tests__/tokenGrammarContract.test.ts
+++ b/packages/blend-native/__tests__/tokenGrammarContract.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest'
+import {
+    parseBackground,
+    parseBorder,
+    parseBorderRadius,
+    parseBoxShadow,
+    parseDimension,
+    parseDuration,
+    parseSize,
+} from '../src/adapters/cssStringAdapter'
+
+/**
+ * The factory→adapter grammar contract.
+ *
+ * The export contract (`nodeEntryContract.test.ts`) proves the web factories
+ * *exist*; this test proves the strings they *emit* stay parseable. That gap
+ * is real: `surfaceStyle.put()` silently drops any value a parser refuses, so
+ * a web-side token written in a grammar the adapter does not know (a `to top`
+ * gradient, a `rem` length) degrades on device with no error anywhere.
+ *
+ * Every registered slot is resolved for both themes and both breakpoints, and
+ * every leaf is fed to the parser its key name selects — the same key→parser
+ * mapping `surfaceStyle.ts` and the component utils use. Key names, not value
+ * shapes, decide the parser: `'600'`, `'ease-in-out'`, and `'1px solid #…'`
+ * are all just strings, and two slots deliberately cross-type their keys
+ * (BUTTONV2's `backgroundColor` holds gradients; ALERTV2's `border` holds the
+ * shorthand despite its `color` typing).
+ *
+ * Registering a new slot in `nativeTokenRegistry.ts` extends this contract
+ * automatically. If a token fails here: fix the adapter or fix the token —
+ * only a value that is genuinely handled outside the adapters may join
+ * `EXCEPTIONS`, with the handler named.
+ */
+
+const THEMES = ['light', 'dark'] as const
+const BREAKPOINTS = ['sm', 'lg'] as const
+
+/**
+ * Values resolved outside the adapter layer. Each entry names the code that
+ * actually handles the value, so a reader can verify the exception is real.
+ */
+const EXCEPTIONS: { pattern: RegExp; handler: string }[] = [
+    {
+        // '50%' — resolveSkeletonRadius() computes a numeric half-box radius
+        // for circles before parseBorderRadius is ever consulted.
+        pattern: /^SKELETON\.\w+\.\w+\.borderRadius\.circle$/,
+        handler: 'skeleton.utils.ts resolveSkeletonRadius',
+    },
+]
+
+type Leaf = { path: string; segments: string[]; value: unknown }
+
+function collectLeaves(
+    node: unknown,
+    path: string[],
+    out: Leaf[] = []
+): Leaf[] {
+    if (node !== null && typeof node === 'object') {
+        for (const [key, value] of Object.entries(node)) {
+            collectLeaves(value, [...path, key], out)
+        }
+        return out
+    }
+    out.push({ path: path.join('.'), segments: path, value: node })
+    return out
+}
+
+const STYLE_KEY_RE =
+    /^(background|backgroundColor|border|borderRadius.*|boxShadow|shadow|focusRing|duration|fontSize|lineHeight|letterSpacing|padding.*|gap)$|(width|height)$/i
+
+/**
+ * The token key that selects the parser. Token trees nest state/size maps
+ * BELOW the style key (`backgroundColor.default`, `border.primary.subtle`),
+ * so the leaf's own key is usually a state name — walk from the leaf upward
+ * to the nearest segment that names a style property.
+ */
+function styleKeyFor(segments: string[]): string | null {
+    // segments[0..2] are slot/theme/breakpoint — never style keys.
+    for (let i = segments.length - 1; i >= 3; i--) {
+        if (STYLE_KEY_RE.test(segments[i])) return segments[i]
+    }
+    return null
+}
+
+/** `null` means the leaf parses cleanly; a string is the violation reason. */
+function checkLeaf(leaf: Leaf): string | null {
+    const { value } = leaf
+    const key = styleKeyFor(leaf.segments) ?? ''
+
+    // Absent optional tokens are skippable by design (`put()` drops them).
+    if (value === undefined || value === null) return null
+
+    const str = String(value)
+
+    // Backgrounds — BUTTONV2's `backgroundColor` includes gradients, so both
+    // keys go through parseBackground (surfaceStyle passes `backgroundColor`
+    // through raw, but Button routes it via `background`).
+    if (key === 'background' || key === 'backgroundColor') {
+        if (str === 'none' || str === 'transparent') return null
+        const parsed = parseBackground(str)
+        if (parsed === null) return 'parseBackground returned null'
+        // Runtime degrades an unsupported gradient to its first stop so a
+        // screen never crashes — but the contract is stricter: a token that
+        // IS a gradient must parse AS a gradient, or web has started
+        // emitting grammar the adapter cannot express.
+        if (/gradient\(/i.test(str) && parsed.type !== 'gradient') {
+            return 'gradient token degraded to a flat color (unsupported syntax)'
+        }
+        if (parsed.type === 'flat' && /gradient\(/i.test(parsed.color)) {
+            return `flat color is a raw gradient string: ${parsed.color}`
+        }
+        if (parsed.type === 'gradient') {
+            const locs = parsed.locations
+            const monotonic = locs.every(
+                (l, i) => l >= 0 && l <= 1 && (i === 0 || l >= locs[i - 1])
+            )
+            if (!monotonic) {
+                return `gradient locations not monotonic in [0,1]: [${locs}]`
+            }
+        }
+        return null
+    }
+
+    if (key === 'border') {
+        if (str === 'none' || str === 'transparent') return null
+        const parsed = parseBorder(str)
+        if (
+            parsed.borderWidth === undefined ||
+            parsed.borderColor === undefined
+        ) {
+            return 'parseBorder could not extract width + color'
+        }
+        return null
+    }
+
+    if (key.startsWith('borderRadius')) {
+        if (parseBorderRadius(str) === undefined) {
+            return 'parseBorderRadius returned undefined'
+        }
+        return null
+    }
+
+    if (key === 'boxShadow' || key === 'shadow' || key === 'focusRing') {
+        if (str === 'none') return null
+        if (parseBoxShadow(str) === null) {
+            // Inset-only shadows are deliberately dropped — RN cannot render
+            // inset at all, and parseBoxShadow documents null as "no shadow".
+            // BUTTONV2's pressed-state shadows are all inset.
+            if (/\binset\b/i.test(str)) return null
+            return 'parseBoxShadow returned null'
+        }
+        return null
+    }
+
+    if (key === 'duration') {
+        if (parseDuration(str) === undefined) {
+            return 'parseDuration returned undefined'
+        }
+        return null
+    }
+
+    if (key === 'fontSize' || key === 'lineHeight' || key === 'letterSpacing') {
+        if (parseDimension(value as string | number) === undefined) {
+            return 'parseDimension returned undefined'
+        }
+        return null
+    }
+
+    if (key.startsWith('padding') || key === 'gap') {
+        if (parseDimension(value as string | number) === undefined) {
+            return 'parseDimension returned undefined (a % here is a bug)'
+        }
+        return null
+    }
+
+    if (/(width|height)$/i.test(key)) {
+        if (parseSize(value as string | number) === undefined) {
+            return 'parseSize returned undefined'
+        }
+        return null
+    }
+
+    // Everything else (colors, font families, keywords, flags) passes
+    // through unparsed — it just has to be a printable primitive.
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+        return 'non-finite number'
+    }
+    if (
+        typeof value !== 'string' &&
+        typeof value !== 'number' &&
+        typeof value !== 'boolean'
+    ) {
+        return `unexpected leaf type: ${typeof value}`
+    }
+    return null
+}
+
+describe('token grammar contract', () => {
+    it('every registered factory emits only adapter-parseable values', async () => {
+        // Imported dynamically so a stale dist fails with a build hint, not a
+        // cryptic resolution error (vitest resolves the workspace link to the
+        // built dist/node.js, unlike jest which maps it to source).
+        let registry: typeof import('../src/theme/nativeTokenRegistry')
+        try {
+            registry = await import('../src/theme/nativeTokenRegistry')
+        } catch (error) {
+            throw new Error(
+                'Could not load the token registry — the workspace link ' +
+                    'serves built dist/, so run `pnpm build:blend` first.\n' +
+                    String(error)
+            )
+        }
+        const { FOUNDATION_THEME, Theme } =
+            await import('@juspay/blend-design-system/node')
+        const themeValues = { light: Theme.LIGHT, dark: Theme.DARK }
+
+        const violations: string[] = []
+        let leafCount = 0
+
+        for (const slot of registry.NATIVE_TOKEN_SLOTS) {
+            const factory = registry.NATIVE_TOKEN_REGISTRY[slot]
+            for (const theme of THEMES) {
+                const responsive = factory(FOUNDATION_THEME, themeValues[theme])
+                for (const bp of BREAKPOINTS) {
+                    const leaves = collectLeaves(responsive[bp], [
+                        slot,
+                        theme,
+                        bp,
+                    ])
+                    leafCount += leaves.length
+                    for (const leaf of leaves) {
+                        if (EXCEPTIONS.some((e) => e.pattern.test(leaf.path))) {
+                            continue
+                        }
+                        const reason = checkLeaf(leaf)
+                        if (reason) {
+                            violations.push(
+                                `${leaf.path} = ${JSON.stringify(leaf.value)} → ${reason}`
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sanity: the walk actually visited real token trees.
+        expect(leafCount).toBeGreaterThan(100)
+
+        expect(
+            violations,
+            'Token values the native adapters cannot parse — fix the ' +
+                'adapter, fix the token, or (only for values handled outside ' +
+                'the adapters) add a documented exception:\n  ' +
+                violations.join('\n  ')
+        ).toEqual([])
+    })
+
+    it('every exception still matches a live token path (no dead entries)', async () => {
+        const registry = await import('../src/theme/nativeTokenRegistry')
+        const { FOUNDATION_THEME, Theme } =
+            await import('@juspay/blend-design-system/node')
+
+        const allPaths: string[] = []
+        for (const slot of registry.NATIVE_TOKEN_SLOTS) {
+            const factory = registry.NATIVE_TOKEN_REGISTRY[slot]
+            for (const theme of THEMES) {
+                const responsive = factory(
+                    FOUNDATION_THEME,
+                    theme === 'light' ? Theme.LIGHT : Theme.DARK
+                )
+                for (const bp of BREAKPOINTS) {
+                    for (const leaf of collectLeaves(responsive[bp], [
+                        slot,
+                        theme,
+                        bp,
+                    ])) {
+                        allPaths.push(leaf.path)
+                    }
+                }
+            }
+        }
+
+        const dead = EXCEPTIONS.filter(
+            (e) => !allPaths.some((p) => e.pattern.test(p))
+        )
+        expect(
+            dead.map((e) => String(e.pattern)),
+            'Exceptions that no longer match any token path — remove them:'
+        ).toEqual([])
+    })
+})

--- a/packages/blend-native/src/adapters/cssStringAdapter.ts
+++ b/packages/blend-native/src/adapters/cssStringAdapter.ts
@@ -25,13 +25,28 @@ import type { ViewStyle } from 'react-native'
  * Here the `.` inside the optional group is mandatory, so each digit run has
  * exactly one valid division and matching stays linear.
  */
-const NUMBER = String.raw`-?(?:\d+(?:\.\d+)?|\.\d+)`
+const UNSIGNED_NUMBER = String.raw`(?:\d+(?:\.\d+)?|\.\d+)`
+const NUMBER = `-?${UNSIGNED_NUMBER}`
 
 /** `"6px"`, `"1.5px"`, `"0"` — a length, with the unit optional. */
 const DIMENSION_RE = new RegExp(`^(${NUMBER})(?:px)?$`)
 
 /** `"50%"`, `"33.5%"`, `"-5%"` — a percentage. */
 const PERCENT_RE = new RegExp(`^(${NUMBER})%$`)
+
+/** `"1px solid #E1E4EA"` — width, style, color. Width cannot be negative. */
+const BORDER_RE = new RegExp(
+    String.raw`^(${UNSIGNED_NUMBER})px\s+(?:solid|dashed|dotted)\s+(.+)$`
+)
+
+/** Every signed decimal in a string — for box-shadow's number run. */
+const NUMBER_G = new RegExp(NUMBER, 'g')
+
+/** `rgba(5, 5, 6, 0.07)` — channels, with the alpha optional. */
+const RGBA_RE = new RegExp(
+    String.raw`rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(${UNSIGNED_NUMBER}))?\s*\)`,
+    'i'
+)
 
 /**
  * Result of parsing a background token.
@@ -166,9 +181,7 @@ export function parseBorder(
     // width: "1px" / "1.5px"
     // style: "solid" / "dashed" / "dotted" (RN only renders solid reliably)
     // color: hex / rgb / rgba / named
-    const match = value
-        .trim()
-        .match(/^(\d*\.?\d+)px\s+(?:solid|dashed|dotted)\s+(.+)$/)
+    const match = value.trim().match(BORDER_RE)
     if (!match) return {}
     const width = parseFloat(match[1])
     const color = match[2].trim()
@@ -201,8 +214,10 @@ export function parseBorderRadius(
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'none') return undefined
 
-    const parts = trimmed.split(/\s+/).map((p) => parseFloat(p))
-    if (parts.some((p) => Number.isNaN(p))) return undefined
+    // Each corner must be a plain length — `parseFloat` would silently turn
+    // `"50%"` into `50` and `"12abc"` into `12`, both wrong on RN.
+    const parts = trimmed.split(/\s+/).map((p) => parseDimension(p))
+    if (parts.some((p) => p === undefined)) return undefined
 
     if (parts.length === 1) return parts[0]
     if (parts.length === 4) {
@@ -262,8 +277,7 @@ export function parseBoxShadow(
     const numericPart = outer
         .replace(/#[0-9a-fA-F]{3,8}|rgba?\([^)]*\)/gi, ' ')
         .replace(/\binset\b/gi, ' ')
-    const nums =
-        numericPart.match(/-?\d*\.?\d+/g)?.map((t) => parseFloat(t)) ?? []
+    const nums = numericPart.match(NUMBER_G)?.map((t) => parseFloat(t)) ?? []
 
     const [offsetX = 0, offsetY = 0, blur = 0, spread = 0] = nums
 
@@ -275,9 +289,7 @@ export function parseBoxShadow(
     // alpha separately for shadowOpacity (iOS multiplies them).
     let resolvedColor = shadowColor
     let resolvedOpacity = 1
-    const rgbaMatch = shadowColor.match(
-        /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)/i
-    )
+    const rgbaMatch = shadowColor.match(RGBA_RE)
     if (rgbaMatch) {
         const [, r, g, b, a] = rgbaMatch
         resolvedColor = `rgb(${r}, ${g}, ${b})`
@@ -298,21 +310,79 @@ export function parseBoxShadow(
     }
 }
 
+/** `linear-gradient(<angle>deg, <stops>)` — the only gradient form Blend tokens use. */
+const LINEAR_GRADIENT_RE = new RegExp(
+    String.raw`linear-gradient\(\s*(${NUMBER})deg\s*,\s*(.+)\s*\)`,
+    'i'
+)
+
+/** The first color inside an unsupported gradient — its degrade target. */
+const FIRST_COLOR_RE = /#[0-9a-fA-F]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\)/i
+
+/** CSS-wide keywords that look like named colors but mean nothing to RN. */
+const NON_COLOR_KEYWORDS = new Set([
+    'inherit',
+    'initial',
+    'unset',
+    'revert',
+    'currentcolor',
+])
+
+/**
+ * Resolve gradient stop positions the way CSS does: a stop without a position
+ * gets one — first stop 0, last stop 1, interior stops spread evenly between
+ * their nearest positioned neighbours — and no stop may sit before an earlier
+ * one (out-of-order positions are raised to the running maximum).
+ */
+function resolveStopLocations(locations: (number | null)[]): number[] {
+    const out = locations.slice()
+    if (out[0] === null) out[0] = 0
+    if (out[out.length - 1] === null) out[out.length - 1] = 1
+
+    // Out-of-order specified positions clamp up to the running maximum.
+    let runningMax = 0
+    for (let i = 0; i < out.length; i++) {
+        const loc = out[i]
+        if (loc === null) continue
+        out[i] = Math.max(loc, runningMax)
+        runningMax = out[i] as number
+    }
+
+    // Interpolate each run of unspecified positions between its neighbours.
+    let i = 0
+    while (i < out.length) {
+        if (out[i] !== null) {
+            i++
+            continue
+        }
+        let j = i
+        while (out[j] === null) j++
+        const prev = out[i - 1] as number
+        const next = out[j] as number
+        const runLength = j - i
+        for (let k = 0; k < runLength; k++) {
+            out[i + k] = prev + ((k + 1) * (next - prev)) / (runLength + 1)
+        }
+        i = j
+    }
+    return out as number[]
+}
+
 /**
  * Parse a CSS `background` value into a `ParsedBackground`.
  *
  * - `"linear-gradient(180deg, #1A56DB -5%, #2563EB 107.5%)"` → gradient descriptor
- *   (percentage midpoints outside [0,1] are clamped — known limitation)
+ *   (percentage stops outside [0,1] are clamped — known limitation)
  * - `"#FFFFFF"` / `"rgb(255,255,255)"` → flat color
- * - `"none"` / `"transparent"` → null
+ * - unsupported gradient syntax (`to top`, radial, conic) → flat first stop,
+ *   never the raw string as a "color"
+ * - `"none"` / `"transparent"` / anything unrecognised → null
  */
 export function parseBackground(value: string | undefined): ParsedBackground {
     if (!value || value === 'none' || value === 'transparent') return null
 
     // Gradient?
-    const gradientMatch = value.match(
-        /linear-gradient\(\s*(\d+)deg\s*,\s*(.+)\s*\)/i
-    )
+    const gradientMatch = value.match(LINEAR_GRADIENT_RE)
     if (gradientMatch) {
         const angle = parseFloat(gradientMatch[1])
         const stopsStr = gradientMatch[2]
@@ -327,7 +397,7 @@ export function parseBackground(value: string | undefined): ParsedBackground {
             .map((s) => s.trim())
             .filter(Boolean)
         const colors: string[] = []
-        const locations: number[] = []
+        const locations: (number | null)[] = []
         for (const stop of stopStrs) {
             // "color" or "color position%"
             const parts = stop.split(/\s+/)
@@ -336,20 +406,13 @@ export function parseBackground(value: string | undefined): ParsedBackground {
                 const pct = parseFloat(parts[1]) / 100
                 locations.push(Math.min(1, Math.max(0, pct)))
             } else {
-                locations.push(0)
+                locations.push(null)
             }
         }
 
         if (colors.length < 2) {
             // Degenerate gradient — treat as flat color.
             return colors[0] ? { type: 'flat', color: colors[0] } : null
-        }
-
-        // If locations weren't specified, distribute evenly.
-        const allZero = locations.every((l) => l === 0)
-        let resolvedLocations = locations
-        if (allZero) {
-            resolvedLocations = colors.map((_, i) => i / (colors.length - 1))
         }
 
         // Convert CSS angle (0deg = bottom→top) to RN {start, end} coords.
@@ -370,14 +433,29 @@ export function parseBackground(value: string | undefined): ParsedBackground {
         return {
             type: 'gradient',
             colors,
-            locations: resolvedLocations,
+            locations: resolveStopLocations(locations),
             start,
             end,
         }
     }
 
-    // Solid color (hex / rgb / rgba / named)
-    if (/^(#[0-9a-fA-F]{3,8}|rgba?\(|[a-z]+)/i.test(value)) {
+    // Any other gradient form (`to top`, non-numeric angles, radial, conic):
+    // degrade to the first color stop rather than handing RN a gradient
+    // string as a "color" — an invalid color renders as a hard error.
+    if (/gradient\(/i.test(value)) {
+        const firstColor = value.match(FIRST_COLOR_RE)
+        return firstColor ? { type: 'flat', color: firstColor[0] } : null
+    }
+
+    // Solid color — a whole-string hex / rgb / rgba / hsl / named color.
+    // Anything trailing after the color (or a bare keyword like `inherit`)
+    // is not expressible as an RN color and returns null instead.
+    if (
+        /^#[0-9a-fA-F]{3,8}$/.test(value) ||
+        /^(?:rgba?|hsla?)\(/i.test(value) ||
+        (/^[a-z]+$/i.test(value) &&
+            !NON_COLOR_KEYWORDS.has(value.toLowerCase()))
+    ) {
         return { type: 'flat', color: value }
     }
 

--- a/packages/blend-native/src/adapters/optionalGradient.ts
+++ b/packages/blend-native/src/adapters/optionalGradient.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { ViewStyle } from 'react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
 
 /**
  * Optional `expo-linear-gradient` probe, shared by every surface that can
@@ -22,7 +22,7 @@ export type GradientComponent = React.ComponentType<{
     locations?: readonly number[]
     start?: { x: number; y: number }
     end?: { x: number; y: number }
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 }>
 
 type GradientModule = { LinearGradient: GradientComponent }

--- a/packages/blend-native/src/components/Alert/alert.types.ts
+++ b/packages/blend-native/src/components/Alert/alert.types.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { GestureResponderEvent, ViewStyle } from 'react-native'
+import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native'
 import type {
     AlertV2ActionPosition,
     AlertV2SubType,
@@ -77,5 +77,5 @@ export type AlertNativeProps = {
     announce?: boolean
     accessibilityLabel?: string
     testID?: string
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 }

--- a/packages/blend-native/src/components/Alert/alert.types.ts
+++ b/packages/blend-native/src/components/Alert/alert.types.ts
@@ -1,21 +1,22 @@
 import type React from 'react'
 import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native'
 import type {
+    AlertBaseProps,
     AlertV2ActionPosition,
-    AlertV2SubType,
-    AlertV2Type,
 } from '@juspay/blend-design-system/node'
 
 /**
  * Props for the native `Alert`.
  *
- * Mirrors web `AlertV2Props` (`packages/blend/lib/components/AlertV2/
- * alertV2.types.ts`) with DOM-specific pieces replaced by RN equivalents:
+ * The scalar core (`type`, `subType`, `heading`, `description`) derives from
+ * web's platform-neutral `AlertBaseProps`, so a web-side rename or addition
+ * reaches this type instead of drifting silently. The rest is re-declared
+ * natively because web's shapes are DOM-bound:
  *
  * - `onClick` handlers become `onPress`, carrying a `GestureResponderEvent`.
  * - `HTMLAttributes` passthrough becomes RN `View` props via `...rest`.
  * - `width` / `maxWidth` / `minWidth` accept token strings or numbers and are
- *   resolved by `parseSize`.
+ *   resolved by `parseSize` (web types them as `CSSObject` values).
  */
 
 export type AlertSlot = {
@@ -52,12 +53,8 @@ export type AlertCloseButton = {
     accessibilityLabel?: string
 }
 
-export type AlertNativeProps = {
-    type?: AlertV2Type
-    subType?: AlertV2SubType
+export type AlertNativeProps = AlertBaseProps & {
     slot?: AlertSlot
-    heading?: string
-    description?: string
     actions?: AlertActions
     closeButton?: AlertCloseButton
 

--- a/packages/blend-native/src/components/Button/Button.tsx
+++ b/packages/blend-native/src/components/Button/Button.tsx
@@ -167,7 +167,7 @@ const Button = forwardRef<RNView, ButtonNativeProps>(function Button(
             accessibilityRole="button"
             // Grouped members drop their shared edges; spread after the
             // resolved surface so `borderWidth` still covers the other sides.
-            style={{ ...styles.groupBorderWidths, ...style }}
+            style={[styles.groupBorderWidths, style]}
             {...rest}
         >
             {content}

--- a/packages/blend-native/src/components/Button/button.types.ts
+++ b/packages/blend-native/src/components/Button/button.types.ts
@@ -1,6 +1,7 @@
 import type {
     GestureResponderEvent,
     PressableProps,
+    StyleProp,
     ViewStyle,
 } from 'react-native'
 import type { ButtonBaseProps } from '@juspay/blend-design-system/node'
@@ -37,7 +38,7 @@ export type ButtonNativeProps = Omit<ButtonBaseProps, 'skeleton'> & {
      */
     justifyContent?: ViewStyle['justifyContent']
     /** Escape hatch for RN styles the token props do not cover. */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 } & Omit<
         PressableProps,
         'style' | 'onPress' | 'disabled' | 'children' | 'testID'

--- a/packages/blend-native/src/components/Skeleton/skeleton.types.ts
+++ b/packages/blend-native/src/components/Skeleton/skeleton.types.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { ViewStyle } from 'react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
 import type {
     SkeletonShape,
     SkeletonVariant,
@@ -23,6 +23,6 @@ export type SkeletonNativeProps = {
     borderRadius?: number
     /** Wrap mode: content keeps its layout, renders invisible. */
     children?: React.ReactNode
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     testID?: string
 }

--- a/packages/blend-native/src/components/Tag/Tag.tsx
+++ b/packages/blend-native/src/components/Tag/Tag.tsx
@@ -177,7 +177,7 @@ const Tag = forwardRef<RNView, TagNativeProps>(function Tag(
                 accessibilityLabel={accessibleName}
                 accessibilityState={getTagAccessibilityState(true, pressed)}
                 testID={testID}
-                style={{ ...groupBorderWidths, ...style }}
+                style={[groupBorderWidths, style]}
             >
                 {content}
             </Pressable>
@@ -192,7 +192,7 @@ const Tag = forwardRef<RNView, TagNativeProps>(function Tag(
             accessibilityRole="text"
             accessibilityLabel={accessibilityLabel}
             testID={testID}
-            style={{ ...groupBorderWidths, ...style }}
+            style={[groupBorderWidths, style]}
         >
             {content}
         </Block>

--- a/packages/blend-native/src/components/Tag/tag.types.ts
+++ b/packages/blend-native/src/components/Tag/tag.types.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { GestureResponderEvent, ViewStyle } from 'react-native'
+import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native'
 import type {
     TagV2Color,
     TagV2Size,
@@ -59,5 +59,5 @@ export type TagNativeProps = {
     accessibilityLabel?: string
     testID?: string
     /** Escape hatch for RN styles the token props do not cover. */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 }

--- a/packages/blend-native/src/components/Tag/tag.types.ts
+++ b/packages/blend-native/src/components/Tag/tag.types.ts
@@ -1,24 +1,22 @@
 import type React from 'react'
 import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native'
-import type {
-    TagV2Color,
-    TagV2Size,
-    TagV2SubType,
-    TagV2Type,
-} from '@juspay/blend-design-system/node'
+import type { TagBaseProps } from '@juspay/blend-design-system/node'
 import type { GroupPosition } from '../shared/group'
 
 /**
  * Props for the native `Tag`.
  *
- * Mirrors web `TagV2Props` (`packages/blend/lib/components/TagV2/
- * TagV2.types.ts`) with DOM-specific pieces replaced by RN equivalents:
+ * Derives from web's platform-neutral `TagBaseProps` (the `ButtonBaseProps`
+ * pattern), so a web-side rename or addition reaches this type instead of
+ * drifting silently. DOM-specific pieces are replaced by RN equivalents:
  *
  * - `onClick` → `onPress`, carrying a `GestureResponderEvent`.
  * - `aria-pressed` → `pressed`, surfaced as `accessibilityState.selected`.
  * - `HTMLAttributes` passthrough → RN `View`/`Pressable` props via `...rest`.
+ * - Web's `ReactElement` slots → native `TagSlot` (`ReactNode`, plain
+ *   `string | number` max height).
  *
- * `skeleton` is deliberately **absent** rather than accepted-and-ignored.
+ * `skeleton` is deliberately **omitted** rather than accepted-and-ignored.
  * Web's `TagV2` renders a `TagSkeleton`, which has no native counterpart yet;
  * omitting the prop from the type keeps it a compile error instead of a
  * silent no-op. Same decision as `Button`.
@@ -30,17 +28,16 @@ export type TagSlot = {
     maxHeight?: string | number
 }
 
-export type TagNativeProps = {
-    text: string
-    size?: TagV2Size
-    type?: TagV2Type
-    subType?: TagV2SubType
-    color?: TagV2Color
+export type TagNativeProps = Omit<
+    TagBaseProps,
+    'skeleton' | 'tagGroupPosition'
+> & {
     leftSlot?: TagSlot
     rightSlot?: TagSlot
     /**
      * Position within a tag group. Collapses the border radius on the joined
-     * edges, matching web's `getTagBorderRadius`.
+     * edges, matching web's `getTagBorderRadius`. Redeclared from the base
+     * (same union) to tie it to the shared `GroupPosition` type.
      */
     tagGroupPosition?: GroupPosition
     /**

--- a/packages/blend-native/src/components/TextInput/textInput.types.ts
+++ b/packages/blend-native/src/components/TextInput/textInput.types.ts
@@ -2,6 +2,7 @@ import type React from 'react'
 import type {
     TextInput as RNTextInput,
     TextInputProps as RNTextInputProps,
+    StyleProp,
     ViewStyle,
 } from 'react-native'
 import type { InputSizeV2 } from '@juspay/blend-design-system/node'
@@ -45,7 +46,7 @@ export type TextInputNativeProps = {
     /** Screen-reader name; defaults to `label`. */
     accessibilityLabel?: string
     /** Escape hatch for the outer column (label + field + footer). */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     /** Ref to the underlying RN TextInput (focus/blur/clear). */
     inputRef?: React.Ref<RNTextInput>
 } & Omit<

--- a/packages/blend-native/src/components/TextInput/textInput.types.ts
+++ b/packages/blend-native/src/components/TextInput/textInput.types.ts
@@ -5,22 +5,26 @@ import type {
     StyleProp,
     ViewStyle,
 } from 'react-native'
-import type { InputSizeV2 } from '@juspay/blend-design-system/node'
-import type { FieldError } from '../shared/field/fieldState'
+import type { TextInputBaseProps } from '@juspay/blend-design-system/node'
 
 /**
  * Props for the native `TextInput` — the port of web's `TextInputV2`.
  *
- * Web pieces swapped for RN ones: `onChange` on a DOM input becomes RN's
- * `onChangeText`, `data-testid` becomes `testID`, and the HTML-attribute
- * passthrough becomes RN `TextInputProps` (which supplies `placeholder`,
- * `keyboardType`, `autoCapitalize`, `secureTextEntry`, ... for free).
+ * Derives from web's platform-neutral `TextInputBaseProps` (the
+ * `ButtonBaseProps` pattern), so a web-side rename or addition reaches this
+ * type instead of drifting silently. Web pieces swapped for RN ones:
+ * `onChange` on a DOM input becomes RN's `onChangeText`, `data-testid`
+ * becomes `testID`, and the HTML-attribute passthrough becomes RN
+ * `TextInputProps` (which supplies `placeholder`, `keyboardType`,
+ * `autoCapitalize`, `secureTextEntry`, ... for free). The base's `error`
+ * shape is exactly `FieldError` (`../shared/field/fieldState`).
  *
  * Deliberately omitted rather than accepted-and-ignored (the `skeleton`
  * precedent — passing them should be a compile error, not a no-op):
  *
  * - `dropdown` — the embedded SingleSelect needs the native Select family.
- * - `helpIconText` — needs a native Tooltip.
+ *   (Web keeps it out of the base type for the same reason.)
+ * - `helpIconText` — needs a native Tooltip; `Omit`-ed from the base.
  * - The floating-label mode (web floats the label into `lg` inputs on
  *   phones) — deferred until the field pattern settles on native.
  */
@@ -30,14 +34,8 @@ export type TextInputSlot = {
     maxHeight?: string | number
 }
 
-export type TextInputNativeProps = {
-    value: string
+export type TextInputNativeProps = Omit<TextInputBaseProps, 'helpIconText'> & {
     onChangeText?: (text: string) => void
-    label?: string
-    subLabel?: string
-    size?: InputSizeV2
-    error?: FieldError
-    hintText?: string
     required?: boolean
     disabled?: boolean
     leftSlot?: TextInputSlot
@@ -50,6 +48,6 @@ export type TextInputNativeProps = {
     /** Ref to the underlying RN TextInput (focus/blur/clear). */
     inputRef?: React.Ref<RNTextInput>
 } & Omit<
-    RNTextInputProps,
-    'value' | 'onChangeText' | 'style' | 'editable' | 'placeholderTextColor'
->
+        RNTextInputProps,
+        'value' | 'onChangeText' | 'style' | 'editable' | 'placeholderTextColor'
+    >

--- a/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
+++ b/packages/blend-native/src/overlay/sheet/BottomSheet.tsx
@@ -6,6 +6,7 @@ import {
     useWindowDimensions,
     View,
     type LayoutChangeEvent,
+    type StyleProp,
     type ViewStyle,
 } from 'react-native'
 import Animated, {
@@ -75,7 +76,7 @@ export type BottomSheetProps = {
     accessibilityLabel?: string
     testID?: string
     /** Style escape hatch for the sheet surface. */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 }
 
 const ENTER = {

--- a/packages/blend-native/src/primitives/Block.tsx
+++ b/packages/blend-native/src/primitives/Block.tsx
@@ -5,6 +5,7 @@ import {
     StyleSheet,
     type View as RNView,
     type ViewProps,
+    type StyleProp,
     type ViewStyle,
 } from 'react-native'
 import {
@@ -33,7 +34,7 @@ import {
 export type BlockProps = SurfaceStyleProps & {
     children?: React.ReactNode
     /** Escape hatch for RN styles the token props do not cover. */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 } & Omit<ViewProps, 'style'>
 
 const BlockImpl = forwardRef<RNView, BlockProps>(function Block(

--- a/packages/blend-native/src/primitives/Pressable.tsx
+++ b/packages/blend-native/src/primitives/Pressable.tsx
@@ -8,6 +8,7 @@ import {
     type LayoutChangeEvent,
     type PressableProps,
     type View as RNView,
+    type StyleProp,
     type ViewStyle,
 } from 'react-native'
 import {
@@ -116,7 +117,7 @@ export type PrimitivePressableProps = SurfaceStyleProps & {
     minTouchTarget?: number
 
     onPress?: (event: GestureResponderEvent) => void
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 } & Omit<PressableProps, 'style' | 'onPress' | 'disabled' | 'children'>
 
 const PressableImpl = forwardRef<RNView, PrimitivePressableProps>(

--- a/packages/blend-native/src/primitives/PrimitiveInput.tsx
+++ b/packages/blend-native/src/primitives/PrimitiveInput.tsx
@@ -3,6 +3,7 @@ import {
     TextInput as RNTextInput,
     StyleSheet,
     type TextInputProps as RNTextInputProps,
+    type StyleProp,
     type TextStyle,
 } from 'react-native'
 import { parseDimension } from '../adapters/cssStringAdapter'
@@ -33,7 +34,7 @@ export type PrimitiveInputProps = {
     lineHeight?: string | number
     /** Placeholder colour for the current state. */
     placeholderColor?: string
-    style?: TextStyle
+    style?: StyleProp<TextStyle>
 } & Omit<RNTextInputProps, 'style' | 'placeholderTextColor'>
 
 const PrimitiveInputImpl = forwardRef<RNTextInput, PrimitiveInputProps>(

--- a/packages/blend-native/src/primitives/Separator.tsx
+++ b/packages/blend-native/src/primitives/Separator.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View, type ViewStyle } from 'react-native'
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native'
 import { FOUNDATION_THEME } from '@juspay/blend-design-system/node'
 import { parseDimension } from '../adapters/cssStringAdapter'
 
@@ -21,7 +21,7 @@ export type SeparatorProps = {
     /** Thickness across the line. Token string or number. */
     thickness?: string | number
     color?: string
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     testID?: string
 }
 

--- a/packages/blend-native/src/primitives/Slot.tsx
+++ b/packages/blend-native/src/primitives/Slot.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react'
-import { View, StyleSheet, type ViewStyle } from 'react-native'
+import { View, StyleSheet, type StyleProp, type ViewStyle } from 'react-native'
 import { parseSize } from '../adapters/cssStringAdapter'
 import { tintSlot } from './tintSlot'
 
@@ -42,7 +42,7 @@ export type SlotProps = {
      * renders a text label, matching web's `aria-hidden`.
      */
     hidden?: boolean
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     testID?: string
 }
 

--- a/packages/blend-native/src/primitives/Text.tsx
+++ b/packages/blend-native/src/primitives/Text.tsx
@@ -3,6 +3,7 @@ import {
     Text as RNText,
     StyleSheet,
     type TextProps as RNTextProps,
+    type StyleProp,
     type TextStyle,
 } from 'react-native'
 import { parseDimension } from '../adapters/cssStringAdapter'
@@ -51,7 +52,7 @@ export type BlendTextProps = {
     /** Flex display — web `Text` is sometimes `inline`; on RN Text is always inline. */
     as?: string
 } & Omit<RNTextProps, 'style'> & {
-        style?: TextStyle
+        style?: StyleProp<TextStyle>
     }
 
 function TextImpl({

--- a/packages/blend/lib/components/AlertV2/alertV2.types.ts
+++ b/packages/blend/lib/components/AlertV2/alertV2.types.ts
@@ -45,15 +45,24 @@ export type AlertV2Dimensions = {
     minWidth?: CSSObject['minWidth']
 }
 
-export type AlertV2Props = {
+/**
+ * Platform-neutral core of the AlertV2 API — the scalar props both platforms
+ * share. `@juspay/blend-native` derives its Alert props from this. Actions,
+ * close button, slot, and dimensions stay platform-specific: the web handlers
+ * are DOM `MouseEvent`s, and the dimensions are CSS-typed.
+ */
+export type AlertBaseProps = {
     type?: AlertV2Type
     subType?: AlertV2SubType
+    heading?: string
+    description?: string
+}
+
+export type AlertV2Props = AlertBaseProps & {
     slot?: {
         slot: ReactElement
         maxHeight?: CSSObject['maxHeight']
     }
-    heading?: string
-    description?: string
     actions?: AlertV2Actions
     closeButton?: {
         show?: boolean

--- a/packages/blend/lib/components/InputsV2/TextInputV2/TextInputV2.types.ts
+++ b/packages/blend/lib/components/InputsV2/TextInputV2/TextInputV2.types.ts
@@ -20,7 +20,12 @@ export type TextInputV2Dropdown = SingleSelectV2Props & {
     position: TextInputV2DropdownPosition
 }
 
-export type TextInputV2Props = {
+/**
+ * Platform-neutral core of the TextInputV2 API — no DOM types, no dropdown
+ * (which would drag the SingleSelectV2 type graph into the node entry).
+ * `@juspay/blend-native` derives its input props from this.
+ */
+export type TextInputBaseProps = {
     value: string
     label?: string
     subLabel?: string
@@ -31,6 +36,9 @@ export type TextInputV2Props = {
     }
     hintText?: string
     helpIconText?: string
+}
+
+export type TextInputV2Props = TextInputBaseProps & {
     dropdown?: TextInputV2Dropdown | TextInputV2Dropdown[]
     leftSlot?: {
         slot: ReactElement
@@ -41,9 +49,9 @@ export type TextInputV2Props = {
         maxHeight?: CSSObject['maxHeight']
     }
 } & Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'style' | 'className' | 'dropdown'
->
+        React.InputHTMLAttributes<HTMLInputElement>,
+        'size' | 'style' | 'className' | 'dropdown'
+    >
 
 export type EmbeddedSingleSelectOptions = {
     fieldLabel: string | undefined

--- a/packages/blend/lib/components/TagV2/TagV2.types.ts
+++ b/packages/blend/lib/components/TagV2/TagV2.types.ts
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import type { SkeletonVariant } from '../Skeleton/skeleton.tokens'
-import { CSSObject } from 'styled-components'
+import type { CSSObject } from 'styled-components'
 
 export enum TagV2PaddingDirection {
     TOP = 'top',
@@ -36,12 +36,26 @@ export enum TagV2Size {
     LG = 'lg',
 }
 
-export type TagV2Props = {
+/**
+ * Platform-neutral core of the TagV2 API — no DOM attributes, no React
+ * element slots. `@juspay/blend-native` derives its Tag props from this, so
+ * a rename or addition here reaches both platforms; `TagV2Props` layers the
+ * web-only pieces (slots, HTML attributes) on top without changing shape.
+ */
+export type TagBaseProps = {
     text: string
     size?: TagV2Size
     type?: TagV2Type
     subType?: TagV2SubType
     color?: TagV2Color
+    skeleton?: {
+        showSkeleton?: boolean
+        skeletonVariant?: SkeletonVariant
+    }
+    tagGroupPosition?: 'center' | 'left' | 'right'
+}
+
+export type TagV2Props = TagBaseProps & {
     leftSlot?: {
         slot: ReactElement
         maxHeight?: CSSObject['maxHeight']
@@ -50,12 +64,7 @@ export type TagV2Props = {
         slot: ReactElement
         maxHeight?: CSSObject['maxHeight']
     }
-    skeleton?: {
-        showSkeleton?: boolean
-        skeletonVariant?: SkeletonVariant
-    }
-    tagGroupPosition?: 'center' | 'left' | 'right'
 } & Omit<
-    React.HTMLAttributes<HTMLDivElement | HTMLButtonElement>,
-    'size' | 'className' | 'style'
->
+        React.HTMLAttributes<HTMLDivElement | HTMLButtonElement>,
+        'size' | 'className' | 'style'
+    >

--- a/packages/blend/lib/node.ts
+++ b/packages/blend/lib/node.ts
@@ -97,6 +97,7 @@ export {
     AlertV2ActionPosition,
     AlertV2PaddingDirection,
 } from './components/AlertV2/alertV2.types'
+export type { AlertBaseProps } from './components/AlertV2/alertV2.types'
 
 export {
     TagV2Type,
@@ -105,5 +106,7 @@ export {
     TagV2Color,
     TagV2PaddingDirection,
 } from './components/TagV2/TagV2.types'
+export type { TagBaseProps } from './components/TagV2/TagV2.types'
 
 export { InputSizeV2, InputStateV2 } from './components/InputsV2/inputV2.types'
+export type { TextInputBaseProps } from './components/InputsV2/TextInputV2/TextInputV2.types'


### PR DESCRIPTION
## What

The three W0 hardening items from the blend-native final audit, done before Wave A grows the catalog:

1. **Token grammar contract test** (`tokenGrammarContract.test.ts`) — walks every registered factory's output (light + dark × sm + lg) and feeds each leaf to the parser its token key selects. A web-side token written in grammar the adapter can't parse now fails CI with the exact path (verified by mutation: a `to top` gradient in the built tokens produces 100+ named violations) instead of silently dropping a style on device. Registering a new slot extends the contract automatically. Deliberate drops are carved out with their handlers named (inset shadows → RN can't render them; skeleton's `50%` circle → `resolveSkeletonRadius`).
2. **`parseBackground` hardening** — unsupported gradient syntax degrades to the first color stop (never the raw string as a "color"), negative/decimal angles parse, and stop positions resolve per the CSS spec (no more `0` sentinel collision or non-monotonic mixed lists). `parseBorder`/`parseBoxShadow`/`parseBorderRadius` move onto the linear `NUMBER` pattern; `parseBorderRadius` refuses non-length corners.
3. **`StyleProp<ViewStyle>` package-wide** — all 13 style props widen so `style={[a, b]}` works like every other RN library; the three object-spread merge sites move to array form. Source-compatible.
4. **Base-props derivation** — Tag, Alert and TextInput now derive from `TagBaseProps` / `AlertBaseProps` / `TextInputBaseProps` exported from `lib/node.ts` (the `ButtonBaseProps` pattern), closing the silent-drift hole. Native public prop shapes are unchanged.

## Web impact: none (verified)

The `packages/blend` change is a pure type regrouping. The base types contain only props that were already free of CSS/DOM types; every web-visible prop keeps its exact original type. Built `dist/main.js`/`dist/node.js` are **byte-identical** with and without the change (deterministic build, hashes compared), and all 245 TagV2/AlertV2/TextInputV2 web tests pass.

## Release sequencing caveat

blend-native's published `d.ts` will reference the new base types, which web `0.0.38-beta.2` does not ship. **Before the next native npm publish, cut a web beta containing this PR and bump native's peer floor** (the `3312aa85` precedent). `check:peer` validates value exports only and will not catch this.

## Verification

- `pnpm build:blend` (lint + build + `check:dist`) ✅, web Tag/Alert/TextInput suites 245/245 ✅
- blend-native: `typecheck` ✅, `lint` ✅, vitest 712/712 (22 files) ✅, jest render 51/51 ✅, bob build ✅
- `pnpm check:circular` ✅
- Contract-test kill check: mutated a built gradient token to `to top` form → test fails with exact paths; restored → green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFAA3auicZ2oi3FyN96qP