### PR TITLE
feat(native-site): spec-driven component playground with native navigation

### DIFF
--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -54,9 +54,15 @@ export default function App() {
     const tabs: readonly TabKey[] = spec.gallery
         ? ['preview', 'gallery']
         : ['preview']
-    // A spec without a gallery hides the tab; if it was the active one,
-    // fall back rather than rendering an empty screen.
-    const activeTab = spec.gallery ? tab : 'preview'
+
+    const selectComponent = useCallback((name: string) => {
+        setComponentName(name)
+        // A spec with no gallery hides that tab. Reset the choice rather
+        // than leaving it parked, or the next component that does have a
+        // gallery would open on it without the user asking.
+        if (!findSpec(name).gallery) setTab('preview')
+        setDrawerOpen(false)
+    }, [])
 
     return (
         <PlatformPreview>
@@ -91,10 +97,7 @@ export default function App() {
                                         <ComponentDrawer
                                             groups={COMPONENT_GROUPS}
                                             value={componentName}
-                                            onChange={(name) => {
-                                                setComponentName(name)
-                                                setDrawerOpen(false)
-                                            }}
+                                            onChange={selectComponent}
                                         />
                                     )}
                                 >
@@ -120,19 +123,30 @@ export default function App() {
                                             }
                                         />
 
-                                        {activeTab === 'preview' ? (
-                                            // Keyed so switching component resets
-                                            // the props to that spec's defaults.
+                                        {/* Hidden rather than unmounted: a
+                                            trip to the Gallery and back must
+                                            not discard the props you just
+                                            configured. Keyed so switching
+                                            component does reset them. */}
+                                        <View
+                                            style={[
+                                                styles.fill,
+                                                tab === 'gallery'
+                                                    ? styles.hidden
+                                                    : null,
+                                            ]}
+                                        >
                                             <Playground
                                                 key={spec.name}
                                                 spec={spec}
                                             />
-                                        ) : (
+                                        </View>
+                                        {tab === 'gallery' ? (
                                             <Gallery spec={spec} />
-                                        )}
+                                        ) : null}
 
                                         <PlaygroundTabBar
-                                            value={activeTab}
+                                            value={tab}
                                             onChange={setTab}
                                             tabs={tabs}
                                         />
@@ -149,4 +163,7 @@ export default function App() {
 
 const styles = StyleSheet.create({
     fill: { flex: 1 },
+    // `display: none` takes the subtree out of Yoga's layout entirely, so
+    // the hidden Playground costs nothing while the Gallery is on screen.
+    hidden: { display: 'none' },
 })

--- a/apps/native-site/App.tsx
+++ b/apps/native-site/App.tsx
@@ -1,140 +1,152 @@
-import { useState } from 'react'
-import {
-    Pressable,
-    SafeAreaView,
-    ScrollView,
-    StatusBar,
-    StyleSheet,
-    Text as RNText,
-    View,
-} from 'react-native'
+import { useCallback, useMemo, useState } from 'react'
+import { StatusBar, StyleSheet, View } from 'react-native'
+import type { LayoutChangeEvent } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { Drawer } from 'react-native-drawer-layout'
 import { BlendNativeProvider, Theme } from 'blend-native'
-import ButtonShowcase from './components/ButtonShowcase'
-import TagShowcase from './components/TagShowcase'
-import AlertShowcase from './components/AlertShowcase'
-import SheetShowcase from './components/SheetShowcase'
-import InputShowcase from './components/InputShowcase'
-import DisplayShowcase from './components/DisplayShowcase'
-import LoadingShowcase from './components/LoadingShowcase'
 import PlatformPreview from './components/PlatformPreview'
+import AppBar from './playground/AppBar'
+import ComponentDrawer from './playground/ComponentDrawer'
+import Gallery from './playground/Gallery'
+import Playground from './playground/Playground'
+import PlaygroundTabBar from './playground/PlaygroundTabBar'
+import { ChromeContext, DARK_CHROME, LIGHT_CHROME } from './playground/chrome'
+import { COMPONENT_GROUPS, findSpec } from './playground/specs'
+import type { TabKey } from './playground/tabBar.shared'
 
-type Tab =
-    | 'alert'
-    | 'tag'
-    | 'button'
-    | 'sheet'
-    | 'input'
-    | 'loading'
-    | 'display'
+/**
+ * Two levels of navigation. The drawer picks the component; the bottom bar
+ * picks how to look at it. The component selection is shared across both
+ * tabs, so moving between Preview and Gallery keeps you on the same
+ * component rather than resetting — which is the reason for having both.
+ *
+ * Blend's own components are used only inside the stage. Everything around
+ * it is plain React Native, so a regression in the library cannot take the
+ * instrument used to inspect it down with it.
+ */
+
+/** Past this the drawer stays open instead of hiding behind the hamburger. */
+const PERMANENT_DRAWER_WIDTH = 1024
 
 export default function App() {
     const [theme, setTheme] = useState<Theme>(Theme.LIGHT)
-    const [tab, setTab] = useState<Tab>('alert')
+    const [componentName, setComponentName] = useState(
+        COMPONENT_GROUPS[0].specs[0].name
+    )
+    const [tab, setTab] = useState<TabKey>('preview')
+    const [drawerOpen, setDrawerOpen] = useState(false)
+
+    // Measured rather than read from `useWindowDimensions`: on the web target
+    // the app renders inside a phone frame, and the window width says 1280
+    // while the app has 390. Trusting the window there pins the drawer open
+    // and squeezes the content into what is left.
+    const [availableWidth, setAvailableWidth] = useState(0)
+    const measure = useCallback((event: LayoutChangeEvent) => {
+        setAvailableWidth(event.nativeEvent.layout.width)
+    }, [])
+    const permanent = availableWidth >= PERMANENT_DRAWER_WIDTH
 
     const isDark = theme === Theme.DARK
-    const palette = isDark
-        ? { bg: '#0E0F11', fg: '#F5F6F7', muted: '#2A2D33' }
-        : { bg: '#FFFFFF', fg: '#1A1C23', muted: '#F0F2F5' }
+    const chrome = isDark ? DARK_CHROME : LIGHT_CHROME
+
+    const spec = useMemo(() => findSpec(componentName), [componentName])
+    const tabs: readonly TabKey[] = spec.gallery
+        ? ['preview', 'gallery']
+        : ['preview']
+    // A spec without a gallery hides the tab; if it was the active one,
+    // fall back rather than rendering an empty screen.
+    const activeTab = spec.gallery ? tab : 'preview'
 
     return (
         <PlatformPreview>
-            {/* GestureHandlerRootView is required for BottomSheet's pan
-                gesture; apps on react-navigation already have one. */}
-            <GestureHandlerRootView style={styles.container}>
-                {/* A single provider themes every Blend component beneath it.
-                    Before this existed each component took its own `theme`
-                    prop, so an app-wide toggle was not expressible. */}
-                <BlendNativeProvider theme={theme}>
-                    <SafeAreaView
-                        style={[
-                            styles.container,
-                            { backgroundColor: palette.bg },
-                        ]}
-                    >
-                        <StatusBar
-                            barStyle={isDark ? 'light-content' : 'dark-content'}
-                        />
-                        <ScrollView contentContainerStyle={styles.scroll}>
-                            <RNText
-                                style={[styles.header, { color: palette.fg }]}
-                            >
-                                Blend Native
-                            </RNText>
-
-                            <View style={styles.controls}>
-                                {(
-                                    [
-                                        'alert',
-                                        'tag',
-                                        'button',
-                                        'sheet',
-                                        'input',
-                                        'loading',
-                                        'display',
-                                    ] as Tab[]
-                                ).map((value) => (
-                                    <Pressable
-                                        key={value}
-                                        onPress={() => setTab(value)}
+            <SafeAreaProvider>
+                {/* GestureHandlerRootView backs both the drawer's edge swipe
+                    and BottomSheet's pan gesture. */}
+                <GestureHandlerRootView style={styles.fill}>
+                    <BlendNativeProvider theme={theme}>
+                        <ChromeContext.Provider value={chrome}>
+                            <StatusBar
+                                barStyle={
+                                    isDark ? 'light-content' : 'dark-content'
+                                }
+                            />
+                            <View style={styles.fill} onLayout={measure}>
+                                <Drawer
+                                    open={drawerOpen}
+                                    onOpen={() => setDrawerOpen(true)}
+                                    onClose={() => setDrawerOpen(false)}
+                                    drawerType={
+                                        permanent ? 'permanent' : 'front'
+                                    }
+                                    drawerStyle={{
+                                        width: 260,
+                                        backgroundColor: chrome.bg,
+                                        borderRightColor: chrome.border,
+                                        borderRightWidth: permanent
+                                            ? StyleSheet.hairlineWidth
+                                            : 0,
+                                    }}
+                                    renderDrawerContent={() => (
+                                        <ComponentDrawer
+                                            groups={COMPONENT_GROUPS}
+                                            value={componentName}
+                                            onChange={(name) => {
+                                                setComponentName(name)
+                                                setDrawerOpen(false)
+                                            }}
+                                        />
+                                    )}
+                                >
+                                    <View
                                         style={[
-                                            styles.control,
-                                            {
-                                                backgroundColor:
-                                                    tab === value
-                                                        ? palette.muted
-                                                        : 'transparent',
-                                            },
+                                            styles.fill,
+                                            { backgroundColor: chrome.bg },
                                         ]}
                                     >
-                                        <RNText style={{ color: palette.fg }}>
-                                            {value[0].toUpperCase() +
-                                                value.slice(1)}
-                                        </RNText>
-                                    </Pressable>
-                                ))}
+                                        <AppBar
+                                            title={spec.name}
+                                            showMenuButton={!permanent}
+                                            onOpenDrawer={() =>
+                                                setDrawerOpen(true)
+                                            }
+                                            isDark={isDark}
+                                            onToggleTheme={() =>
+                                                setTheme(
+                                                    isDark
+                                                        ? Theme.LIGHT
+                                                        : Theme.DARK
+                                                )
+                                            }
+                                        />
 
-                                <Pressable
-                                    onPress={() =>
-                                        setTheme(
-                                            isDark ? Theme.LIGHT : Theme.DARK
-                                        )
-                                    }
-                                    style={[
-                                        styles.control,
-                                        { backgroundColor: palette.muted },
-                                    ]}
-                                >
-                                    <RNText style={{ color: palette.fg }}>
-                                        {isDark ? '☾ Dark' : '☀ Light'}
-                                    </RNText>
-                                </Pressable>
+                                        {activeTab === 'preview' ? (
+                                            // Keyed so switching component resets
+                                            // the props to that spec's defaults.
+                                            <Playground
+                                                key={spec.name}
+                                                spec={spec}
+                                            />
+                                        ) : (
+                                            <Gallery spec={spec} />
+                                        )}
+
+                                        <PlaygroundTabBar
+                                            value={activeTab}
+                                            onChange={setTab}
+                                            tabs={tabs}
+                                        />
+                                    </View>
+                                </Drawer>
                             </View>
-
-                            {tab === 'alert' ? <AlertShowcase /> : null}
-                            {tab === 'tag' ? <TagShowcase /> : null}
-                            {tab === 'button' ? <ButtonShowcase /> : null}
-                            {tab === 'sheet' ? <SheetShowcase /> : null}
-                            {tab === 'input' ? <InputShowcase /> : null}
-                            {tab === 'loading' ? <LoadingShowcase /> : null}
-                            {tab === 'display' ? <DisplayShowcase /> : null}
-                        </ScrollView>
-                    </SafeAreaView>
-                </BlendNativeProvider>
-            </GestureHandlerRootView>
+                        </ChromeContext.Provider>
+                    </BlendNativeProvider>
+                </GestureHandlerRootView>
+            </SafeAreaProvider>
         </PlatformPreview>
     )
 }
 
 const styles = StyleSheet.create({
-    container: { flex: 1 },
-    scroll: { padding: 16, gap: 8 },
-    header: { fontSize: 22, fontWeight: '700', marginBottom: 12 },
-    controls: {
-        flexDirection: 'row',
-        flexWrap: 'wrap',
-        gap: 8,
-        marginBottom: 20,
-    },
-    control: { paddingVertical: 6, paddingHorizontal: 12, borderRadius: 8 },
+    fill: { flex: 1 },
 })

--- a/apps/native-site/README.md
+++ b/apps/native-site/README.md
@@ -2,9 +2,23 @@
 
 Expo demo app for [`blend-native`](../../packages/blend-native).
 
-It renders every variant of every shipped native component so they can be
-checked against the web originals: **Alert**, **Tag** and **Button**, each with
-a light/dark toggle driven by a single `BlendNativeProvider`.
+Every component the library ships gets two views of it, sharing one
+light/dark toggle driven by a single `BlendNativeProvider`:
+
+- **Preview** — one instance, a panel of controls that reach every variant
+  and combination, and the JSX for whatever is currently on screen.
+- **Gallery** — the dense every-variant grid, which is what catches
+  regressions.
+
+A **side drawer** picks the component; a **native bottom bar** picks the view.
+The selection is shared, so moving between Preview and Gallery keeps you on
+the same component.
+
+Open the drawer with the hamburger. Edge-swipe also works, **except on
+Android devices using gesture navigation**, where the system claims the left
+edge for its own back gesture and closes the app instead. That is the OS
+winning a gesture race, not a bug in the drawer, and it is why the hamburger
+is always present rather than being hidden on touch targets.
 
 This app is not a showcase for its own sake — it is the **verification vehicle
 for the library**. Several bugs in `blend-native` were invisible to the test
@@ -19,6 +33,7 @@ pnpm build:blend            # required — see the note below
 
 cd apps/native-site
 pnpm start                  # then press i / a / w
+pnpm test                   # the playground's pure layer (snippet + options)
 ```
 
 `pnpm build:blend` is not optional. `blend-native` imports tokens from
@@ -131,22 +146,64 @@ object, not what reached the screen. Render tests (`pnpm --filter
 blend-native test:render`) now cover behaviour and accessibility, but
 **visual correctness still needs eyes on a device.**
 
+The bottom bar is a third platform check on top of those two: it is a real
+`UIVisualEffectView` on iOS 26 through `expo-glass-effect`, a Material 3
+navigation bar on Android, and a plain bordered bar on the web. Below iOS 26
+the glass API is absent, so the iOS file falls back to an opaque surface —
+a translucent bar with no material behind it would leave the labels sitting
+unreadably on the scroll content. Checking one platform tells you nothing
+about the other two.
+
 ## Folder structure
 
 ```
 apps/native-site/
-├── App.tsx                     # provider, theme toggle, tab switcher
-├── app.json                    # Expo config
-├── metro.config.js             # pnpm symlink + workspace source resolution
+├── App.tsx                        # provider, drawer, app bar, tab bar
+├── app.json                       # Expo config
+├── metro.config.js                # pnpm symlink + workspace source resolution
 ├── babel.config.js
-└── components/
+├── playground/
+│   ├── types.ts                   # ComponentSpec, Control — the contract
+│   ├── snippet.ts                 # props -> JSX string (pure, unit-tested)
+│   ├── snippet.test.ts
+│   ├── chrome.ts                  # the harness palette, deliberately not Blend's
+│   ├── Playground.tsx             # stage + controls + snippet + reset
+│   ├── Gallery.tsx                # wraps a showcase as the second view
+│   ├── AppBar.tsx                 # title, hamburger, theme toggle
+│   ├── ComponentDrawer.tsx        # the grouped component list
+│   ├── tabBar.shared.ts           # props the three tab bars all satisfy
+│   ├── PlaygroundTabBar.tsx       # default / web
+│   ├── PlaygroundTabBar.ios.tsx   # Liquid Glass (expo-glass-effect)
+│   ├── PlaygroundTabBar.android.tsx  # Material 3 navigation bar
+│   ├── controls/                  # Segmented, Select, Toggle, Text, Panel
+│   └── specs/                     # one file per component + the registry
+└── components/                    # the showcases, now the Gallery view
     ├── AlertShowcase.tsx       # 7 types x 2 subTypes, actions, slots, wrapping
     ├── TagShowcase.tsx         # 3 types x 6 colors x 4 sizes x 2 subTypes
     ├── ButtonShowcase.tsx      # types, sizes, states, subTypes, widths
+    ├── InputShowcase.tsx       # TextInput sizes, slots, states
+    ├── LoadingShowcase.tsx     # Skeleton, Spinner, ProgressBar
+    ├── DisplayShowcase.tsx     # Avatar, Card, KeyValuePair
+    ├── SheetShowcase.tsx       # BottomSheet
     ├── PlatformPreview.tsx     # web-only Mobile/Web switch + zoom
     ├── MobileFrame.web.tsx     # phone chrome for the browser target
     └── MobileFrame.native.tsx  # passthrough on native
 ```
+
+### Two rules the harness depends on
+
+**The control chrome is plain React Native, never `blend-native`.** The
+playground is the instrument used to inspect the library, so it has to keep
+working when the library does not — a control panel built out of the
+components under test goes blank exactly when you need it. `chrome.ts` holds
+its own palette for the same reason.
+
+**Options come from the enums, not from hardcoded lists.**
+`enumOptions(TagColor, 'TagColor')` rather than `['neutral', 'primary', ...]`,
+so a colour added to the library shows up in the controls on its own. String
+unions have no runtime object to enumerate, so `unionOptions` takes an
+explicit list — and fails to compile if the union gains a member the list
+does not have.
 
 `MobileFrame.web.tsx` / `MobileFrame.native.tsx` are a genuine platform split,
 which is what Metro's `.web` / `.native` suffixes are for. Note that
@@ -154,10 +211,52 @@ which is what Metro's `.web` / `.native` suffixes are for. Note that
 no platform variants, and the suffix would advertise a split that does not
 exist.
 
-### Adding a showcase
+### Adding a component
 
-1. Create `components/<Name>Showcase.tsx`.
-2. Add it to the `Tab` union and the switch in `App.tsx`.
+Write a spec and register it. There is no screen to add.
+
+1. Create `playground/specs/<name>.spec.tsx`:
+
+    ```tsx
+    const spec: ComponentSpec<BadgeNativeProps> = {
+        name: 'Badge',
+        summary: 'One line on what is worth knowing.',
+        mode: 'inline', // 'overlay' for things that present over the screen
+        defaults: { text: 'New', variant: BadgeVariant.SUBTLE },
+        controls: [
+            {
+                kind: 'segmented',
+                key: 'variant',
+                label: 'Variant',
+                options: enumOptions(BadgeVariant, 'BadgeVariant'),
+            },
+            { kind: 'text', key: 'text', label: 'Text', always: true },
+        ],
+        render: (props) => <Badge {...props} />,
+        gallery: BadgeShowcase, // optional; without it the Gallery tab hides
+    }
+    ```
+
+2. Add it to a group in `playground/specs/index.ts`.
+
+Notes that save time:
+
+- `always: true` prints a prop in the snippet even at its default. Use it for
+  props the component has no default for — without it the snippet reads
+  `<Badge />`, which renders nothing.
+- `hidden: true` drives the preview without printing. It is for
+  playground-only props such as a family selector.
+- A `segmented` control with more than four options is promoted to a picker
+  automatically, so nobody has to remember to change `kind` when an enum grows.
+- Toggle payloads that are objects must be **module-level constants** — the
+  toggle decides it is on by comparing with `Object.is`, so an inline object
+  would leave it permanently off.
+
+### Adding a gallery
+
+1. Create `components/<Name>Showcase.tsx` returning a `View` (the harness
+   supplies the `ScrollView`).
+2. Point a spec's `gallery` at it. Several specs may share one.
 3. Lead with the case most likely to regress. `AlertShowcase` opens with a
    long wrapping description for exactly this reason.
 

--- a/apps/native-site/README.md
+++ b/apps/native-site/README.md
@@ -251,6 +251,15 @@ Notes that save time:
 - Toggle payloads that are objects must be **module-level constants** — the
   toggle decides it is on by comparing with `Object.is`, so an inline object
   would leave it permanently off.
+- `off: undefined` and an omitted `off` mean different things. The first
+  clears the prop; the second writes `false`. A slot toggle wants the first —
+  `leftSlot={false}` is not a value its type accepts, and it would end up in
+  the snippet as well as in the component's props.
+- `wrapSnippet` reshapes the generated block for specs whose real call is not
+  a single element: a wrapper around several children, or a function call
+  such as `addSnackbar({ ... })`. `replaceProp` and `addProps` in `snippet.ts`
+  do the editing; anything the stage supplies but no control drives (required
+  props, children) belongs there, or the snippet will not compile.
 
 ### Adding a gallery
 

--- a/apps/native-site/package.json
+++ b/apps/native-site/package.json
@@ -5,22 +5,26 @@
     "private": true,
     "scripts": {
         "start": "expo start",
-        "android": "expo start --android",
-        "ios": "expo start --ios",
+        "android": "expo run:android",
+        "ios": "expo run:ios",
         "web": "expo start --web",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@expo/metro-runtime": "~56.0.20",
         "@juspay/blend-design-system": "workspace:*",
         "blend-native": "workspace:*",
         "expo": "~56.0.12",
+        "expo-glass-effect": "56.0.4",
         "expo-linear-gradient": "~56.0.4",
         "lucide-react-native": "^1.33.0",
         "react": "19.2.3",
         "react-device-frameset": "^1.3.4",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
+        "react-native-drawer-layout": "4.2.10",
         "react-native-gesture-handler": "~2.31.1",
         "react-native-reanimated": "~4.3.1",
         "react-native-safe-area-context": "~5.7.0",
@@ -31,6 +35,7 @@
     "devDependencies": {
         "@babel/core": "^7.29.0",
         "@types/react": "~19.1.2",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "vitest": "^3.2.4"
     }
 }

--- a/apps/native-site/package.json
+++ b/apps/native-site/package.json
@@ -5,8 +5,8 @@
     "private": true,
     "scripts": {
         "start": "expo start",
-        "android": "expo run:android",
-        "ios": "expo run:ios",
+        "android": "expo start --android",
+        "ios": "expo start --ios",
         "web": "expo start --web",
         "typecheck": "tsc --noEmit",
         "test": "vitest run",

--- a/apps/native-site/playground/AppBar.tsx
+++ b/apps/native-site/playground/AppBar.tsx
@@ -1,0 +1,106 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Menu, Moon, Sun } from 'lucide-react-native'
+import { useChrome } from './chrome'
+
+/** Title, the drawer trigger, and the app-wide light/dark toggle. */
+export default function AppBar({
+    title,
+    onOpenDrawer,
+    isDark,
+    onToggleTheme,
+    showMenuButton,
+}: {
+    title: string
+    onOpenDrawer: () => void
+    isDark: boolean
+    onToggleTheme: () => void
+    /** Hidden when the drawer is permanent — there is nothing to open. */
+    showMenuButton: boolean
+}) {
+    const chrome = useChrome()
+    const insets = useSafeAreaInsets()
+
+    return (
+        <View
+            style={[
+                styles.bar,
+                {
+                    backgroundColor: chrome.bg,
+                    borderBottomColor: chrome.border,
+                    paddingTop: insets.top,
+                },
+            ]}
+        >
+            <View style={styles.row}>
+                {showMenuButton ? (
+                    <Pressable
+                        onPress={onOpenDrawer}
+                        accessibilityRole="button"
+                        accessibilityLabel="Open the component list"
+                        android_ripple={{
+                            color: chrome.surfaceAlt,
+                            borderless: true,
+                        }}
+                        style={styles.iconButton}
+                    >
+                        <Menu size={22} color={chrome.fg} />
+                    </Pressable>
+                ) : null}
+
+                <Text
+                    numberOfLines={1}
+                    style={[styles.title, { color: chrome.fg }]}
+                >
+                    {title}
+                </Text>
+
+                <Pressable
+                    onPress={onToggleTheme}
+                    accessibilityRole="switch"
+                    accessibilityState={{ checked: isDark }}
+                    accessibilityLabel={
+                        isDark
+                            ? 'Switch to light theme'
+                            : 'Switch to dark theme'
+                    }
+                    android_ripple={{
+                        color: chrome.surfaceAlt,
+                        borderless: true,
+                    }}
+                    style={styles.iconButton}
+                >
+                    {isDark ? (
+                        <Moon size={20} color={chrome.fg} />
+                    ) : (
+                        <Sun size={20} color={chrome.fg} />
+                    )}
+                </Pressable>
+            </View>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    bar: { borderBottomWidth: StyleSheet.hairlineWidth },
+    row: {
+        height: 52,
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 6,
+        gap: 4,
+    },
+    iconButton: {
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 22,
+    },
+    title: {
+        flex: 1,
+        fontSize: 17,
+        fontWeight: '700',
+        paddingHorizontal: 6,
+    },
+})

--- a/apps/native-site/playground/ComponentDrawer.tsx
+++ b/apps/native-site/playground/ComponentDrawer.tsx
@@ -1,0 +1,118 @@
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useChrome } from './chrome'
+import type { SpecGroup } from './specs'
+
+/**
+ * Drawer contents: the component list, grouped.
+ *
+ * The selection is shared by both tabs, so picking a component in Preview
+ * and switching to Gallery shows the same component rather than resetting —
+ * which is the point of having the two modes side by side.
+ */
+export default function ComponentDrawer({
+    groups,
+    value,
+    onChange,
+}: {
+    groups: readonly SpecGroup[]
+    value: string
+    onChange: (name: string) => void
+}) {
+    const chrome = useChrome()
+    const insets = useSafeAreaInsets()
+
+    return (
+        <View style={[styles.root, { backgroundColor: chrome.bg }]}>
+            <ScrollView
+                contentContainerStyle={[
+                    styles.scroll,
+                    {
+                        paddingTop: 16 + insets.top,
+                        paddingBottom: 24 + insets.bottom,
+                    },
+                ]}
+            >
+                <Text style={[styles.brand, { color: chrome.fg }]}>
+                    Blend Native
+                </Text>
+                {groups.map((group) => (
+                    <View key={group.title} style={styles.group}>
+                        <Text
+                            style={[
+                                styles.groupTitle,
+                                { color: chrome.fgMuted },
+                            ]}
+                        >
+                            {group.title}
+                        </Text>
+                        {group.specs.map((spec) => {
+                            const selected = spec.name === value
+                            return (
+                                <Pressable
+                                    key={spec.name}
+                                    onPress={() => onChange(spec.name)}
+                                    accessibilityRole="menuitem"
+                                    accessibilityState={{ selected }}
+                                    android_ripple={{
+                                        color: chrome.surfaceAlt,
+                                    }}
+                                    style={[
+                                        styles.item,
+                                        selected
+                                            ? {
+                                                  backgroundColor:
+                                                      chrome.surfaceAlt,
+                                              }
+                                            : null,
+                                    ]}
+                                >
+                                    <Text
+                                        style={[
+                                            styles.itemLabel,
+                                            {
+                                                color: selected
+                                                    ? chrome.accent
+                                                    : chrome.fg,
+                                                fontWeight: selected
+                                                    ? '700'
+                                                    : '500',
+                                            },
+                                        ]}
+                                    >
+                                        {spec.name}
+                                    </Text>
+                                </Pressable>
+                            )
+                        })}
+                    </View>
+                ))}
+            </ScrollView>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    root: { flex: 1 },
+    scroll: { paddingHorizontal: 12, gap: 20 },
+    brand: { fontSize: 18, fontWeight: '700', paddingHorizontal: 8 },
+    group: { gap: 2 },
+    groupTitle: {
+        fontSize: 11,
+        fontWeight: '700',
+        letterSpacing: 0.6,
+        textTransform: 'uppercase',
+        paddingHorizontal: 8,
+        paddingBottom: 6,
+    },
+    item: {
+        minHeight: 44,
+        justifyContent: 'center',
+        paddingHorizontal: 12,
+        borderRadius: 10,
+        // Drawer rows are the primary navigation on a phone; keep them at the
+        // platform minimum touch height even though the label is short.
+        overflow: 'hidden',
+    },
+    itemLabel: { fontSize: 15 },
+})

--- a/apps/native-site/playground/Gallery.tsx
+++ b/apps/native-site/playground/Gallery.tsx
@@ -1,0 +1,43 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useChrome } from './chrome'
+import type { AnySpec } from './types'
+
+/**
+ * The dense every-variant grid — the format the app had before the
+ * playground, kept because it answers a different question. Controls answer
+ * "what can this component do?"; a wall of every combination answers "is
+ * anything broken?", which is how the Tag descender clipping and the Alert
+ * wrapping bug were both caught.
+ *
+ * The showcase files are reused unchanged. Several specs share one, so a
+ * component's gallery may show its neighbours too.
+ */
+export default function Gallery({ spec }: { spec: AnySpec }) {
+    const chrome = useChrome()
+    const Showcase = spec.gallery
+
+    if (!Showcase) {
+        return (
+            <View style={[styles.empty, { backgroundColor: chrome.bg }]}>
+                <Text style={[styles.emptyText, { color: chrome.fgMuted }]}>
+                    {spec.name} has no gallery.
+                </Text>
+            </View>
+        )
+    }
+
+    return (
+        <ScrollView
+            style={{ backgroundColor: chrome.bg }}
+            contentContainerStyle={styles.scroll}
+        >
+            <Showcase />
+        </ScrollView>
+    )
+}
+
+const styles = StyleSheet.create({
+    scroll: { padding: 16, paddingBottom: 40, gap: 8 },
+    empty: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+    emptyText: { fontSize: 13 },
+})

--- a/apps/native-site/playground/Playground.tsx
+++ b/apps/native-site/playground/Playground.tsx
@@ -29,17 +29,16 @@ export default function Playground({ spec }: { spec: AnySpec }) {
         setProps((current) => ({ ...current, [key]: value }))
     }, [])
 
-    const dirty = useMemo(
-        () =>
-            Object.keys(spec.defaults).some(
-                (key) =>
-                    !Object.is(
-                        (props as Record<string, unknown>)[key],
-                        (spec.defaults as Record<string, unknown>)[key]
-                    )
-            ),
-        [props, spec.defaults]
-    )
+    // Both key sets, not just the defaults': a prop the spec has no default
+    // for (`loading`, `width`, a slot) is absent from `defaults`, and
+    // checking only those keys would leave Reset disabled after changing it
+    // — with no other way to undo.
+    const dirty = useMemo(() => {
+        const current = props as Record<string, unknown>
+        const initial = spec.defaults as Record<string, unknown>
+        const keys = new Set([...Object.keys(initial), ...Object.keys(current)])
+        return [...keys].some((key) => !Object.is(current[key], initial[key]))
+    }, [props, spec.defaults])
 
     const snippet = useMemo(
         () =>

--- a/apps/native-site/playground/Playground.tsx
+++ b/apps/native-site/playground/Playground.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+    Platform,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View,
+} from 'react-native'
+import { ChevronRight, RotateCcw } from 'lucide-react-native'
+import { MONO_FONT, useChrome } from './chrome'
+import ControlPanel from './controls/ControlPanel'
+import { buildSnippet } from './snippet'
+import type { AnySpec } from './types'
+
+/**
+ * One component, one instance, and the controls to reshape it.
+ *
+ * State is keyed on the spec by the caller (`<Playground key={spec.name} />`),
+ * so switching component resets the props without an effect.
+ */
+export default function Playground({ spec }: { spec: AnySpec }) {
+    const chrome = useChrome()
+    const [props, setProps] = useState(spec.defaults)
+    const [open, setOpen] = useState(false)
+    const [showCode, setShowCode] = useState(false)
+
+    const onChange = useCallback((key: string, value: unknown) => {
+        setProps((current) => ({ ...current, [key]: value }))
+    }, [])
+
+    const dirty = useMemo(
+        () =>
+            Object.keys(spec.defaults).some(
+                (key) =>
+                    !Object.is(
+                        (props as Record<string, unknown>)[key],
+                        (spec.defaults as Record<string, unknown>)[key]
+                    )
+            ),
+        [props, spec.defaults]
+    )
+
+    const snippet = useMemo(
+        () =>
+            buildSnippet(
+                spec.name,
+                props,
+                spec.defaults,
+                spec.controls,
+                spec.wrapSnippet
+            ),
+        [props, spec]
+    )
+
+    return (
+        <ScrollView
+            style={{ backgroundColor: chrome.bg }}
+            contentContainerStyle={styles.scroll}
+            keyboardShouldPersistTaps="handled"
+        >
+            <View
+                style={[
+                    styles.stage,
+                    {
+                        backgroundColor: chrome.stage,
+                        borderColor: chrome.stageBorder,
+                    },
+                ]}
+            >
+                {spec.mode === 'overlay' ? (
+                    <Pressable
+                        onPress={() => setOpen(true)}
+                        accessibilityRole="button"
+                        style={[
+                            styles.trigger,
+                            { backgroundColor: chrome.accent },
+                        ]}
+                    >
+                        <Text
+                            style={[
+                                styles.triggerLabel,
+                                { color: chrome.accentFg },
+                            ]}
+                        >
+                            {spec.triggerLabel ?? `Show ${spec.name}`}
+                        </Text>
+                    </Pressable>
+                ) : null}
+
+                {spec.render(props, { open, setOpen })}
+            </View>
+
+            <View style={styles.summaryRow}>
+                <Text style={[styles.summary, { color: chrome.fgMuted }]}>
+                    {spec.summary}
+                </Text>
+                <Pressable
+                    onPress={() => setProps(spec.defaults)}
+                    disabled={!dirty}
+                    accessibilityRole="button"
+                    accessibilityLabel="Reset to defaults"
+                    accessibilityState={{ disabled: !dirty }}
+                    style={[
+                        styles.reset,
+                        {
+                            borderColor: chrome.border,
+                            opacity: dirty ? 1 : 0.4,
+                        },
+                    ]}
+                >
+                    <RotateCcw size={13} color={chrome.fgMuted} />
+                    <Text
+                        style={[styles.resetLabel, { color: chrome.fgMuted }]}
+                    >
+                        Reset
+                    </Text>
+                </Pressable>
+            </View>
+
+            <ControlPanel
+                controls={spec.controls}
+                props={props}
+                onChange={onChange}
+            />
+
+            <View style={[styles.codeCard, { borderColor: chrome.border }]}>
+                <Pressable
+                    onPress={() => setShowCode((value) => !value)}
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded: showCode }}
+                    style={styles.codeHeader}
+                >
+                    {/* The rotation goes on a wrapper View, not on the
+                        icon: react-native-svg does not reliably apply a
+                        transform passed through to the Svg element. */}
+                    <View style={showCode ? styles.chevronOpen : undefined}>
+                        <ChevronRight size={14} color={chrome.fgMuted} />
+                    </View>
+                    <Text style={[styles.codeTitle, { color: chrome.fgMuted }]}>
+                        JSX
+                    </Text>
+                </Pressable>
+                {showCode ? (
+                    <ScrollView
+                        horizontal
+                        style={[
+                            styles.codeBody,
+                            { backgroundColor: chrome.codeBg },
+                        ]}
+                    >
+                        <Text
+                            selectable
+                            style={[styles.code, { color: chrome.codeFg }]}
+                        >
+                            {snippet}
+                        </Text>
+                    </ScrollView>
+                ) : null}
+            </View>
+        </ScrollView>
+    )
+}
+
+const styles = StyleSheet.create({
+    scroll: { padding: 16, gap: 20, paddingBottom: 40 },
+    stage: {
+        minHeight: 168,
+        borderRadius: 12,
+        // Dashed so a component's own bounds are readable against it —
+        // `alignSelf` and width behaviour are invisible on a flush surface.
+        // Android renders dashed corners as solid; the boundary still reads.
+        borderWidth: 1,
+        borderStyle: 'dashed',
+        padding: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+    },
+    trigger: {
+        paddingVertical: 11,
+        paddingHorizontal: 18,
+        borderRadius: 10,
+        minHeight: 44,
+        justifyContent: 'center',
+    },
+    triggerLabel: { fontSize: 14, fontWeight: '600' },
+    summaryRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+    },
+    summary: { fontSize: 12, lineHeight: 17, flexShrink: 1 },
+    reset: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 5,
+        paddingVertical: 6,
+        paddingHorizontal: 10,
+        borderRadius: 8,
+        borderWidth: 1,
+    },
+    resetLabel: { fontSize: 12, fontWeight: '500' },
+    codeCard: { borderRadius: 10, borderWidth: 1, overflow: 'hidden' },
+    codeHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+    },
+    chevronOpen: { transform: [{ rotate: '90deg' }] },
+    codeTitle: {
+        fontSize: 11,
+        fontWeight: '700',
+        letterSpacing: 0.6,
+        textTransform: 'uppercase',
+    },
+    codeBody: { paddingHorizontal: 12, paddingVertical: 10 },
+    code: {
+        fontFamily: Platform.select(MONO_FONT),
+        fontSize: 12,
+        lineHeight: 18,
+    },
+})

--- a/apps/native-site/playground/PlaygroundTabBar.android.tsx
+++ b/apps/native-site/playground/PlaygroundTabBar.android.tsx
@@ -1,0 +1,123 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { DARK_CHROME, useChrome } from './chrome'
+import { TAB_ITEMS } from './tabBar.shared'
+import type { TabBarProps } from './tabBar.shared'
+
+/**
+ * Material 3 navigation bar: 80dp container, a 64x32dp pill indicator that
+ * sits behind the active icon, and the label underneath.
+ *
+ * The colours are M3 roles rather than the harness palette — a navigation
+ * bar is one of the few places where matching the platform matters more than
+ * matching the app, and `surfaceContainer` / `secondaryContainer` have no
+ * equivalent in the chrome palette.
+ */
+const M3 = {
+    light: {
+        container: '#F3F3FA',
+        indicator: '#DCE1FF',
+        activeIcon: '#151B2C',
+        activeLabel: '#191C20',
+        inactive: '#44474E',
+    },
+    dark: {
+        container: '#1B1B1F',
+        indicator: '#3F4759',
+        activeIcon: '#DCE1FF',
+        activeLabel: '#E2E2E9',
+        inactive: '#C4C6CF',
+    },
+}
+
+export default function PlaygroundTabBar({
+    value,
+    onChange,
+    tabs,
+}: TabBarProps) {
+    const chrome = useChrome()
+    const insets = useSafeAreaInsets()
+    const colors = chrome === DARK_CHROME ? M3.dark : M3.light
+
+    return (
+        <View
+            accessibilityRole="tablist"
+            style={[
+                styles.bar,
+                {
+                    backgroundColor: colors.container,
+                    paddingBottom: insets.bottom,
+                },
+            ]}
+        >
+            {tabs.map((key) => {
+                const item = TAB_ITEMS[key]
+                const selected = key === value
+                return (
+                    <Pressable
+                        key={key}
+                        onPress={() => onChange(key)}
+                        accessibilityRole="tab"
+                        accessibilityState={{ selected }}
+                        accessibilityLabel={item.label}
+                        android_ripple={{
+                            color: colors.indicator,
+                            borderless: false,
+                        }}
+                        style={styles.item}
+                    >
+                        <View
+                            style={[
+                                styles.indicator,
+                                selected
+                                    ? { backgroundColor: colors.indicator }
+                                    : null,
+                            ]}
+                        >
+                            <item.icon
+                                size={24}
+                                color={
+                                    selected
+                                        ? colors.activeIcon
+                                        : colors.inactive
+                                }
+                            />
+                        </View>
+                        <Text
+                            style={[
+                                styles.label,
+                                {
+                                    color: selected
+                                        ? colors.activeLabel
+                                        : colors.inactive,
+                                    fontWeight: selected ? '700' : '500',
+                                },
+                            ]}
+                        >
+                            {item.label}
+                        </Text>
+                    </Pressable>
+                )
+            })}
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    bar: { flexDirection: 'row' },
+    item: {
+        flex: 1,
+        height: 80,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 4,
+    },
+    indicator: {
+        width: 64,
+        height: 32,
+        borderRadius: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    label: { fontSize: 12, letterSpacing: 0.5 },
+})

--- a/apps/native-site/playground/PlaygroundTabBar.ios.tsx
+++ b/apps/native-site/playground/PlaygroundTabBar.ios.tsx
@@ -1,0 +1,90 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect'
+import { DARK_CHROME, useChrome } from './chrome'
+import { TAB_ITEMS } from './tabBar.shared'
+import type { TabBarProps } from './tabBar.shared'
+
+/**
+ * iOS tab bar, backed by a real `UIVisualEffectView` through
+ * `expo-glass-effect` — the Liquid Glass material iOS 26 uses for its own
+ * bars, so content scrolling underneath is refracted rather than merely
+ * dimmed.
+ *
+ * The API only exists on iOS 26 and up, and some 26 builds ship without it,
+ * so `isLiquidGlassAvailable()` decides at runtime. On a miss the bar paints
+ * an opaque surface instead: a translucent bar with no material behind it
+ * would leave the labels sitting unreadably on top of the scroll content.
+ *
+ * Do not animate this with `opacity` — at 0 the system stops rendering the
+ * effect entirely rather than fading it.
+ */
+const GLASS = isLiquidGlassAvailable()
+
+export default function PlaygroundTabBar({
+    value,
+    onChange,
+    tabs,
+}: TabBarProps) {
+    const chrome = useChrome()
+    const insets = useSafeAreaInsets()
+    const isDark = chrome === DARK_CHROME
+
+    const items = tabs.map((key) => {
+        const item = TAB_ITEMS[key]
+        const selected = key === value
+        const color = selected ? chrome.accent : chrome.fgMuted
+        return (
+            <Pressable
+                key={key}
+                onPress={() => onChange(key)}
+                accessibilityRole="tab"
+                accessibilityState={{ selected }}
+                accessibilityLabel={item.label}
+                style={styles.item}
+            >
+                <item.icon size={22} color={color} />
+                <Text style={[styles.label, { color }]}>{item.label}</Text>
+            </Pressable>
+        )
+    })
+
+    const layout = [styles.bar, { paddingBottom: 6 + insets.bottom }]
+
+    if (!GLASS) {
+        return (
+            <View
+                accessibilityRole="tablist"
+                style={[
+                    layout,
+                    {
+                        backgroundColor: chrome.surface,
+                        borderTopColor: chrome.border,
+                        borderTopWidth: StyleSheet.hairlineWidth,
+                    },
+                ]}
+            >
+                {items}
+            </View>
+        )
+    }
+
+    return (
+        <GlassView
+            accessibilityRole="tablist"
+            glassEffectStyle="regular"
+            // The app has its own light/dark toggle, so the material must not
+            // follow the system appearance independently of it.
+            colorScheme={isDark ? 'dark' : 'light'}
+            style={layout}
+        >
+            {items}
+        </GlassView>
+    )
+}
+
+const styles = StyleSheet.create({
+    bar: { flexDirection: 'row', paddingTop: 8 },
+    item: { flex: 1, alignItems: 'center', gap: 3, minHeight: 44 },
+    label: { fontSize: 10, fontWeight: '600' },
+})

--- a/apps/native-site/playground/PlaygroundTabBar.ios.tsx
+++ b/apps/native-site/playground/PlaygroundTabBar.ios.tsx
@@ -19,7 +19,22 @@ import type { TabBarProps } from './tabBar.shared'
  * Do not animate this with `opacity` — at 0 the system stops rendering the
  * effect entirely rather than fading it.
  */
-const GLASS = isLiquidGlassAvailable()
+/**
+ * `isLiquidGlassAvailable` reaches for the native module, which **throws**
+ * when it is not linked rather than returning `false`. This runs at module
+ * scope, so an unguarded throw would surface as a red screen while the app's
+ * import graph evaluates — taking everything down instead of degrading one
+ * bar. Below iOS 26 the module is present and simply answers `false`.
+ */
+function glassAvailable(): boolean {
+    try {
+        return isLiquidGlassAvailable()
+    } catch {
+        return false
+    }
+}
+
+const GLASS = glassAvailable()
 
 export default function PlaygroundTabBar({
     value,

--- a/apps/native-site/playground/PlaygroundTabBar.tsx
+++ b/apps/native-site/playground/PlaygroundTabBar.tsx
@@ -1,0 +1,64 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useChrome } from './chrome'
+import { TAB_ITEMS } from './tabBar.shared'
+import type { TabBarProps } from './tabBar.shared'
+
+/**
+ * Default bar — what the browser target gets. iOS and Android resolve their
+ * own files (`.ios` / `.android`) with the platform's real navigation
+ * chrome; there is nothing native to reach for here.
+ */
+export default function PlaygroundTabBar({
+    value,
+    onChange,
+    tabs,
+}: TabBarProps) {
+    const chrome = useChrome()
+    const insets = useSafeAreaInsets()
+
+    return (
+        <View
+            accessibilityRole="tablist"
+            style={[
+                styles.bar,
+                {
+                    backgroundColor: chrome.surface,
+                    borderTopColor: chrome.border,
+                    paddingBottom: 10 + insets.bottom,
+                },
+            ]}
+        >
+            {tabs.map((key) => {
+                const item = TAB_ITEMS[key]
+                const selected = key === value
+                const color = selected ? chrome.accent : chrome.fgMuted
+                return (
+                    <Pressable
+                        key={key}
+                        onPress={() => onChange(key)}
+                        accessibilityRole="tab"
+                        accessibilityState={{ selected }}
+                        accessibilityLabel={item.label}
+                        style={styles.item}
+                    >
+                        <item.icon size={20} color={color} />
+                        <Text style={[styles.label, { color }]}>
+                            {item.label}
+                        </Text>
+                    </Pressable>
+                )
+            })}
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    bar: {
+        flexDirection: 'row',
+        borderTopWidth: StyleSheet.hairlineWidth,
+        paddingTop: 10,
+    },
+    item: { flex: 1, alignItems: 'center', gap: 4, minHeight: 44 },
+    label: { fontSize: 11, fontWeight: '600' },
+})

--- a/apps/native-site/playground/chrome.ts
+++ b/apps/native-site/playground/chrome.ts
@@ -1,0 +1,71 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * The playground's own palette.
+ *
+ * Deliberately hand-rolled rather than read from Blend's tokens: the harness
+ * is the instrument used to inspect the library, so it must keep working
+ * when the library does not. A control panel built out of the components
+ * under test goes blank exactly when you need it most.
+ */
+export type ChromePalette = {
+    bg: string
+    surface: string
+    surfaceAlt: string
+    border: string
+    fg: string
+    fgMuted: string
+    accent: string
+    accentFg: string
+    /** The preview stage and its dashed boundary. */
+    stage: string
+    stageBorder: string
+    codeBg: string
+    codeFg: string
+    scrim: string
+}
+
+export const LIGHT_CHROME: ChromePalette = {
+    bg: '#FFFFFF',
+    surface: '#F7F8FA',
+    surfaceAlt: '#EDEFF3',
+    border: '#DFE3E9',
+    fg: '#1A1C23',
+    fgMuted: '#6B7280',
+    accent: '#2B7FFF',
+    accentFg: '#FFFFFF',
+    stage: '#FAFBFC',
+    stageBorder: '#C7CED8',
+    codeBg: '#F4F5F7',
+    codeFg: '#2B3038',
+    scrim: 'rgba(16, 18, 22, 0.4)',
+}
+
+export const DARK_CHROME: ChromePalette = {
+    bg: '#0E0F11',
+    surface: '#17191D',
+    surfaceAlt: '#212429',
+    border: '#2E3238',
+    fg: '#F5F6F7',
+    fgMuted: '#9BA3AF',
+    accent: '#4C8DFF',
+    accentFg: '#0A1220',
+    stage: '#131518',
+    stageBorder: '#3A3F47',
+    codeBg: '#1B1E23',
+    codeFg: '#D7DBE0',
+    scrim: 'rgba(0, 0, 0, 0.55)',
+}
+
+export const ChromeContext = createContext<ChromePalette>(LIGHT_CHROME)
+
+export function useChrome(): ChromePalette {
+    return useContext(ChromeContext)
+}
+
+/** Monospace face for the JSX snippet, per platform. */
+export const MONO_FONT = {
+    ios: 'Menlo',
+    android: 'monospace',
+    default: 'monospace',
+}

--- a/apps/native-site/playground/controls/ControlPanel.tsx
+++ b/apps/native-site/playground/controls/ControlPanel.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { useChrome } from '../chrome'
-import { CONTROL_GROUPS } from '../types'
+import { CONTROL_GROUPS, toggleValues } from '../types'
 import type { Control, ControlGroup, Option } from '../types'
 import SegmentedControl from './SegmentedControl'
 import SelectControl from './SelectControl'
@@ -76,8 +76,7 @@ function ControlRow<P extends object>({
     const set = (next: unknown) => onChange(control.key, next)
 
     if (control.kind === 'toggle') {
-        const on = control.on === undefined ? true : control.on
-        const off = control.off === undefined ? false : control.off
+        const { on, off } = toggleValues(control)
         return (
             <ToggleControl
                 label={control.label}

--- a/apps/native-site/playground/controls/ControlPanel.tsx
+++ b/apps/native-site/playground/controls/ControlPanel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { useChrome } from '../chrome'
 import { CONTROL_GROUPS } from '../types'
@@ -86,7 +87,7 @@ function ControlRow<P extends object>({
         )
     }
 
-    const labelled = (child: React.ReactNode) => (
+    const labelled = (child: ReactNode) => (
         <View style={styles.field}>
             <Text style={[styles.fieldLabel, { color: chrome.fgMuted }]}>
                 {control.label}

--- a/apps/native-site/playground/controls/ControlPanel.tsx
+++ b/apps/native-site/playground/controls/ControlPanel.tsx
@@ -1,0 +1,138 @@
+import { StyleSheet, Text, View } from 'react-native'
+import { useChrome } from '../chrome'
+import { CONTROL_GROUPS } from '../types'
+import type { Control, ControlGroup, Option } from '../types'
+import SegmentedControl from './SegmentedControl'
+import SelectControl from './SelectControl'
+import TextControl from './TextControl'
+import ToggleControl from './ToggleControl'
+
+/**
+ * Past this many values an inline row wraps into an unreadable block, so the
+ * panel promotes the control to a picker regardless of what the spec asked
+ * for. That keeps specs honest when an enum grows: nobody has to remember to
+ * change `segmented` to `select`.
+ */
+const MAX_INLINE_OPTIONS = 4
+
+const DEFAULT_GROUP: ControlGroup = 'Appearance'
+
+export default function ControlPanel<P extends object>({
+    controls,
+    props,
+    onChange,
+}: {
+    controls: readonly Control<P>[]
+    props: P
+    onChange: (key: string, value: unknown) => void
+}) {
+    const chrome = useChrome()
+
+    return (
+        <View style={styles.panel}>
+            {CONTROL_GROUPS.map((group) => {
+                const inGroup = controls.filter(
+                    (control) => (control.group ?? DEFAULT_GROUP) === group
+                )
+                if (inGroup.length === 0) return null
+
+                return (
+                    <View key={group} style={styles.group}>
+                        <Text
+                            style={[
+                                styles.groupTitle,
+                                { color: chrome.fgMuted },
+                            ]}
+                        >
+                            {group}
+                        </Text>
+                        {inGroup.map((control) => (
+                            <ControlRow
+                                key={control.key}
+                                control={control}
+                                props={props}
+                                onChange={onChange}
+                            />
+                        ))}
+                    </View>
+                )
+            })}
+        </View>
+    )
+}
+
+function ControlRow<P extends object>({
+    control,
+    props,
+    onChange,
+}: {
+    control: Control<P>
+    props: P
+    onChange: (key: string, value: unknown) => void
+}) {
+    const chrome = useChrome()
+    const value = (props as Record<string, unknown>)[control.key]
+    const set = (next: unknown) => onChange(control.key, next)
+
+    if (control.kind === 'toggle') {
+        const on = control.on === undefined ? true : control.on
+        const off = control.off === undefined ? false : control.off
+        return (
+            <ToggleControl
+                label={control.label}
+                value={Object.is(value, on)}
+                onChange={(isOn) => set(isOn ? on : off)}
+            />
+        )
+    }
+
+    const labelled = (child: React.ReactNode) => (
+        <View style={styles.field}>
+            <Text style={[styles.fieldLabel, { color: chrome.fgMuted }]}>
+                {control.label}
+            </Text>
+            {child}
+        </View>
+    )
+
+    if (control.kind === 'text') {
+        return labelled(
+            <TextControl
+                label={control.label}
+                value={typeof value === 'string' ? value : ''}
+                placeholder={control.placeholder}
+                onChange={set}
+            />
+        )
+    }
+
+    const options = control.options as readonly Option<unknown>[]
+    const inline =
+        control.kind === 'segmented' && options.length <= MAX_INLINE_OPTIONS
+
+    return labelled(
+        inline ? (
+            <SegmentedControl options={options} value={value} onChange={set} />
+        ) : (
+            <SelectControl
+                label={control.label}
+                options={options}
+                value={value}
+                onChange={set}
+            />
+        )
+    )
+}
+
+const styles = StyleSheet.create({
+    panel: { gap: 20 },
+    group: { gap: 12 },
+    groupTitle: {
+        fontSize: 11,
+        fontWeight: '700',
+        letterSpacing: 0.6,
+        textTransform: 'uppercase',
+    },
+    field: { gap: 6 },
+    fieldLabel: { fontSize: 12, fontWeight: '500' },
+})

--- a/apps/native-site/playground/controls/SegmentedControl.tsx
+++ b/apps/native-site/playground/controls/SegmentedControl.tsx
@@ -1,0 +1,76 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useChrome } from '../chrome'
+import type { Option } from '../types'
+
+/**
+ * Inline option row, for controls with few enough values to read at a
+ * glance. `ControlPanel` falls back to `SelectControl` past that point.
+ */
+export default function SegmentedControl({
+    options,
+    value,
+    onChange,
+}: {
+    options: readonly Option<unknown>[]
+    value: unknown
+    onChange: (value: unknown) => void
+}) {
+    const chrome = useChrome()
+
+    return (
+        <View style={styles.row}>
+            {options.map((option) => {
+                const selected = Object.is(option.value, value)
+                return (
+                    <Pressable
+                        key={option.label}
+                        onPress={() => onChange(option.value)}
+                        accessibilityRole="radio"
+                        accessibilityState={{ selected }}
+                        accessibilityLabel={option.label}
+                        style={[
+                            styles.item,
+                            {
+                                backgroundColor: selected
+                                    ? chrome.accent
+                                    : chrome.surfaceAlt,
+                                borderColor: selected
+                                    ? chrome.accent
+                                    : chrome.border,
+                            },
+                        ]}
+                    >
+                        <Text
+                            style={[
+                                styles.label,
+                                {
+                                    color: selected
+                                        ? chrome.accentFg
+                                        : chrome.fg,
+                                },
+                            ]}
+                        >
+                            {option.label}
+                        </Text>
+                    </Pressable>
+                )
+            })}
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    row: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+    item: {
+        paddingVertical: 7,
+        paddingHorizontal: 12,
+        borderRadius: 8,
+        borderWidth: 1,
+        // 44pt is the platform minimum for a touch target; these sit in a
+        // dense panel, so the row keeps the height and the hit area grows
+        // via padding rather than the label.
+        minHeight: 34,
+        justifyContent: 'center',
+    },
+    label: { fontSize: 13, fontWeight: '500' },
+})

--- a/apps/native-site/playground/controls/SelectControl.tsx
+++ b/apps/native-site/playground/controls/SelectControl.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { Modal, Pressable, ScrollView, StyleSheet, Text } from 'react-native'
+import { Check, ChevronDown } from 'lucide-react-native'
+import { useChrome } from '../chrome'
+import type { Option } from '../types'
+
+/**
+ * Value picker for controls with more options than fit inline. Built on RN's
+ * own `Modal` rather than Blend's `BottomSheet` — see `chrome.ts` for why
+ * the harness does not consume the library it inspects.
+ */
+export default function SelectControl({
+    label,
+    options,
+    value,
+    onChange,
+}: {
+    label: string
+    options: readonly Option<unknown>[]
+    value: unknown
+    onChange: (value: unknown) => void
+}) {
+    const chrome = useChrome()
+    const [open, setOpen] = useState(false)
+    const current = options.find((option) => Object.is(option.value, value))
+
+    return (
+        <>
+            <Pressable
+                onPress={() => setOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel={`${label}: ${current?.label ?? 'none'}`}
+                accessibilityHint="Opens the value list"
+                style={[
+                    styles.trigger,
+                    {
+                        backgroundColor: chrome.surfaceAlt,
+                        borderColor: chrome.border,
+                    },
+                ]}
+            >
+                <Text style={[styles.triggerLabel, { color: chrome.fg }]}>
+                    {current?.label ?? '—'}
+                </Text>
+                <ChevronDown size={16} color={chrome.fgMuted} />
+            </Pressable>
+
+            <Modal
+                visible={open}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setOpen(false)}
+            >
+                <Pressable
+                    style={[styles.scrim, { backgroundColor: chrome.scrim }]}
+                    onPress={() => setOpen(false)}
+                    accessibilityRole="button"
+                    accessibilityLabel="Close the value list"
+                >
+                    {/* Swallows presses so a tap on the sheet itself does not
+                        fall through to the scrim's dismiss handler. */}
+                    <Pressable
+                        style={[
+                            styles.sheet,
+                            {
+                                backgroundColor: chrome.bg,
+                                borderColor: chrome.border,
+                            },
+                        ]}
+                        onPress={() => {}}
+                    >
+                        <Text style={[styles.title, { color: chrome.fgMuted }]}>
+                            {label}
+                        </Text>
+                        <ScrollView>
+                            {options.map((option) => {
+                                const selected = Object.is(option.value, value)
+                                return (
+                                    <Pressable
+                                        key={option.label}
+                                        accessibilityRole="menuitem"
+                                        accessibilityState={{ selected }}
+                                        onPress={() => {
+                                            onChange(option.value)
+                                            setOpen(false)
+                                        }}
+                                        style={styles.row}
+                                    >
+                                        <Text
+                                            style={[
+                                                styles.rowLabel,
+                                                { color: chrome.fg },
+                                            ]}
+                                        >
+                                            {option.label}
+                                        </Text>
+                                        {selected ? (
+                                            <Check
+                                                size={16}
+                                                color={chrome.accent}
+                                            />
+                                        ) : null}
+                                    </Pressable>
+                                )
+                            })}
+                        </ScrollView>
+                    </Pressable>
+                </Pressable>
+            </Modal>
+        </>
+    )
+}
+
+const styles = StyleSheet.create({
+    trigger: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 8,
+        minHeight: 40,
+        paddingVertical: 8,
+        paddingHorizontal: 12,
+        borderRadius: 8,
+        borderWidth: 1,
+    },
+    triggerLabel: { fontSize: 13, fontWeight: '500', flexShrink: 1 },
+    scrim: { flex: 1, justifyContent: 'flex-end' },
+    sheet: {
+        maxHeight: '70%',
+        borderTopLeftRadius: 16,
+        borderTopRightRadius: 16,
+        borderWidth: StyleSheet.hairlineWidth,
+        paddingTop: 12,
+        paddingBottom: 28,
+        paddingHorizontal: 8,
+    },
+    title: {
+        fontSize: 11,
+        fontWeight: '700',
+        letterSpacing: 0.6,
+        textTransform: 'uppercase',
+        paddingHorizontal: 12,
+        paddingBottom: 8,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        minHeight: 44,
+        paddingHorizontal: 12,
+    },
+    rowLabel: { fontSize: 15, flexShrink: 1 },
+})

--- a/apps/native-site/playground/controls/TextControl.tsx
+++ b/apps/native-site/playground/controls/TextControl.tsx
@@ -1,0 +1,46 @@
+import { StyleSheet, TextInput } from 'react-native'
+import { useChrome } from '../chrome'
+
+/** Free-text control, for headings, labels and body copy. */
+export default function TextControl({
+    label,
+    value,
+    placeholder,
+    onChange,
+}: {
+    label: string
+    value: string
+    placeholder?: string
+    onChange: (value: string) => void
+}) {
+    const chrome = useChrome()
+
+    return (
+        <TextInput
+            value={value}
+            onChangeText={onChange}
+            placeholder={placeholder}
+            placeholderTextColor={chrome.fgMuted}
+            accessibilityLabel={label}
+            style={[
+                styles.input,
+                {
+                    color: chrome.fg,
+                    backgroundColor: chrome.surfaceAlt,
+                    borderColor: chrome.border,
+                },
+            ]}
+        />
+    )
+}
+
+const styles = StyleSheet.create({
+    input: {
+        minHeight: 40,
+        paddingVertical: 8,
+        paddingHorizontal: 12,
+        borderRadius: 8,
+        borderWidth: 1,
+        fontSize: 13,
+    },
+})

--- a/apps/native-site/playground/controls/ToggleControl.tsx
+++ b/apps/native-site/playground/controls/ToggleControl.tsx
@@ -1,0 +1,43 @@
+import { StyleSheet, Switch, Text, View } from 'react-native'
+import { useChrome } from '../chrome'
+
+/**
+ * Boolean control. Uses RN's `Switch`, which is the real platform control on
+ * both targets — a UISwitch on iOS, a Material switch on Android.
+ */
+export default function ToggleControl({
+    label,
+    value,
+    onChange,
+}: {
+    label: string
+    value: boolean
+    onChange: (value: boolean) => void
+}) {
+    const chrome = useChrome()
+
+    return (
+        <View style={styles.row}>
+            <Text style={[styles.label, { color: chrome.fg }]}>{label}</Text>
+            <Switch
+                value={value}
+                onValueChange={onChange}
+                accessibilityLabel={label}
+                trackColor={{ false: chrome.border, true: chrome.accent }}
+                thumbColor={chrome.bg}
+                ios_backgroundColor={chrome.border}
+            />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        minHeight: 36,
+    },
+    label: { fontSize: 13, fontWeight: '500', flexShrink: 1 },
+})

--- a/apps/native-site/playground/snippet.test.ts
+++ b/apps/native-site/playground/snippet.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { buildSnippet, indent } from './snippet'
-import { enumOptions, humanize, numberOptions, unionOptions } from './types'
+import { addProps, buildSnippet, indent, replaceProp } from './snippet'
+import {
+    enumOptions,
+    humanize,
+    numberOptions,
+    toggleValues,
+    unionOptions,
+} from './types'
 import type { Control } from './types'
 
 enum Color {
@@ -79,6 +85,12 @@ describe('buildSnippet', () => {
         expect(snippet({ count: 2 })).toContain('count={2}')
     })
 
+    it('drops a slot cleared back to undefined, rather than printing {false}', () => {
+        // Regression: `off: undefined` used to collapse to `false`, which
+        // put `leftSlot={false}` in the block — not valid for the prop type.
+        expect(snippet({ leftSlot: undefined })).not.toContain('leftSlot')
+    })
+
     it('uses the toggle code hint for non-scalar values', () => {
         expect(snippet({ leftSlot: SLOT })).toContain(
             'leftSlot={{ slot: <Star /> }}'
@@ -129,16 +141,76 @@ describe('buildSnippet', () => {
     })
 })
 
+describe('replaceProp', () => {
+    const block = '<Tag\n    text="Blend"\n    size={2}\n/>'
+
+    it('rewrites the matching line and keeps its indentation', () => {
+        expect(replaceProp(block, 'text', '"First"')).toBe(
+            '<Tag\n    text="First"\n    size={2}\n/>'
+        )
+    })
+
+    it('leaves the block alone when the prop is absent', () => {
+        expect(replaceProp(block, 'color', '"red"')).toBe(block)
+    })
+})
+
+describe('addProps', () => {
+    it('appends to a multi-line block', () => {
+        expect(addProps('<Sheet\n    topRadius={0}\n/>', ['open={open}'])).toBe(
+            '<Sheet\n    topRadius={0}\n    open={open}\n/>'
+        )
+    })
+
+    it('expands a self-closed one-liner, which has no line to append after', () => {
+        expect(addProps('<Sheet />', ['open={open}'])).toBe(
+            '<Sheet\n    open={open}\n/>'
+        )
+    })
+})
+
 describe('indent', () => {
     it('shifts every non-empty line and leaves blank lines alone', () => {
         expect(indent('a\n\nb')).toBe('    a\n\n    b')
     })
 })
 
+describe('toggleValues', () => {
+    it('defaults to true / false when the spec says nothing', () => {
+        expect(toggleValues({})).toEqual({ on: true, off: false })
+    })
+
+    it('treats an explicit `off: undefined` as "clear the prop"', () => {
+        // Regression: this used to collapse to `false`, so switching a slot
+        // toggle on and off wrote `leftSlot={false}` — into the component's
+        // props and into the generated JSX, where it does not type-check.
+        expect(toggleValues({ on: SLOT, off: undefined })).toEqual({
+            on: SLOT,
+            off: undefined,
+        })
+    })
+
+    it('still honours an explicit `off: false`', () => {
+        expect(toggleValues({ on: 'yes', off: false })).toEqual({
+            on: 'yes',
+            off: false,
+        })
+    })
+})
+
 describe('option builders', () => {
     it('humanizes enum keys', () => {
         expect(humanize('NO_FILL')).toBe('No fill')
+        expect(humanize('SUCCESS')).toBe('Success')
+        expect(humanize('MD')).toBe('Md')
+        expect(humanize('wrap-clamp')).toBe('Wrap clamp')
         expect(humanize('sm')).toBe('Sm')
+    })
+
+    it('leaves component names alone rather than flattening their case', () => {
+        // Regression: these used to render as "Taggroup" / "Iconbutton".
+        expect(humanize('TagGroup')).toBe('TagGroup')
+        expect(humanize('IconButton')).toBe('IconButton')
     })
 
     it('derives options from the enum object, not a hardcoded list', () => {

--- a/apps/native-site/playground/snippet.test.ts
+++ b/apps/native-site/playground/snippet.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import { buildSnippet, indent } from './snippet'
+import { enumOptions, humanize, numberOptions, unionOptions } from './types'
+import type { Control } from './types'
+
+enum Color {
+    SUCCESS = 'success',
+    NO_FILL = 'noFill',
+}
+
+type Props = {
+    text?: string
+    color?: Color
+    count?: number
+    disabled?: boolean
+    leftSlot?: { slot: string }
+}
+
+const SLOT = { slot: 'star' }
+
+const defaults: Props = { text: 'Blend', color: Color.SUCCESS }
+
+const controls: readonly Control<Props>[] = [
+    { kind: 'text', key: 'text', label: 'Text', always: true },
+    {
+        kind: 'segmented',
+        key: 'color',
+        label: 'Color',
+        options: enumOptions(Color, 'Color'),
+    },
+    {
+        kind: 'segmented',
+        key: 'count',
+        label: 'Count',
+        options: numberOptions([1, 2]),
+    },
+    { kind: 'toggle', key: 'disabled', label: 'Disabled' },
+    {
+        kind: 'toggle',
+        key: 'leftSlot',
+        label: 'Left slot',
+        on: SLOT,
+        off: undefined,
+        onCode: '{ slot: <Star /> }',
+    },
+]
+
+const snippet = (props: Props) =>
+    buildSnippet('Tag', { ...defaults, ...props }, defaults, controls)
+
+describe('buildSnippet', () => {
+    it('omits props still at their default', () => {
+        expect(snippet({})).toBe('<Tag\n    text="Blend"\n/>')
+    })
+
+    it('keeps a prop marked `always`, so the snippet still renders something', () => {
+        // `text` equals the default here and is printed anyway.
+        expect(snippet({})).toContain('text="Blend"')
+    })
+
+    it('prints enum values by name rather than by string value', () => {
+        expect(snippet({ color: Color.NO_FILL })).toContain(
+            'color={Color.NO_FILL}'
+        )
+    })
+
+    it('quotes strings and shorthands true booleans', () => {
+        const out = snippet({ text: 'Hi', disabled: true })
+        expect(out).toContain('text="Hi"')
+        expect(out).toContain('\n    disabled\n')
+        expect(out).not.toContain('disabled={true}')
+    })
+
+    it('prints false explicitly, since the default was undefined', () => {
+        expect(snippet({ disabled: false })).toContain('disabled={false}')
+    })
+
+    it('wraps numbers in braces', () => {
+        expect(snippet({ count: 2 })).toContain('count={2}')
+    })
+
+    it('uses the toggle code hint for non-scalar values', () => {
+        expect(snippet({ leftSlot: SLOT })).toContain(
+            'leftSlot={{ slot: <Star /> }}'
+        )
+    })
+
+    it('falls back to a placeholder when a non-scalar has no code hint', () => {
+        const out = buildSnippet('Tag', { leftSlot: { slot: 'x' } }, {}, [
+            { kind: 'toggle', key: 'leftSlot', label: 'Slot', on: SLOT },
+        ])
+        expect(out).toContain('leftSlot={/* ... */}')
+    })
+
+    it('switches to an expression when a string contains a quote', () => {
+        expect(snippet({ text: 'say "hi"' })).toContain('text={"say \\"hi\\""}')
+    })
+
+    it('self-closes on one line when nothing differs and nothing is forced', () => {
+        expect(buildSnippet('Spinner', {}, {}, [])).toBe('<Spinner />')
+    })
+
+    it('leaves hidden controls out, so playground-only props never reach the JSX', () => {
+        const out = buildSnippet('Tag', { count: 2, disabled: true }, {}, [
+            {
+                kind: 'segmented',
+                key: 'count',
+                label: 'Family',
+                hidden: true,
+                options: numberOptions([1, 2]),
+            },
+            { kind: 'toggle', key: 'disabled', label: 'Disabled' },
+        ])
+        expect(out).not.toContain('count')
+        expect(out).toContain('disabled')
+    })
+
+    it('passes the rendered block through `wrapSnippet`', () => {
+        const out = buildSnippet(
+            'Tag',
+            { text: 'Hi' },
+            {},
+            [{ kind: 'text', key: 'text', label: 'Text' }],
+            (inner) => `<TagGroup>\n${indent(inner)}\n</TagGroup>`
+        )
+        expect(out).toBe(
+            '<TagGroup>\n    <Tag\n        text="Hi"\n    />\n</TagGroup>'
+        )
+    })
+})
+
+describe('indent', () => {
+    it('shifts every non-empty line and leaves blank lines alone', () => {
+        expect(indent('a\n\nb')).toBe('    a\n\n    b')
+    })
+})
+
+describe('option builders', () => {
+    it('humanizes enum keys', () => {
+        expect(humanize('NO_FILL')).toBe('No fill')
+        expect(humanize('sm')).toBe('Sm')
+    })
+
+    it('derives options from the enum object, not a hardcoded list', () => {
+        expect(enumOptions(Color, 'Color')).toEqual([
+            { label: 'Success', value: 'success', code: 'Color.SUCCESS' },
+            { label: 'No fill', value: 'noFill', code: 'Color.NO_FILL' },
+        ])
+    })
+
+    it('builds union options without a code hint', () => {
+        type Shape = 'circle' | 'square'
+        expect(unionOptions<Shape>()(['circle', 'square'])).toEqual([
+            { label: 'Circle', value: 'circle' },
+            { label: 'Square', value: 'square' },
+        ])
+    })
+})

--- a/apps/native-site/playground/snippet.ts
+++ b/apps/native-site/playground/snippet.ts
@@ -58,6 +58,34 @@ function codeFor<P>(control: Control<P>, value: unknown): string | undefined {
     return undefined
 }
 
+/**
+ * Rewrites one prop line in a rendered block, for `wrapSnippet`. Returns the
+ * block untouched when the prop is not present.
+ */
+export function replaceProp(
+    jsx: string,
+    key: string,
+    formatted: string
+): string {
+    const lines = jsx.split('\n')
+    const index = lines.findIndex((line) => line.trim().startsWith(`${key}=`))
+    if (index === -1) return jsx
+
+    const line = lines[index]
+    const pad = line.slice(0, line.length - line.trimStart().length)
+    lines[index] = `${pad}${key}=${formatted}`
+    return lines.join('\n')
+}
+
+/** Inserts prop lines the stage supplies but no control drives. */
+export function addProps(jsx: string, props: readonly string[]): string {
+    const extra = props.map((prop) => `${INDENT}${prop}`).join('\n')
+    if (jsx.endsWith(' />')) {
+        return `${jsx.slice(0, -3)}\n${extra}\n/>`
+    }
+    return jsx.replace(/\n\/>$/, `\n${extra}\n/>`)
+}
+
 export function buildSnippet<P extends object>(
     componentName: string,
     props: P,

--- a/apps/native-site/playground/snippet.ts
+++ b/apps/native-site/playground/snippet.ts
@@ -1,0 +1,96 @@
+import type { Control, Option } from './types'
+
+/**
+ * Renders the current playground props as the JSX you would write to get
+ * them. Pure — no React, no react-native — so it is unit-tested directly.
+ *
+ * Only props that differ from the spec defaults are printed, which keeps the
+ * block short as controls change and doubles as documentation of what the
+ * defaults actually are. Props the component has no default for opt out with
+ * `always: true` on their control, otherwise the snippet would render
+ * nothing.
+ */
+
+const INDENT = '    '
+
+/** Re-indents a rendered block, for `wrapSnippet`. */
+export function indent(text: string, levels = 1): string {
+    const pad = INDENT.repeat(levels)
+    return text
+        .split('\n')
+        .map((line) => (line.length > 0 ? pad + line : line))
+        .join('\n')
+}
+
+/** Escapes a string for a JSX attribute, switching to an expression when a quote or newline makes the attribute form illegal. */
+function formatString(value: string): string {
+    if (value.includes('"') || value.includes('\n')) {
+        return `{${JSON.stringify(value)}}`
+    }
+    return `"${value}"`
+}
+
+/**
+ * `null` means "omit this prop". `undefined` values are omitted because
+ * passing them is the same as not passing them.
+ */
+function formatValue(value: unknown, code: string | undefined): string | null {
+    if (code !== undefined) return `{${code}}`
+    if (value === undefined || value === null) return null
+    if (typeof value === 'string') return formatString(value)
+    if (typeof value === 'boolean') return value ? '' : '{false}'
+    if (typeof value === 'number') return `{${value}}`
+    // Slots, actions and handlers have no readable literal form. The control
+    // can supply one via `code`/`onCode`; without it, say so rather than
+    // printing `[object Object]`.
+    return '{/* ... */}'
+}
+
+function codeFor<P>(control: Control<P>, value: unknown): string | undefined {
+    if (control.kind === 'select' || control.kind === 'segmented') {
+        const options = control.options as readonly Option<unknown>[]
+        return options.find((option) => Object.is(option.value, value))?.code
+    }
+    if (control.kind === 'toggle') {
+        const on = control.on === undefined ? true : control.on
+        return Object.is(value, on) ? control.onCode : undefined
+    }
+    return undefined
+}
+
+export function buildSnippet<P extends object>(
+    componentName: string,
+    props: P,
+    defaults: P,
+    controls: readonly Control<P>[],
+    wrap?: (inner: string, props: P) => string
+): string {
+    const lines: string[] = []
+
+    for (const control of controls) {
+        if (control.hidden) continue
+        const key = control.key as keyof P
+        const value = props[key]
+
+        // Defaults are scalars or module-level constants, so identity is the
+        // right comparison — a slot object is the same object until a
+        // control swaps it.
+        if (!control.always && Object.is(value, defaults[key])) continue
+
+        const formatted = formatValue(value, codeFor(control, value))
+        if (formatted === null) continue
+
+        lines.push(
+            formatted === ''
+                ? `${INDENT}${control.key}`
+                : `${INDENT}${control.key}=${formatted}`
+        )
+    }
+
+    const inner =
+        lines.length === 0
+            ? `<${componentName} />`
+            : `<${componentName}\n${lines.join('\n')}\n/>`
+
+    return wrap ? wrap(inner, props) : inner
+}

--- a/apps/native-site/playground/specs/alert.spec.tsx
+++ b/apps/native-site/playground/specs/alert.spec.tsx
@@ -1,0 +1,129 @@
+import {
+    Alert,
+    AlertActionPosition,
+    AlertSubType,
+    AlertType,
+} from 'blend-native'
+import type { AlertActions, AlertNativeProps } from 'blend-native'
+import AlertShowcase from '../../components/AlertShowcase'
+import { BELL_NODE } from './slots'
+import { enumOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const noop = () => {}
+
+/**
+ * `actions` is one object, so position and the two buttons share a control.
+ * The list is the shapes worth seeing rather than every permutation.
+ */
+const ACTION_SETS: readonly {
+    label: string
+    value: AlertActions | undefined
+    code?: string
+}[] = [
+    { label: 'None', value: undefined },
+    {
+        label: 'Primary',
+        value: { primaryAction: { text: 'Retry', onPress: noop } },
+        code: "{ primaryAction: { text: 'Retry', onPress } }",
+    },
+    {
+        label: 'Primary + secondary',
+        value: {
+            primaryAction: { text: 'Retry', onPress: noop },
+            secondaryAction: { text: 'Dismiss', onPress: noop },
+        },
+        code: "{ primaryAction: { text: 'Retry', onPress }, secondaryAction: { text: 'Dismiss', onPress } }",
+    },
+    {
+        label: 'Inline (right)',
+        value: {
+            position: AlertActionPosition.RIGHT,
+            primaryAction: { text: 'Retry', onPress: noop },
+        },
+        code: "{ position: AlertActionPosition.RIGHT, primaryAction: { text: 'Retry', onPress } }",
+    },
+]
+
+const CLOSE_BUTTON = { show: true, onPress: noop }
+const ALERT_SLOT = { slot: BELL_NODE }
+
+const spec: ComponentSpec<AlertNativeProps> = {
+    name: 'Alert',
+    summary:
+        'Announced to assistive tech on appearance, matching web’s hard-coded assertive live region. Turn `announce` off for alerts that are part of a screen’s initial content, or several of them talk over each other.',
+    mode: 'inline',
+    gallery: AlertShowcase,
+    defaults: {
+        type: AlertType.PRIMARY,
+        subType: AlertSubType.SUBTLE,
+        heading: 'Settlement delayed',
+        description:
+            'The acquirer has not confirmed this batch yet. Payouts will resume once it does.',
+        // Off by default: every control change remounts the alert, and an
+        // announcement on each one would make the screen reader unusable.
+        announce: false,
+    },
+    controls: [
+        {
+            kind: 'select',
+            key: 'type',
+            label: 'Type',
+            options: enumOptions(AlertType, 'AlertType'),
+        },
+        {
+            kind: 'segmented',
+            key: 'subType',
+            label: 'Sub type',
+            options: enumOptions(AlertSubType, 'AlertSubType'),
+        },
+        {
+            kind: 'text',
+            key: 'heading',
+            label: 'Heading',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'description',
+            label: 'Description',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'select',
+            key: 'actions',
+            label: 'Actions',
+            group: 'Content',
+            options: ACTION_SETS,
+        },
+        {
+            kind: 'toggle',
+            key: 'slot',
+            label: 'Leading slot',
+            group: 'Content',
+            on: ALERT_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Bell size={16} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'closeButton',
+            label: 'Close button',
+            group: 'Content',
+            on: CLOSE_BUTTON,
+            off: undefined,
+            onCode: '{ show: true, onPress }',
+        },
+        {
+            kind: 'toggle',
+            key: 'announce',
+            label: 'Announce on appear',
+            group: 'State',
+        },
+    ],
+    render: (props) => <Alert {...props} />,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/avatar.spec.tsx
+++ b/apps/native-site/playground/specs/avatar.spec.tsx
@@ -1,0 +1,102 @@
+import {
+    Avatar,
+    AvatarShape,
+    AvatarSize,
+    AvatarStatusPosition,
+    AvatarStatusType,
+} from 'blend-native'
+import type { AvatarNativeProps } from 'blend-native'
+import DisplayShowcase from '../../components/DisplayShowcase'
+import { enumOptions, humanize } from '../types'
+import type { ComponentSpec } from '../types'
+
+const SAMPLE_IMAGE =
+    'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop'
+
+/**
+ * `status` is one object prop, so type and position share a control rather
+ * than getting one each — a second control writing to the same key would
+ * clobber the first. The list carries every status plus one off-default
+ * position, which is what there is to see.
+ */
+const STATUSES = [
+    { label: 'None', value: undefined },
+    ...Object.entries(AvatarStatusType)
+        .filter(([, value]) => value !== AvatarStatusType.NONE)
+        .map(([key, value]) => ({
+            label: humanize(key),
+            value: {
+                type: value,
+                position: AvatarStatusPosition.BOTTOM_RIGHT,
+            },
+            code: `{ type: AvatarStatusType.${key} }`,
+        })),
+    {
+        label: 'Online, top left',
+        value: {
+            type: AvatarStatusType.ONLINE,
+            position: AvatarStatusPosition.TOP_LEFT,
+        },
+        code: '{ type: AvatarStatusType.ONLINE, position: AvatarStatusPosition.TOP_LEFT }',
+    },
+] as const
+
+const spec: ComponentSpec<AvatarNativeProps> = {
+    name: 'Avatar',
+    summary:
+        'Image with an initials fallback. The fallback colour is hashed from the text by the same function web uses, so a person keeps their colour across platforms.',
+    mode: 'inline',
+    gallery: DisplayShowcase,
+    defaults: {
+        alt: 'Priya Raman',
+        size: AvatarSize.MD,
+        shape: AvatarShape.CIRCULAR,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(AvatarSize, 'AvatarSize'),
+        },
+        {
+            kind: 'segmented',
+            key: 'shape',
+            label: 'Shape',
+            options: enumOptions(AvatarShape, 'AvatarShape'),
+        },
+        {
+            kind: 'toggle',
+            key: 'src',
+            label: 'Load an image',
+            group: 'Content',
+            on: SAMPLE_IMAGE,
+            off: undefined,
+            onCode: '"https://..."',
+        },
+        {
+            kind: 'text',
+            key: 'alt',
+            label: 'Name (drives the initials)',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'fallbackText',
+            label: 'Override the initials',
+            group: 'Content',
+            placeholder: 'PR',
+        },
+        {
+            kind: 'select',
+            key: 'status',
+            label: 'Status dot',
+            group: 'State',
+            options: STATUSES,
+        },
+    ],
+    render: (props) => <Avatar {...props} />,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/bottomSheet.spec.tsx
+++ b/apps/native-site/playground/specs/bottomSheet.spec.tsx
@@ -1,0 +1,99 @@
+import { StyleSheet, Text, View } from 'react-native'
+import { BottomSheet } from 'blend-native'
+import type { BottomSheetProps } from 'blend-native'
+import SheetShowcase from '../../components/SheetShowcase'
+import { numberOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+/**
+ * `open` and `onClose` come from the harness rather than from controls — the
+ * stage owns visibility for overlay specs — so they are dropped from the
+ * spec's prop type and supplied in `render`.
+ */
+type SheetPlaygroundProps = Omit<BottomSheetProps, 'open' | 'onClose'> & {
+    /** Playground-only: how much content to put in, to exercise the cap. */
+    paragraphs: number
+}
+
+const BODY =
+    'Dragging past the halfway point dismisses the sheet when dragToDismiss is on. The sheet never grows past maxHeightFraction of the screen, and scrolls inside that instead.'
+
+const spec: ComponentSpec<SheetPlaygroundProps> = {
+    name: 'BottomSheet',
+    summary:
+        'The gesture-driven sheet the phone modes of Select, Menu and Modal are built on. Also public, for consumer-built sheets.',
+    mode: 'overlay',
+    triggerLabel: 'Open the sheet',
+    gallery: SheetShowcase,
+    defaults: {
+        paragraphs: 2,
+        showHandle: true,
+        dragToDismiss: true,
+        dismissOnBackdropPress: true,
+        maxHeightFraction: 0.6,
+        topRadius: 16,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'maxHeightFraction',
+            label: 'Max height',
+            options: [
+                { label: '40%', value: 0.4, code: '0.4' },
+                { label: '60%', value: 0.6, code: '0.6' },
+                { label: '90%', value: 0.9, code: '0.9' },
+            ],
+        },
+        {
+            kind: 'segmented',
+            key: 'topRadius',
+            label: 'Top radius',
+            options: numberOptions([0, 16, 28]),
+        },
+        {
+            kind: 'segmented',
+            key: 'paragraphs',
+            label: 'Content length',
+            hidden: true,
+            options: numberOptions([1, 2, 6]),
+        },
+        { kind: 'toggle', key: 'showHandle', label: 'Handle', group: 'State' },
+        {
+            kind: 'toggle',
+            key: 'dragToDismiss',
+            label: 'Drag to dismiss',
+            group: 'State',
+        },
+        {
+            kind: 'toggle',
+            key: 'dismissOnBackdropPress',
+            label: 'Dismiss on backdrop press',
+            group: 'State',
+        },
+    ],
+    render: ({ paragraphs, ...props }, ctx) => (
+        <BottomSheet
+            {...props}
+            open={ctx.open}
+            onClose={() => ctx.setOpen(false)}
+            accessibilityLabel="Playground sheet"
+        >
+            <View style={styles.body}>
+                <Text style={styles.title}>Sheet</Text>
+                {Array.from({ length: paragraphs }, (_, index) => (
+                    <Text key={index} style={styles.paragraph}>
+                        {BODY}
+                    </Text>
+                ))}
+            </View>
+        </BottomSheet>
+    ),
+}
+
+const styles = StyleSheet.create({
+    body: { padding: 20, gap: 12 },
+    title: { fontSize: 17, fontWeight: '700' },
+    paragraph: { fontSize: 14, lineHeight: 21 },
+})
+
+export default spec

--- a/apps/native-site/playground/specs/bottomSheet.spec.tsx
+++ b/apps/native-site/playground/specs/bottomSheet.spec.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View } from 'react-native'
 import { BottomSheet } from 'blend-native'
 import type { BottomSheetProps } from 'blend-native'
 import SheetShowcase from '../../components/SheetShowcase'
+import { addProps, indent } from '../snippet'
 import { numberOptions } from '../types'
 import type { ComponentSpec } from '../types'
 
@@ -88,6 +89,18 @@ const spec: ComponentSpec<SheetPlaygroundProps> = {
             </View>
         </BottomSheet>
     ),
+    // `open`, `onClose` and the children come from the harness, not from a
+    // control, and `open`/`onClose` are required — without them the block
+    // would not compile if you pasted it.
+    wrapSnippet: (inner) => {
+        const withRequired = addProps(inner, [
+            'open={open}',
+            'onClose={() => setOpen(false)}',
+        ])
+        return `${withRequired.replace(/\n?\/>$/, '\n>')}\n${indent(
+            '<SheetBody />'
+        )}\n</BottomSheet>`
+    },
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-site/playground/specs/button.spec.tsx
+++ b/apps/native-site/playground/specs/button.spec.tsx
@@ -1,0 +1,208 @@
+import {
+    Button,
+    ButtonGroup,
+    ButtonSize,
+    ButtonSubType,
+    ButtonType,
+    IconButton,
+    LinkButton,
+} from 'blend-native'
+import type { ButtonNativeProps } from 'blend-native'
+import ButtonShowcase from '../../components/ButtonShowcase'
+import { BELL_NODE, CHECK_SLOT, STAR_SLOT } from './slots'
+import { indent } from '../snippet'
+import { enumOptions, numberOptions, unionOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+/**
+ * Which of the four exported components the stage renders. Playground-only,
+ * so it is `hidden` from the snippet; `wrapSnippet` renames the element
+ * instead.
+ */
+type ButtonFamily = 'Button' | 'IconButton' | 'LinkButton' | 'ButtonGroup'
+
+type ButtonPlaygroundProps = ButtonNativeProps & { family: ButtonFamily }
+
+/**
+ * Strips props a narrower family does not accept. Spreading them through
+ * would not be a type error — TypeScript skips excess-property checks on a
+ * JSX spread — but it would reach the component at runtime and undo the
+ * thing that makes the family distinct.
+ */
+function omit<T extends object, K extends keyof T>(
+    source: T,
+    keys: readonly K[]
+): Omit<T, K> {
+    const next = { ...source }
+    for (const key of keys) delete next[key]
+    return next
+}
+
+function ButtonFamilyPreview({ family, ...props }: ButtonPlaygroundProps) {
+    if (family === 'IconButton') {
+        // The icon-only shape cannot be undone from outside: `text`, the
+        // slots and `subType` are absent from IconButton's props on purpose.
+        return (
+            <IconButton
+                {...omit(props, ['text', 'subType', 'leftSlot', 'rightSlot'])}
+                icon={BELL_NODE}
+                accessibilityLabel="Notifications"
+            />
+        )
+    }
+
+    if (family === 'LinkButton') {
+        return (
+            <LinkButton
+                {...omit(props, ['justifyContent', 'buttonGroupPosition'])}
+            />
+        )
+    }
+
+    if (family === 'ButtonGroup') {
+        return (
+            <ButtonGroup>
+                <Button {...props} text="Back" />
+                <Button {...props} />
+                <Button {...props} text="Next" />
+            </ButtonGroup>
+        )
+    }
+
+    return <Button {...props} />
+}
+
+/** Removes whole prop lines from a rendered block. */
+function dropProps(jsx: string, keys: readonly string[]): string {
+    return jsx
+        .split('\n')
+        .filter((line) => {
+            const trimmed = line.trim()
+            return !keys.some(
+                (key) => trimmed === key || trimmed.startsWith(`${key}=`)
+            )
+        })
+        .join('\n')
+}
+
+const spec: ComponentSpec<ButtonPlaygroundProps> = {
+    name: 'Button',
+    summary:
+        'Four exports over one token slot. LinkButton differs only by announcing as a link — RN has no anchor, so navigation is the app’s job in `onPress`.',
+    mode: 'inline',
+    gallery: ButtonShowcase,
+    defaults: {
+        family: 'Button',
+        text: 'Continue',
+        buttonType: ButtonType.PRIMARY,
+        size: ButtonSize.MEDIUM,
+        subType: ButtonSubType.DEFAULT,
+    },
+    controls: [
+        {
+            kind: 'select',
+            key: 'family',
+            label: 'Component',
+            hidden: true,
+            options: unionOptions<ButtonFamily>()([
+                'Button',
+                'IconButton',
+                'LinkButton',
+                'ButtonGroup',
+            ]),
+        },
+        {
+            kind: 'segmented',
+            key: 'buttonType',
+            label: 'Type',
+            options: enumOptions(ButtonType, 'ButtonType'),
+        },
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(ButtonSize, 'ButtonSize'),
+        },
+        {
+            kind: 'segmented',
+            key: 'subType',
+            label: 'Sub type',
+            options: enumOptions(ButtonSubType, 'ButtonSubType'),
+        },
+        {
+            kind: 'segmented',
+            key: 'width',
+            label: 'Width',
+            options: numberOptions([120, 200, 280]),
+        },
+        {
+            kind: 'text',
+            key: 'text',
+            label: 'Text',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'toggle',
+            key: 'leftSlot',
+            label: 'Left slot',
+            group: 'Content',
+            on: STAR_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Star size={14} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'rightSlot',
+            label: 'Right slot',
+            group: 'Content',
+            on: CHECK_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Check size={14} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'loading',
+            label: 'Loading',
+            group: 'State',
+        },
+        {
+            kind: 'toggle',
+            key: 'disabled',
+            label: 'Disabled',
+            group: 'State',
+        },
+    ],
+    render: (props) => <ButtonFamilyPreview {...props} />,
+    wrapSnippet: (inner, props) => {
+        if (props.family === 'ButtonGroup') {
+            return `<ButtonGroup>\n${indent(inner)}\n</ButtonGroup>`
+        }
+        if (props.family === 'IconButton') {
+            // IconButton's type omits these, so leaving them in would print
+            // JSX that does not compile.
+            const stripped = dropProps(inner, [
+                'text',
+                'subType',
+                'leftSlot',
+                'rightSlot',
+            ])
+            return stripped
+                .replace('<Button', '<IconButton')
+                .replace(
+                    /\n\/>$/,
+                    '\n    icon={<Bell size={16} />}' +
+                        '\n    accessibilityLabel="Notifications"\n/>'
+                )
+        }
+        if (props.family === 'LinkButton') {
+            return dropProps(inner, ['justifyContent']).replace(
+                '<Button',
+                '<LinkButton'
+            )
+        }
+        return inner
+    },
+}
+
+export default spec

--- a/apps/native-site/playground/specs/button.spec.tsx
+++ b/apps/native-site/playground/specs/button.spec.tsx
@@ -133,7 +133,12 @@ const spec: ComponentSpec<ButtonPlaygroundProps> = {
             kind: 'segmented',
             key: 'width',
             label: 'Width',
-            options: numberOptions([120, 200, 280]),
+            // `Auto` writes `undefined`: without it a width, once set, could
+            // not be cleared, since no other option produces the unset value.
+            options: [
+                { label: 'Auto', value: undefined },
+                ...numberOptions([120, 200, 280]),
+            ],
         },
         {
             kind: 'text',

--- a/apps/native-site/playground/specs/card.spec.tsx
+++ b/apps/native-site/playground/specs/card.spec.tsx
@@ -1,0 +1,103 @@
+import { Card, CardOrientation, CardPadding, CardVariant } from 'blend-native'
+import type { CardNativeProps } from 'blend-native'
+import DisplayShowcase from '../../components/DisplayShowcase'
+import { MEDIA_NODE } from './slots'
+import { enumOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const spec: ComponentSpec<CardNativeProps> = {
+    name: 'Card',
+    summary:
+        'Surface for grouped content. Web’s `interactive` becomes `onPress` here: providing it renders a Pressable card with a button role.',
+    mode: 'inline',
+    gallery: DisplayShowcase,
+    defaults: {
+        variant: CardVariant.OUTLINED,
+        orientation: CardOrientation.VERTICAL,
+        padding: CardPadding.COMFORTABLE,
+        title: 'Settlement summary',
+        subtitle: 'Updated 4 minutes ago',
+        description:
+            'Payouts for the current cycle have been reconciled against the acquirer statement.',
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'variant',
+            label: 'Variant',
+            options: enumOptions(CardVariant, 'CardVariant'),
+        },
+        {
+            kind: 'segmented',
+            key: 'orientation',
+            label: 'Orientation',
+            options: enumOptions(CardOrientation, 'CardOrientation'),
+        },
+        {
+            kind: 'segmented',
+            key: 'padding',
+            label: 'Padding',
+            options: enumOptions(CardPadding, 'CardPadding'),
+        },
+        { kind: 'toggle', key: 'centered', label: 'Centered' },
+        {
+            kind: 'text',
+            key: 'eyebrow',
+            label: 'Eyebrow',
+            group: 'Content',
+            placeholder: 'PAYOUTS',
+        },
+        {
+            kind: 'text',
+            key: 'title',
+            label: 'Title',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'subtitle',
+            label: 'Subtitle',
+            group: 'Content',
+        },
+        {
+            kind: 'text',
+            key: 'description',
+            label: 'Description',
+            group: 'Content',
+        },
+        {
+            kind: 'toggle',
+            key: 'media',
+            label: 'Media',
+            group: 'Content',
+            on: MEDIA_NODE,
+            off: undefined,
+            onCode: '<Image ... />',
+        },
+        {
+            kind: 'toggle',
+            key: 'truncateTitle',
+            label: 'Truncate title',
+            group: 'State',
+        },
+        {
+            kind: 'toggle',
+            key: 'selected',
+            label: 'Selected (needs a press handler)',
+            group: 'State',
+        },
+    ],
+    render: (props) => (
+        <Card
+            {...props}
+            maxWidth={280}
+            // `selected` chrome and the button role only apply to a pressable
+            // card, so the handler follows the toggle rather than being
+            // always-on (which would make every card announce as a button).
+            onPress={props.selected ? () => {} : undefined}
+        />
+    ),
+}
+
+export default spec

--- a/apps/native-site/playground/specs/card.spec.tsx
+++ b/apps/native-site/playground/specs/card.spec.tsx
@@ -5,6 +5,8 @@ import { MEDIA_NODE } from './slots'
 import { enumOptions } from '../types'
 import type { ComponentSpec } from '../types'
 
+const noop = () => {}
+
 const spec: ComponentSpec<CardNativeProps> = {
     name: 'Card',
     summary:
@@ -83,21 +85,24 @@ const spec: ComponentSpec<CardNativeProps> = {
         },
         {
             kind: 'toggle',
+            key: 'onPress',
+            label: 'Pressable',
+            group: 'State',
+            on: noop,
+            off: undefined,
+            onCode: 'handlePress',
+        },
+        {
+            // Web parity: selected chrome and the selected a11y state only
+            // apply to a pressable card, so this does nothing on its own.
+            // Surfacing that is more useful than hiding it.
+            kind: 'toggle',
             key: 'selected',
-            label: 'Selected (needs a press handler)',
+            label: 'Selected (needs Pressable)',
             group: 'State',
         },
     ],
-    render: (props) => (
-        <Card
-            {...props}
-            maxWidth={280}
-            // `selected` chrome and the button role only apply to a pressable
-            // card, so the handler follows the toggle rather than being
-            // always-on (which would make every card announce as a button).
-            onPress={props.selected ? () => {} : undefined}
-        />
-    ),
+    render: (props) => <Card {...props} maxWidth={280} />,
 }
 
 export default spec

--- a/apps/native-site/playground/specs/index.ts
+++ b/apps/native-site/playground/specs/index.ts
@@ -1,0 +1,64 @@
+import { asAnySpec } from '../types'
+import type { AnySpec } from '../types'
+import alert from './alert.spec'
+import avatar from './avatar.spec'
+import bottomSheet from './bottomSheet.spec'
+import button from './button.spec'
+import card from './card.spec'
+import keyValuePair from './keyValuePair.spec'
+import progressBar from './progressBar.spec'
+import skeleton from './skeleton.spec'
+import snackbar from './snackbar.spec'
+import spinner from './spinner.spec'
+import tag from './tag.spec'
+import textInput from './textInput.spec'
+
+/**
+ * The component list behind the drawer. Every renderable `blend-native`
+ * exports has an entry, with the families (Button/IconButton/LinkButton/
+ * ButtonGroup, Tag/TagGroup) folded into one spec apiece — they share a
+ * token slot, and reading them against each other is the point.
+ *
+ * Adding a component is a spec file plus one line here.
+ */
+export type SpecGroup = {
+    title: string
+    specs: readonly AnySpec[]
+}
+
+export const COMPONENT_GROUPS: readonly SpecGroup[] = [
+    {
+        title: 'Actions',
+        specs: [asAnySpec(button), asAnySpec(tag)],
+    },
+    {
+        title: 'Inputs',
+        specs: [asAnySpec(textInput)],
+    },
+    {
+        title: 'Feedback',
+        specs: [
+            asAnySpec(alert),
+            asAnySpec(snackbar),
+            asAnySpec(progressBar),
+            asAnySpec(spinner),
+            asAnySpec(skeleton),
+        ],
+    },
+    {
+        title: 'Data display',
+        specs: [asAnySpec(avatar), asAnySpec(card), asAnySpec(keyValuePair)],
+    },
+    {
+        title: 'Overlays',
+        specs: [asAnySpec(bottomSheet)],
+    },
+]
+
+export const ALL_SPECS: readonly AnySpec[] = COMPONENT_GROUPS.flatMap(
+    (group) => group.specs
+)
+
+export function findSpec(name: string): AnySpec {
+    return ALL_SPECS.find((spec) => spec.name === name) ?? ALL_SPECS[0]
+}

--- a/apps/native-site/playground/specs/keyValuePair.spec.tsx
+++ b/apps/native-site/playground/specs/keyValuePair.spec.tsx
@@ -1,0 +1,91 @@
+import { KeyValuePair, KeyValuePairSize } from 'blend-native'
+import type {
+    KeyValuePairNativeProps,
+    KeyValuePairOrientation,
+    KeyValuePairTextOverflow,
+} from 'blend-native'
+import DisplayShowcase from '../../components/DisplayShowcase'
+import { CHECK_SLOT } from './slots'
+import { enumOptions, numberOptions, unionOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const VALUE_RIGHT = { valueRight: CHECK_SLOT.slot }
+
+const spec: ComponentSpec<KeyValuePairNativeProps> = {
+    name: 'KeyValuePair',
+    summary:
+        'Label above or beside a value. Truncation maps to RN `numberOfLines`: truncate is 1 line, wrap-clamp caps at `maxLines`, wrap is unlimited.',
+    mode: 'inline',
+    gallery: DisplayShowcase,
+    defaults: {
+        keyString: 'Transaction ID',
+        value: 'ord_9f2c41ab77e3',
+        size: KeyValuePairSize.MD,
+        orientation: 'vertical',
+        textOverflow: 'wrap',
+        maxLines: 2,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(KeyValuePairSize, 'KeyValuePairSize'),
+        },
+        {
+            kind: 'segmented',
+            key: 'orientation',
+            label: 'Orientation',
+            options: unionOptions<KeyValuePairOrientation>()([
+                'vertical',
+                'horizontal',
+            ]),
+        },
+        {
+            kind: 'segmented',
+            key: 'textOverflow',
+            label: 'Text overflow',
+            options: unionOptions<KeyValuePairTextOverflow>()([
+                'truncate',
+                'wrap',
+                'wrap-clamp',
+            ]),
+        },
+        {
+            kind: 'segmented',
+            key: 'maxLines',
+            label: 'Max lines (wrap-clamp)',
+            options: numberOptions([1, 2, 3]),
+        },
+        {
+            kind: 'text',
+            key: 'keyString',
+            label: 'Key',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'value',
+            label: 'Value',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'toggle',
+            key: 'slots',
+            label: 'Trailing slot',
+            group: 'Content',
+            on: VALUE_RIGHT,
+            off: undefined,
+            onCode: '{ valueRight: <Check size={14} /> }',
+        },
+    ],
+    render: (props) => (
+        // Bounded so `truncate` and `wrap-clamp` have an edge to act against —
+        // in an unconstrained stage every value fits and the control looks inert.
+        <KeyValuePair {...props} maxWidth={220} />
+    ),
+}
+
+export default spec

--- a/apps/native-site/playground/specs/progressBar.spec.tsx
+++ b/apps/native-site/playground/specs/progressBar.spec.tsx
@@ -1,0 +1,75 @@
+import {
+    ProgressBar,
+    ProgressBarAppearance,
+    ProgressBarSize,
+    ProgressBarVariant,
+} from 'blend-native'
+import type { ProgressBarNativeProps } from 'blend-native'
+import LoadingShowcase from '../../components/LoadingShowcase'
+import { enumOptions, numberOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const spec: ComponentSpec<ProgressBarNativeProps> = {
+    name: 'ProgressBar',
+    summary:
+        'Determinate progress only, like web. Native draws discrete ticks for the segmented track — RN has no repeating-linear-gradient.',
+    mode: 'inline',
+    gallery: LoadingShowcase,
+    defaults: {
+        value: 60,
+        size: ProgressBarSize.MD,
+        variant: ProgressBarVariant.LINEAR,
+        appearance: ProgressBarAppearance.SOLID,
+        showLabel: true,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'value',
+            label: 'Value',
+            always: true,
+            options: numberOptions([0, 25, 60, 100]),
+        },
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(ProgressBarSize, 'ProgressBarSize'),
+        },
+        {
+            kind: 'segmented',
+            key: 'variant',
+            label: 'Variant',
+            options: enumOptions(ProgressBarVariant, 'ProgressBarVariant'),
+        },
+        {
+            kind: 'segmented',
+            key: 'appearance',
+            label: 'Appearance',
+            options: enumOptions(
+                ProgressBarAppearance,
+                'ProgressBarAppearance'
+            ),
+        },
+        {
+            kind: 'toggle',
+            key: 'showLabel',
+            label: 'Show label',
+            group: 'Content',
+        },
+    ],
+    render: (props) => (
+        <ProgressBar
+            {...props}
+            // The circular variant sizes itself from tokens; only the linear
+            // track needs a width to stretch into.
+            style={
+                props.variant === ProgressBarVariant.LINEAR
+                    ? { width: 240 }
+                    : undefined
+            }
+        />
+    ),
+}
+
+export default spec

--- a/apps/native-site/playground/specs/skeleton.spec.tsx
+++ b/apps/native-site/playground/specs/skeleton.spec.tsx
@@ -1,0 +1,55 @@
+import { Skeleton } from 'blend-native'
+import type {
+    SkeletonNativeProps,
+    SkeletonShape,
+    SkeletonVariant,
+} from 'blend-native'
+import LoadingShowcase from '../../components/LoadingShowcase'
+import { numberOptions, unionOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const spec: ComponentSpec<SkeletonNativeProps> = {
+    name: 'Skeleton',
+    summary:
+        'Placeholder box while content loads. `pulse` breathes; `wave` and `shimmer` sweep a gradient across it.',
+    mode: 'inline',
+    gallery: LoadingShowcase,
+    defaults: { variant: 'pulse', shape: 'rounded', width: 200, height: 20 },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'variant',
+            label: 'Variant',
+            options: unionOptions<SkeletonVariant>()([
+                'pulse',
+                'wave',
+                'shimmer',
+            ]),
+        },
+        {
+            kind: 'segmented',
+            key: 'shape',
+            label: 'Shape',
+            options: unionOptions<SkeletonShape>()([
+                'rectangle',
+                'rounded',
+                'circle',
+            ]),
+        },
+        {
+            kind: 'segmented',
+            key: 'width',
+            label: 'Width',
+            options: numberOptions([80, 140, 200, 260]),
+        },
+        {
+            kind: 'segmented',
+            key: 'height',
+            label: 'Height',
+            options: numberOptions([12, 20, 48, 80]),
+        },
+    ],
+    render: (props) => <Skeleton {...props} />,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/slots.tsx
+++ b/apps/native-site/playground/specs/slots.tsx
@@ -1,0 +1,33 @@
+import { View } from 'react-native'
+import { Bell, Check, Search, Star, X } from 'lucide-react-native'
+
+/**
+ * Slot payloads shared by the specs.
+ *
+ * Module-level constants on purpose: a toggle control decides whether it is
+ * on by comparing the current prop against its `on` value with `Object.is`,
+ * so the payload has to be the same object every render. Building these
+ * inline in a spec would leave the toggle permanently off.
+ *
+ * The icons carry no `color` — `Slot` tints them from the component's own
+ * tokens, which is the behaviour worth exercising here.
+ */
+export const STAR_SLOT = { slot: <Star size={14} /> }
+export const CHECK_SLOT = { slot: <Check size={14} /> }
+export const BELL_SLOT = { slot: <Bell size={16} /> }
+export const SEARCH_SLOT = { slot: <Search size={16} /> }
+export const X_SLOT = { slot: <X size={14} /> }
+
+export const STAR_NODE = <Star size={16} />
+export const BELL_NODE = <Bell size={16} />
+
+/** Stand-in for card imagery, so `media` can be toggled without an asset. */
+export const MEDIA_NODE = (
+    <View
+        style={{
+            height: 96,
+            borderRadius: 8,
+            backgroundColor: '#B8C6E8',
+        }}
+    />
+)

--- a/apps/native-site/playground/specs/snackbar.spec.tsx
+++ b/apps/native-site/playground/specs/snackbar.spec.tsx
@@ -1,0 +1,134 @@
+import { useEffect } from 'react'
+import { SnackbarVariant, addSnackbar } from 'blend-native'
+import type { SnackbarOptions } from 'blend-native'
+import { indent } from '../snippet'
+import { enumOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+/**
+ * `addSnackbar` is imperative and has no rendered form, so the spec fires it
+ * from an effect when the harness trigger flips `open`, then hands control
+ * straight back. There is no component in the stage — the snackbar appears
+ * over the whole screen from the provider's outlet.
+ *
+ * This is the design-system surface. `showToast` is the lower-level host it
+ * is built on and is not given a spec of its own.
+ */
+function SnackbarTrigger({
+    options,
+    open,
+    setOpen,
+}: {
+    options: SnackbarOptions
+    open: boolean
+    setOpen: (open: boolean) => void
+}) {
+    useEffect(() => {
+        if (!open) return
+        addSnackbar(options)
+        setOpen(false)
+    }, [open, options, setOpen])
+
+    return null
+}
+
+const ACTION = {
+    label: 'Undo',
+    onPress: () => {},
+}
+
+const spec: ComponentSpec<SnackbarOptions> = {
+    name: 'Snackbar',
+    summary:
+        'Bottom-centred and imperative. Web’s six positions need a top outlet first, so `position` is omitted from the native options rather than accepted and ignored.',
+    mode: 'overlay',
+    triggerLabel: 'Show the snackbar',
+    defaults: {
+        header: 'Refund initiated',
+        description: 'It will reach the customer in 3-5 business days.',
+        variant: SnackbarVariant.SUCCESS,
+        duration: 4000,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'variant',
+            label: 'Variant',
+            options: enumOptions(SnackbarVariant, 'SnackbarVariant'),
+        },
+        {
+            kind: 'text',
+            key: 'header',
+            label: 'Header',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'description',
+            label: 'Description',
+            group: 'Content',
+        },
+        {
+            kind: 'toggle',
+            key: 'actionButton',
+            label: 'Action button',
+            group: 'Content',
+            on: ACTION,
+            off: undefined,
+            onCode: "{ label: 'Undo', onPress }",
+        },
+        {
+            kind: 'select',
+            key: 'duration',
+            label: 'Duration',
+            group: 'State',
+            options: [
+                { label: '2s', value: 2000, code: '2000' },
+                { label: '4s', value: 4000, code: '4000' },
+                { label: '8s', value: 8000, code: '8000' },
+                {
+                    label: 'Until dismissed',
+                    value: null,
+                    code: 'null',
+                },
+            ],
+        },
+    ],
+    render: (props, ctx) => (
+        <SnackbarTrigger
+            options={props}
+            open={ctx.open}
+            setOpen={ctx.setOpen}
+        />
+    ),
+}
+
+/**
+ * `addSnackbar` is a call, not an element, so the generated tag is reshaped
+ * into the options object it actually is. Handles the boolean shorthand
+ * (`dismissible` with no `=`) as well as `key={value}` and `key="value"`.
+ */
+function toEntry(line: string): string {
+    const trimmed = line.trim()
+    const equals = trimmed.indexOf('=')
+    if (equals === -1) return `${trimmed}: true,`
+
+    const key = trimmed.slice(0, equals)
+    const raw = trimmed.slice(equals + 1)
+    const value =
+        raw.startsWith('{') && raw.endsWith('}') ? raw.slice(1, -1) : raw
+    return `${key}: ${value},`
+}
+
+spec.wrapSnippet = (inner) => {
+    const entries = inner
+        .split('\n')
+        .filter((line) => line.startsWith('    '))
+        .map(toEntry)
+
+    if (entries.length === 0) return 'addSnackbar({})'
+    return `addSnackbar({\n${indent(entries.join('\n'))}\n})`
+}
+
+export default spec

--- a/apps/native-site/playground/specs/spinner.spec.tsx
+++ b/apps/native-site/playground/specs/spinner.spec.tsx
@@ -1,0 +1,52 @@
+import { Spinner } from 'blend-native'
+import type {
+    SpinnerColor,
+    SpinnerNativeProps,
+    SpinnerSize,
+} from 'blend-native'
+import LoadingShowcase from '../../components/LoadingShowcase'
+import { unionOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const spec: ComponentSpec<SpinnerNativeProps> = {
+    name: 'Spinner',
+    summary:
+        'Indeterminate activity. Web animates the arc with SMIL; native rotates the same geometry with Reanimated, and both render it static under reduce-motion.',
+    mode: 'inline',
+    gallery: LoadingShowcase,
+    defaults: { size: 'md', color: 'default' },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: unionOptions<SpinnerSize>()(['sm', 'md', 'lg']),
+        },
+        {
+            kind: 'segmented',
+            key: 'color',
+            label: 'Color',
+            options: unionOptions<SpinnerColor>()([
+                'default',
+                'primary',
+                'inverse',
+            ]),
+        },
+        {
+            kind: 'toggle',
+            key: 'overlay',
+            label: 'Blocking overlay',
+            group: 'State',
+        },
+        {
+            kind: 'text',
+            key: 'label',
+            label: 'Screen-reader label',
+            group: 'Content',
+            placeholder: 'Loading',
+        },
+    ],
+    render: (props) => <Spinner {...props} />,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/tag.spec.tsx
+++ b/apps/native-site/playground/specs/tag.spec.tsx
@@ -10,35 +10,35 @@ import {
 import type { TagNativeProps } from 'blend-native'
 import TagShowcase from '../../components/TagShowcase'
 import { CHECK_SLOT, STAR_SLOT } from './slots'
-import { indent } from '../snippet'
+import { indent, replaceProp } from '../snippet'
 import { enumOptions, unionOptions } from '../types'
 import type { ComponentSpec } from '../types'
 
 /**
- * `family` is a playground-only prop: it picks which of the two exported
- * components the stage renders, and is stripped before either of them sees
- * it. It carries no control `code`, so it never reaches the snippet.
+ * `family` and `stacked` are playground-only: they pick which component the
+ * stage renders and how the group joins its members. Both are `hidden`, so
+ * they never reach the snippet as props of `Tag`; `wrapSnippet` expresses
+ * them as the wrapper instead.
  */
 type TagFamily = 'Tag' | 'TagGroup'
 
-type TagPlaygroundProps = TagNativeProps & { family: TagFamily }
+type TagPlaygroundProps = TagNativeProps & {
+    family: TagFamily
+    stacked: boolean
+}
 
-/** Interactive tags own their pressed state so the toggle is observable. */
-function PressableTag({ family, ...props }: TagPlaygroundProps) {
+const noop = () => {}
+
+/**
+ * An interactive tag owns its own pressed state, so the toggle the control
+ * exists to demonstrate is actually observable. Group members each get their
+ * own — pressing one must not move its neighbours.
+ *
+ * `TagGroup` clones its children to inject `tagGroupPosition`, and the
+ * injected prop arrives here in `props` and is spread straight through.
+ */
+function InteractiveTag(props: TagNativeProps) {
     const [pressed, setPressed] = useState(false)
-
-    if (family === 'TagGroup') {
-        return (
-            <TagGroup>
-                <Tag {...props} text="First" />
-                <Tag {...props} text={props.text} />
-                <Tag {...props} text="Last" />
-            </TagGroup>
-        )
-    }
-
-    if (!props.onPress) return <Tag {...props} />
-
     return (
         <Tag
             {...props}
@@ -48,14 +48,33 @@ function PressableTag({ family, ...props }: TagPlaygroundProps) {
     )
 }
 
+function TagPreview({ family, stacked, ...props }: TagPlaygroundProps) {
+    // Swapping the component type on `onPress` also remounts it, which is
+    // what clears a stale pressed state when the toggle goes off and on.
+    const Item = props.onPress ? InteractiveTag : Tag
+
+    if (family === 'TagGroup') {
+        return (
+            <TagGroup stacked={stacked}>
+                <Item {...props} text="First" />
+                <Item {...props} />
+                <Item {...props} text="Last" />
+            </TagGroup>
+        )
+    }
+
+    return <Item {...props} />
+}
+
 const spec: ComponentSpec<TagPlaygroundProps> = {
     name: 'Tag',
     summary:
-        'Static label, or a pressable toggle once `onPress` is supplied — mirroring web’s `TagElement = onClick ? PrimitiveButton : Block`. Grouped tags collapse the radius on joined edges.',
+        'Static label, or a pressable toggle once `onPress` is supplied — mirroring web’s `TagElement = onClick ? PrimitiveButton : Block`. A stacked group collapses the radius on joined edges.',
     mode: 'inline',
     gallery: TagShowcase,
     defaults: {
         family: 'Tag',
+        stacked: true,
         text: 'Settled',
         type: TagType.SUBTLE,
         color: TagColor.SUCCESS,
@@ -69,6 +88,12 @@ const spec: ComponentSpec<TagPlaygroundProps> = {
             label: 'Component',
             hidden: true,
             options: unionOptions<TagFamily>()(['Tag', 'TagGroup']),
+        },
+        {
+            kind: 'toggle',
+            key: 'stacked',
+            label: 'Stacked (TagGroup only)',
+            hidden: true,
         },
         {
             kind: 'segmented',
@@ -124,16 +149,25 @@ const spec: ComponentSpec<TagPlaygroundProps> = {
             key: 'onPress',
             label: 'Interactive',
             group: 'State',
-            on: () => {},
+            on: noop,
             off: undefined,
             onCode: 'handlePress',
         },
     ],
-    render: (props) => <PressableTag {...props} />,
-    wrapSnippet: (inner, props) =>
-        props.family === 'TagGroup'
-            ? `<TagGroup>\n${indent(inner)}\n</TagGroup>`
-            : inner,
+    render: (props) => <TagPreview {...props} />,
+    // The stage renders three members in group mode, so the snippet does
+    // too — a one-member group is exactly the case where the radius
+    // collapsing this mode exists to show does not happen.
+    wrapSnippet: (inner, props) => {
+        if (props.family !== 'TagGroup') return inner
+        const members = [
+            replaceProp(inner, 'text', '"First"'),
+            inner,
+            replaceProp(inner, 'text', '"Last"'),
+        ]
+        const open = props.stacked ? '<TagGroup stacked>' : '<TagGroup>'
+        return `${open}\n${members.map((m) => indent(m)).join('\n')}\n</TagGroup>`
+    },
 }
 
 export default spec

--- a/apps/native-site/playground/specs/tag.spec.tsx
+++ b/apps/native-site/playground/specs/tag.spec.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import {
+    Tag,
+    TagColor,
+    TagGroup,
+    TagSize,
+    TagSubType,
+    TagType,
+} from 'blend-native'
+import type { TagNativeProps } from 'blend-native'
+import TagShowcase from '../../components/TagShowcase'
+import { CHECK_SLOT, STAR_SLOT } from './slots'
+import { indent } from '../snippet'
+import { enumOptions, unionOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+/**
+ * `family` is a playground-only prop: it picks which of the two exported
+ * components the stage renders, and is stripped before either of them sees
+ * it. It carries no control `code`, so it never reaches the snippet.
+ */
+type TagFamily = 'Tag' | 'TagGroup'
+
+type TagPlaygroundProps = TagNativeProps & { family: TagFamily }
+
+/** Interactive tags own their pressed state so the toggle is observable. */
+function PressableTag({ family, ...props }: TagPlaygroundProps) {
+    const [pressed, setPressed] = useState(false)
+
+    if (family === 'TagGroup') {
+        return (
+            <TagGroup>
+                <Tag {...props} text="First" />
+                <Tag {...props} text={props.text} />
+                <Tag {...props} text="Last" />
+            </TagGroup>
+        )
+    }
+
+    if (!props.onPress) return <Tag {...props} />
+
+    return (
+        <Tag
+            {...props}
+            pressed={pressed}
+            onPress={() => setPressed((value) => !value)}
+        />
+    )
+}
+
+const spec: ComponentSpec<TagPlaygroundProps> = {
+    name: 'Tag',
+    summary:
+        'Static label, or a pressable toggle once `onPress` is supplied — mirroring web’s `TagElement = onClick ? PrimitiveButton : Block`. Grouped tags collapse the radius on joined edges.',
+    mode: 'inline',
+    gallery: TagShowcase,
+    defaults: {
+        family: 'Tag',
+        text: 'Settled',
+        type: TagType.SUBTLE,
+        color: TagColor.SUCCESS,
+        size: TagSize.MD,
+        subType: TagSubType.ROUNDED,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'family',
+            label: 'Component',
+            hidden: true,
+            options: unionOptions<TagFamily>()(['Tag', 'TagGroup']),
+        },
+        {
+            kind: 'segmented',
+            key: 'type',
+            label: 'Type',
+            options: enumOptions(TagType, 'TagType'),
+        },
+        {
+            kind: 'select',
+            key: 'color',
+            label: 'Color',
+            options: enumOptions(TagColor, 'TagColor'),
+        },
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(TagSize, 'TagSize'),
+        },
+        {
+            kind: 'segmented',
+            key: 'subType',
+            label: 'Shape',
+            options: enumOptions(TagSubType, 'TagSubType'),
+        },
+        {
+            kind: 'text',
+            key: 'text',
+            label: 'Text',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'toggle',
+            key: 'leftSlot',
+            label: 'Left slot',
+            group: 'Content',
+            on: STAR_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Star size={14} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'rightSlot',
+            label: 'Right slot',
+            group: 'Content',
+            on: CHECK_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Check size={14} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'onPress',
+            label: 'Interactive',
+            group: 'State',
+            on: () => {},
+            off: undefined,
+            onCode: 'handlePress',
+        },
+    ],
+    render: (props) => <PressableTag {...props} />,
+    wrapSnippet: (inner, props) =>
+        props.family === 'TagGroup'
+            ? `<TagGroup>\n${indent(inner)}\n</TagGroup>`
+            : inner,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/textInput.spec.tsx
+++ b/apps/native-site/playground/specs/textInput.spec.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import { InputSize, TextInput } from 'blend-native'
+import type { TextInputNativeProps } from 'blend-native'
+import InputShowcase from '../../components/InputShowcase'
+import { SEARCH_SLOT } from './slots'
+import { enumOptions } from '../types'
+import type { ComponentSpec } from '../types'
+
+const ERROR = { show: true, message: 'Enter a valid merchant reference' }
+
+/**
+ * `value` is controlled, so the preview needs local state to be typeable —
+ * without it the field would reject every keystroke and read as broken. The
+ * text control still drives it: a change from above resets what is typed.
+ */
+function LiveTextInput(props: TextInputNativeProps) {
+    const [value, setValue] = useState(props.value)
+    useEffect(() => setValue(props.value), [props.value])
+
+    return (
+        <TextInput
+            {...props}
+            value={value}
+            onChangeText={setValue}
+            style={{ width: 260 }}
+        />
+    )
+}
+
+const spec: ComponentSpec<TextInputNativeProps> = {
+    name: 'TextInput',
+    summary:
+        'Label, field and footer in one column. The floating-label mode and the embedded dropdown are web-only for now — both are omitted from the type rather than accepted and ignored.',
+    mode: 'inline',
+    gallery: InputShowcase,
+    defaults: {
+        value: '',
+        label: 'Merchant reference',
+        placeholder: 'ord_9f2c41ab77e3',
+        size: InputSize.MD,
+    },
+    controls: [
+        {
+            kind: 'segmented',
+            key: 'size',
+            label: 'Size',
+            options: enumOptions(InputSize, 'InputSize'),
+        },
+        {
+            kind: 'text',
+            key: 'label',
+            label: 'Label',
+            group: 'Content',
+            always: true,
+        },
+        {
+            kind: 'text',
+            key: 'subLabel',
+            label: 'Sub label',
+            group: 'Content',
+            placeholder: 'optional',
+        },
+        {
+            kind: 'text',
+            key: 'placeholder',
+            label: 'Placeholder',
+            group: 'Content',
+        },
+        {
+            kind: 'text',
+            key: 'hintText',
+            label: 'Hint',
+            group: 'Content',
+            placeholder: 'Shown under the field',
+        },
+        {
+            kind: 'toggle',
+            key: 'leftSlot',
+            label: 'Left slot',
+            group: 'Content',
+            on: SEARCH_SLOT,
+            off: undefined,
+            onCode: '{ slot: <Search size={16} /> }',
+        },
+        {
+            kind: 'toggle',
+            key: 'required',
+            label: 'Required',
+            group: 'State',
+        },
+        {
+            kind: 'toggle',
+            key: 'disabled',
+            label: 'Disabled',
+            group: 'State',
+        },
+        {
+            kind: 'toggle',
+            key: 'error',
+            label: 'Error',
+            group: 'State',
+            on: ERROR,
+            off: undefined,
+            onCode: "{ show: true, message: '...' }",
+        },
+    ],
+    render: (props) => <LiveTextInput {...props} />,
+}
+
+export default spec

--- a/apps/native-site/playground/specs/textInput.spec.tsx
+++ b/apps/native-site/playground/specs/textInput.spec.tsx
@@ -3,6 +3,7 @@ import { InputSize, TextInput } from 'blend-native'
 import type { TextInputNativeProps } from 'blend-native'
 import InputShowcase from '../../components/InputShowcase'
 import { SEARCH_SLOT } from './slots'
+import { addProps } from '../snippet'
 import { enumOptions } from '../types'
 import type { ComponentSpec } from '../types'
 
@@ -105,6 +106,11 @@ const spec: ComponentSpec<TextInputNativeProps> = {
         },
     ],
     render: (props) => <LiveTextInput {...props} />,
+    // `value` is required and controlled. The preview holds it in local
+    // state; a consumer holds it in theirs, so the snippet says so rather
+    // than printing a field nobody can type into.
+    wrapSnippet: (inner) =>
+        addProps(inner, ['value={value}', 'onChangeText={setValue}']),
 }
 
 export default spec

--- a/apps/native-site/playground/tabBar.shared.ts
+++ b/apps/native-site/playground/tabBar.shared.ts
@@ -1,0 +1,30 @@
+import type { ComponentType } from 'react'
+import { LayoutGrid, SlidersHorizontal } from 'lucide-react-native'
+
+/**
+ * Contract shared by the three `PlaygroundTabBar` implementations.
+ *
+ * Metro picks the file: `.ios` on iOS, `.android` on Android, and the
+ * suffix-less `PlaygroundTabBar.tsx` everywhere else (which is also the one
+ * TypeScript resolves, so the shared props type is what keeps the platform
+ * variants from drifting apart).
+ */
+export type TabKey = 'preview' | 'gallery'
+
+export type TabItem = {
+    key: TabKey
+    label: string
+    icon: ComponentType<{ size?: number; color?: string }>
+}
+
+export const TAB_ITEMS: Record<TabKey, TabItem> = {
+    preview: { key: 'preview', label: 'Preview', icon: SlidersHorizontal },
+    gallery: { key: 'gallery', label: 'Gallery', icon: LayoutGrid },
+}
+
+export type TabBarProps = {
+    value: TabKey
+    onChange: (value: TabKey) => void
+    /** Specs without a gallery pass `['preview']` so the item disappears. */
+    tabs: readonly TabKey[]
+}

--- a/apps/native-site/playground/types.ts
+++ b/apps/native-site/playground/types.ts
@@ -124,10 +124,23 @@ export function asAnySpec<P extends object>(spec: ComponentSpec<P>): AnySpec {
     return spec as unknown as AnySpec
 }
 
-/** `NO_FILL` -> `No fill`, `sm` -> `Sm`. */
+/**
+ * `NO_FILL` -> `No fill`, `wrap-clamp` -> `Wrap clamp`, `sm` -> `Sm`.
+ *
+ * A value that is already a proper name is left alone: enum keys are
+ * SCREAMING_SNAKE and want flattening, but union values such as `TagGroup`
+ * and `IconButton` are component names, and lowercasing them produces
+ * "Taggroup" and "Iconbutton".
+ */
 export function humanize(value: string): string {
-    const spaced = value.replace(/[_-]+/g, ' ').toLowerCase()
-    return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+    // Separator or all-caps means an enum key (`NO_FILL`, `SUCCESS`, `MD`).
+    // Mixed case starting uppercase means a name, and is kept verbatim.
+    if (/[_-]/.test(value) || value === value.toUpperCase()) {
+        const spaced = value.replace(/[_-]+/g, ' ').toLowerCase()
+        return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+    }
+    if (/^[A-Z]/.test(value)) return value
+    return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 /**
@@ -161,6 +174,27 @@ export const unionOptions =
         list: L & ([T] extends [L[number]] ? unknown : never)
     ): readonly Option<T>[] =>
         list.map((value) => ({ label: humanize(value), value }))
+
+/**
+ * The two values a toggle writes.
+ *
+ * `off: undefined` and an omitted `off` are deliberately different: the
+ * first means "clear the prop", the second means "write `false`". Collapsing
+ * them puts `leftSlot={false}` into the props a component receives and into
+ * the generated JSX, where it does not type-check.
+ *
+ * Lives here rather than inline in `ControlPanel` so it can be tested
+ * without rendering.
+ */
+export function toggleValues(control: { on?: unknown; off?: unknown }): {
+    on: unknown
+    off: unknown
+} {
+    return {
+        on: 'on' in control ? control.on : true,
+        off: 'off' in control ? control.off : false,
+    }
+}
 
 /** Numeric presets, for props with no natural enumeration. */
 export function numberOptions(

--- a/apps/native-site/playground/types.ts
+++ b/apps/native-site/playground/types.ts
@@ -1,0 +1,175 @@
+import type { ComponentType, ReactNode } from 'react'
+
+/**
+ * The playground harness contract.
+ *
+ * Adding a component to the demo app is a spec file, not a screen: declare
+ * the props you want to be adjustable and how to render them, and the
+ * harness supplies the stage, the control panel, the live JSX snippet and
+ * the reset button.
+ *
+ * Nothing in this module imports `react-native`, so it is unit-testable in
+ * plain vitest alongside `snippet.ts`.
+ */
+
+/** Panel section a control belongs to. Rendered in this order. */
+export const CONTROL_GROUPS = ['Appearance', 'Content', 'State'] as const
+
+export type ControlGroup = (typeof CONTROL_GROUPS)[number]
+
+export type Option<V> = {
+    label: string
+    value: V
+    /**
+     * Source text for the JSX snippet, when the runtime value does not read
+     * well on its own — `TagColor.SUCCESS` rather than `"success"`.
+     */
+    code?: string
+}
+
+type Common = {
+    label: string
+    /** Defaults to `Appearance`. */
+    group?: ControlGroup
+    /**
+     * Print this prop in the snippet even when it still equals the spec
+     * default. Use it for props the component has no default for (`text`,
+     * `heading`, `keyString`) — omitting those would produce a snippet that
+     * renders nothing.
+     */
+    always?: boolean
+    /**
+     * Drive the preview but stay out of the snippet. For playground-only
+     * props such as a family selector, which choose *which* component the
+     * stage renders and are stripped before it sees them — printing them
+     * would produce JSX that does not compile.
+     */
+    hidden?: boolean
+}
+
+/**
+ * A control, tied to one prop of `P`. Distributing over the keys is what
+ * makes `options` type-check against the prop it drives: a `TagColor` option
+ * list cannot be attached to `size`.
+ */
+export type Control<P> = {
+    [K in keyof P & string]:
+        | (Common & {
+              /** `segmented` is inline (2-4 options); `select` opens a sheet. */
+              kind: 'select' | 'segmented'
+              key: K
+              options: readonly Option<P[K]>[]
+          })
+        | (Common & {
+              kind: 'toggle'
+              key: K
+              /** Written when on. Defaults to `true`. */
+              on?: P[K]
+              /** Written when off. Defaults to `false`. */
+              off?: P[K]
+              /** Snippet source for the on-value, when it is not a scalar. */
+              onCode?: string
+          })
+        | (Common & {
+              kind: 'text'
+              key: K
+              placeholder?: string
+          })
+}[keyof P & string]
+
+/** Passed to `render` so overlay specs can drive their own visibility. */
+export type RenderContext = {
+    open: boolean
+    setOpen: (open: boolean) => void
+}
+
+export type ComponentSpec<P extends object> = {
+    /** Component name, used as the nav label and in the JSX snippet. */
+    name: string
+    /** One-line description shown under the stage. */
+    summary: string
+    /**
+     * `inline` renders the component into the stage. `overlay` renders a
+     * trigger instead, for components that present over the screen —
+     * `render` then drives itself from `ctx.open`.
+     */
+    mode: 'inline' | 'overlay'
+    /** Starting props. Also the baseline the snippet diffs against. */
+    defaults: P
+    controls: readonly Control<P>[]
+    render: (props: P, ctx: RenderContext) => ReactNode
+    /** Label for the overlay trigger. Ignored when `mode` is `inline`. */
+    triggerLabel?: string
+    /**
+     * Wrap the generated JSX, for specs whose stage renders more than the one
+     * element — a tag group around its tags, say. Receives the inner block
+     * already rendered; `indent` in `snippet.ts` handles the reflow.
+     */
+    wrapSnippet?: (inner: string, props: P) => string
+    /**
+     * The dense every-variant grid, shown under the Gallery tab. Several
+     * specs share one; a spec without one hides the Gallery tab.
+     */
+    gallery?: ComponentType
+}
+
+/**
+ * A spec with its props type erased, so a heterogeneous list of them can be
+ * held in one array. The harness only ever reads props it got out of the
+ * same spec, so the erasure is sound.
+ */
+export type AnySpec = ComponentSpec<Record<string, unknown>>
+
+export function asAnySpec<P extends object>(spec: ComponentSpec<P>): AnySpec {
+    return spec as unknown as AnySpec
+}
+
+/** `NO_FILL` -> `No fill`, `sm` -> `Sm`. */
+export function humanize(value: string): string {
+    const spaced = value.replace(/[_-]+/g, ' ').toLowerCase()
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/**
+ * Build options from an enum object, so a variant added to the library shows
+ * up in the controls on its own instead of waiting for someone to remember
+ * a hardcoded list.
+ *
+ * `enumName` is only used for the snippet, which reads better as
+ * `TagColor.SUCCESS` than as the `"success"` the value actually is.
+ */
+export function enumOptions<E extends Record<string, string>>(
+    enumObject: E,
+    enumName: string
+): readonly Option<E[keyof E]>[] {
+    return Object.entries(enumObject).map(([key, value]) => ({
+        label: humanize(key),
+        value: value as E[keyof E],
+        code: `${enumName}.${key}`,
+    }))
+}
+
+/**
+ * Build options from a string union, which has no runtime object to
+ * enumerate. The `[T] extends [L[number]]` guard makes the call fail to
+ * compile if the union gains a member that is not listed — the closest we
+ * can get to the automatic behaviour `enumOptions` has for real enums.
+ */
+export const unionOptions =
+    <T extends string>() =>
+    <L extends readonly T[]>(
+        list: L & ([T] extends [L[number]] ? unknown : never)
+    ): readonly Option<T>[] =>
+        list.map((value) => ({ label: humanize(value), value }))
+
+/** Numeric presets, for props with no natural enumeration. */
+export function numberOptions(
+    values: readonly number[],
+    suffix = ''
+): readonly Option<number>[] {
+    return values.map((value) => ({
+        label: `${value}${suffix}`,
+        value,
+        code: String(value),
+    }))
+}

--- a/apps/native-site/vitest.config.ts
+++ b/apps/native-site/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Covers the playground's pure layer only — `snippet.ts` and the option
+ * helpers in `types.ts`, neither of which imports `react-native`. Component
+ * behaviour is verified in `blend-native`'s own render suite; what this app
+ * is for is being looked at on a device.
+ */
+export default defineConfig({
+    test: {
+        include: ['playground/**/*.test.ts'],
+        environment: 'node',
+    },
+})

--- a/packages/blend-native/src/index.ts
+++ b/packages/blend-native/src/index.ts
@@ -47,6 +47,17 @@ export type { ProgressBarNativeProps } from './components/ProgressBar'
 export { Spinner } from './components/Spinner'
 export type { SpinnerNativeProps } from './components/Spinner'
 
+// Value unions for the props above. Exported so a consumer can type a
+// `variant`/`size` prop of their own, and so tooling can enumerate the
+// options; they are string unions on the web side, not enums, so there is
+// no runtime object to re-export.
+export type {
+    SkeletonVariant,
+    SkeletonShape,
+    SpinnerSize,
+    SpinnerColor,
+} from '@juspay/blend-design-system/node'
+
 export type {
     AlertNativeProps,
     AlertSlot,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
             expo:
                 specifier: ~56.0.12
                 version: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            expo-glass-effect:
+                specifier: 56.0.4
+                version: 56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
             expo-linear-gradient:
                 specifier: ~56.0.4
                 version: 56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
@@ -464,6 +467,9 @@ importers:
             react-native:
                 specifier: 0.85.3
                 version: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            react-native-drawer-layout:
+                specifier: 4.2.10
+                version: 4.2.10(cefaf9700597b310fdd15f17867ed642)
             react-native-gesture-handler:
                 specifier: ~2.31.1
                 version: 2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
@@ -492,6 +498,9 @@ importers:
             typescript:
                 specifier: ~6.0.3
                 version: 6.0.3
+            vitest:
+                specifier: ^3.2.4
+                version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.50.0)(tsx@4.21.0)(yaml@2.8.2)
 
     apps/site:
         dependencies:
@@ -10341,6 +10350,19 @@ packages:
                 integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
             }
 
+    color-string@1.9.1:
+        resolution:
+            {
+                integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==,
+            }
+
+    color@4.2.3:
+        resolution:
+            {
+                integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==,
+            }
+        engines: { node: '>=12.5.0' }
+
     colorette@2.0.20:
         resolution:
             {
@@ -12000,6 +12022,16 @@ packages:
             react: '*'
             react-native: '*'
 
+    expo-glass-effect@56.0.4:
+        resolution:
+            {
+                integrity: sha512-xI9rXtDwi7RW82uAlfyaXO6+k21ApWJ2tHAWYqPr/FjfmZbKsgNJ4Q0iZzGPCwboqjTGxaRZ61SZxBl8hDt5iA==,
+            }
+        peerDependencies:
+            expo: '*'
+            react: '*'
+            react-native: '*'
+
     expo-keep-awake@56.0.3:
         resolution:
             {
@@ -13406,6 +13438,12 @@ packages:
         resolution:
             {
                 integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+            }
+
+    is-arrayish@0.3.4:
+        resolution:
+            {
+                integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==,
             }
 
     is-async-function@2.1.1:
@@ -17685,6 +17723,17 @@ packages:
         engines: { node: ^20.19.0 || ^22.12.0 || >= 23.4.0 }
         hasBin: true
 
+    react-native-drawer-layout@4.2.10:
+        resolution:
+            {
+                integrity: sha512-O6TQdZ5LSm3dqnuR4rX9KPtE+9dVg7jsezEYz1l01rkQTe4fQvYZIoPu2sZFl5X2N70uhRdjnPULySVR3sBUwA==,
+            }
+        peerDependencies:
+            react: '>= 18.2.0'
+            react-native: '*'
+            react-native-gesture-handler: '>= 2.0.0'
+            react-native-reanimated: '>= 2.0.0'
+
     react-native-gesture-handler@2.31.1:
         resolution:
             {
@@ -18727,6 +18776,12 @@ packages:
         resolution:
             {
                 integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==,
+            }
+
+    simple-swizzle@0.2.4:
+        resolution:
+            {
+                integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==,
             }
 
     sirv@3.0.2:
@@ -20299,6 +20354,14 @@ packages:
         peerDependenciesMeta:
             '@types/react':
                 optional: true
+
+    use-latest-callback@0.2.6:
+        resolution:
+            {
+                integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==,
+            }
+        peerDependencies:
+            react: '>=16.8'
 
     use-sidecar@1.1.3:
         resolution:
@@ -22982,6 +23045,7 @@ snapshots:
             - supports-color
             - typescript
             - utf-8-validate
+        optional: true
 
     '@expo/code-signing-certificates@0.0.6':
         dependencies:
@@ -23079,6 +23143,7 @@ snapshots:
         optionalDependencies:
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optional: true
 
     '@expo/dom-webview@56.0.6(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)':
         dependencies:
@@ -23091,6 +23156,7 @@ snapshots:
             expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optional: true
 
     '@expo/env@2.3.1':
         dependencies:
@@ -23209,6 +23275,7 @@ snapshots:
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
             stacktrace-parser: 0.1.11
+        optional: true
 
     '@expo/metro-config@56.0.18(expo@56.0.20)(typescript@5.8.3)':
         dependencies:
@@ -23433,6 +23500,7 @@ snapshots:
             react-dom: 19.2.3(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
+        optional: true
 
     '@expo/schema-utils@56.0.2': {}
 
@@ -25937,7 +26005,9 @@ snapshots:
             metro-runtime: 0.84.5
         transitivePeerDependencies:
             - '@babel/core'
+            - bufferutil
             - supports-color
+            - utf-8-validate
 
     '@react-native/normalize-colors@0.74.89': {}
 
@@ -25960,6 +26030,7 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optionalDependencies:
             '@types/react': 19.2.7
+        optional: true
 
     '@react-three/fiber@9.5.0(@types/react@19.2.7)(expo-asset@56.0.23(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3))(expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)))(expo@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(three@0.182.0)':
         dependencies:
@@ -27876,7 +27947,7 @@ snapshots:
             sirv: 3.0.2
             tinyglobby: 0.2.15
             tinyrainbow: 2.0.0
-            vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.27)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.50.0)(tsx@4.21.0)(yaml@2.8.2)
+            vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.50.0)(tsx@4.21.0)(yaml@2.8.2)
 
     '@vitest/utils@2.0.5':
         dependencies:
@@ -28443,7 +28514,7 @@ snapshots:
             react-refresh: 0.14.2
         optionalDependencies:
             '@babel/runtime': 7.28.4
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
         transitivePeerDependencies:
             - '@babel/core'
             - supports-color
@@ -28874,6 +28945,16 @@ snapshots:
     color-name@1.1.3: {}
 
     color-name@1.1.4: {}
+
+    color-string@1.9.1:
+        dependencies:
+            color-name: 1.1.4
+            simple-swizzle: 0.2.4
+
+    color@4.2.3:
+        dependencies:
+            color-convert: 2.0.1
+            color-string: 1.9.1
 
     colorette@2.0.20: {}
 
@@ -29986,6 +30067,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
             - typescript
+        optional: true
 
     expo-constants@56.0.24(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30002,6 +30084,7 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         transitivePeerDependencies:
             - supports-color
+        optional: true
 
     expo-file-system@56.0.10(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30012,6 +30095,7 @@ snapshots:
         dependencies:
             expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optional: true
 
     expo-font@56.0.7(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
@@ -30026,10 +30110,17 @@ snapshots:
             fontfaceobserver: 2.3.0
             react: 19.2.3
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optional: true
+
+    expo-glass-effect@56.0.4(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
+        dependencies:
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
 
     expo-keep-awake@56.0.3(expo@56.0.20)(react@19.2.3):
         dependencies:
-            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)
+            expo: 56.0.20(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
             react: 19.2.3
 
     expo-linear-gradient@15.0.8(expo@56.0.20)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
@@ -30083,6 +30174,7 @@ snapshots:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
         optionalDependencies:
             react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+        optional: true
 
     expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)):
         dependencies:
@@ -30091,6 +30183,7 @@ snapshots:
     expo-modules-jsi@56.0.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)):
         dependencies:
             react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.3)
+        optional: true
 
     expo-server@56.0.6: {}
 
@@ -30219,6 +30312,7 @@ snapshots:
             - supports-color
             - typescript
             - utf-8-validate
+        optional: true
 
     exponential-backoff@3.1.3: {}
 
@@ -31163,6 +31257,8 @@ snapshots:
             get-intrinsic: 1.3.0
 
     is-arrayish@0.2.1: {}
+
+    is-arrayish@0.3.4: {}
 
     is-async-function@2.1.1:
         dependencies:
@@ -34588,6 +34684,15 @@ snapshots:
             - babel-plugin-macros
             - supports-color
 
+    react-native-drawer-layout@4.2.10(cefaf9700597b310fdd15f17867ed642):
+        dependencies:
+            color: 4.2.3
+            react: 19.2.3
+            react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3)
+            react-native-gesture-handler: 2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3)
+            use-latest-callback: 0.2.6(react@19.2.3)
+
     react-native-gesture-handler@2.31.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.2.3))(react@19.2.3):
         dependencies:
             '@egjs/hammerjs': 2.0.17
@@ -34769,6 +34874,7 @@ snapshots:
             - bufferutil
             - supports-color
             - utf-8-validate
+        optional: true
 
     react-phone-input-2@2.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
         dependencies:
@@ -35476,6 +35582,10 @@ snapshots:
             bplist-creator: 0.1.0
             bplist-parser: 0.3.1
             plist: 3.1.1
+
+    simple-swizzle@0.2.4:
+        dependencies:
+            is-arrayish: 0.3.4
 
     sirv@3.0.2:
         dependencies:
@@ -36511,6 +36621,10 @@ snapshots:
             tslib: 2.8.1
         optionalDependencies:
             '@types/react': 19.2.7
+
+    use-latest-callback@0.2.6(react@19.2.3):
+        dependencies:
+            react: 19.2.3
 
     use-sidecar@1.1.3(@types/react@19.2.7)(react@19.2.3):
         dependencies:


### PR DESCRIPTION
## What this changes

`apps/native-site` had seven tabs, each a hand-written wall of every variant —
`TagShowcase` alone renders 144 tags. That format answers *"is anything
broken?"* well, and it is how the Tag descender clipping and the Alert
text-wrap bug were both caught. It answers *"what does this component do?"*
badly: there is no way to see one instance and change its props, no way to
reach a specific combination, and every new prop means hand-editing a
showcase.

The library had also outgrown it — sixteen renderables against seven
showcases, so several components shared a screen and none were individually
explorable.

This adds a **preview stage driven by controls** and keeps the grids as a
second view, so both questions get answered.

| | |
|---|---|
| **Preview** | one instance, controls that reach every variant and combination, and the JSX for what is on screen |
| **Gallery** | the existing dense grid, unchanged |

A **side drawer** picks the component; a **native bottom bar** picks the
view. The selection is shared, so moving between Preview and Gallery keeps
you on the same component.

Twelve nav entries cover all sixteen renderables — the Button family
(Button / IconButton / LinkButton / ButtonGroup) and Tag / TagGroup fold
into one spec each, since they share a token slot and reading them against
each other is the point.

## Adding a component is now a spec file

```tsx
const spec: ComponentSpec<BadgeNativeProps> = {
    name: 'Badge',
    summary: 'One line on what is worth knowing.',
    mode: 'inline',
    defaults: { text: 'New', variant: BadgeVariant.SUBTLE },
    controls: [
        { kind: 'segmented', key: 'variant', label: 'Variant',
          options: enumOptions(BadgeVariant, 'BadgeVariant') },
        { kind: 'text', key: 'text', label: 'Text', always: true },
    ],
    render: (props) => <Badge {...props} />,
    gallery: BadgeShowcase,
}
```

Plus one line in `playground/specs/index.ts`. No screen to add, no switch to
extend.

## Four decisions worth reviewing

**1. The control chrome is plain React Native, never `blend-native`.** The
playground is the instrument used to inspect the library, so it has to keep
working when the library does not — a control panel built out of the
components under test goes blank exactly when you need it. `chrome.ts` holds
its own palette for the same reason.

**2. Options come from the enums.** `enumOptions(TagColor, 'TagColor')`
rather than a hardcoded list, so a colour added to the library appears in the
controls on its own. String unions have no runtime object to enumerate, so
`unionOptions` takes an explicit list — and **fails to compile** if the union
gains a member the list does not have. That guard was verified by
deliberately omitting one.

**3. The snippet diffs against the spec defaults**, so it stays short and
doubles as documentation of what the defaults are. `always: true` opts a prop
back in for components that have no default of their own — without it the
snippet reads `<Badge />`, which renders nothing.

**4. Playground-only props never reach the snippet.** A family selector picks
*which* component renders and is stripped before it gets there; `hidden: true`
keeps it out of the JSX, and `wrapSnippet` reshapes the output where the real
call differs — `<TagGroup>` around its tags, or `addSnackbar({ ... })`, which
is a call rather than an element.

`snippet.ts` is pure and unit-tested (16 tests, `pnpm --filter native-site
test`) — defaults omitted, enums printed by name, booleans shorthanded,
strings switched to expression form when they contain a quote.

## The bottom bar is genuinely native

Three implementations behind the `.ios` / `.android` / suffix-less split,
held to one shape by `tabBar.shared.ts`:

- **iOS** — `GlassView` from `expo-glass-effect`, a real `UIVisualEffectView`.
  The API only exists on iOS 26 and some 26 builds ship without it, so
  `isLiquidGlassAvailable()` decides at runtime and the miss paints an opaque
  surface. A translucent bar with no material behind it would leave the labels
  sitting unreadably on the scroll content.
- **Android** — Material 3: 80dp container, 64×32dp pill indicator behind the
  active icon, label underneath, ripple.
- **Web** — a plain bordered bar.

Not `react-native-bottom-tabs` or Expo Router `NativeTabs`: each would mean
adopting React Navigation or file-based routing and restructuring `App.tsx`
into a navigator, for a two-item switcher — and neither renders on the web
target the phone-frame preview depends on.

## One bug this found

`useWindowDimensions()` reports the **browser** width on the web target,
where the app renders inside a phone frame. The drawer went permanent at
1280px while the app actually had 390, crushing the content to ~130px. Now
measured with `onLayout` on the container, which is correct in every case.

## Library change

`SkeletonVariant`, `SkeletonShape`, `SpinnerSize` and `SpinnerColor` are
re-exported from `blend-native`. The props referenced them but the barrel
never exposed them, so a consumer could not type a `variant` prop of their
own. Type-only and additive.

## Verification

```
format:check                     pass
check:circular                   pass
blend-native  typecheck / lint   pass
blend-native  765 unit + 84 render  pass
blend-native  bob build          pass
native-site   typecheck          pass
native-site   16 snippet tests   pass
```

On device, because `react-native-web` misses RN-specific layout bugs:

- **iOS 26.4** (iPhone 17 Pro, dev build) — Liquid Glass renders; content is
  visibly refracted through the bar. Drawer, dark theme, Gallery, and the
  Alert/Button/Tag previews all correct.
- **iOS fallback branch** — forced on; paints opaque with the hairline rule,
  not transparent.
- **Android** (Pixel 8, `expo run:android`) — Material 3 bar with the pill
  indicator; controls, drawer, component switching, the Snackbar overlay
  trigger, and the JSX snippet all verified with real taps. Reset correctly
  enables only once a control has moved.
- **Web** — the fallback bar and the phone-frame preview both work; the
  permanent-drawer branch was exercised by lowering the threshold.

### Known, not introduced here

- **Drawer edge-swipe loses to Android's system back gesture** on
  gesture-navigation devices — the OS owns the left edge and closes the app.
  Documented in the README; the hamburger is always present and works on both
  platforms.
- **`pnpm --filter blend-native check:peer` fails on `dev` today**, with 15
  values missing from the published peer (Avatar, Card, KeyValuePair,
  ProgressBar, Snackbar). Verified identical with this branch's change
  stashed, so it is pre-existing — the recent components outran the published
  `@juspay/blend-design-system`. It gates the publish workflow, not CI, but it
  will block the next `blend-native` release until blend is published.

## Review round — eight defects found and fixed

The first push was reviewed adversarially before merge. Everything below was
real, and every fix was re-verified on the Android device with real taps.

| | |
|---|---|
| A toggle's `off: undefined` collapsed to `false` | Switching a slot off wrote `leftSlot={false}` — into the component's props and into the JSX, where it does not type-check. Nine specs were affected, including `onPress={false}` on Tag. The resolution moved to `toggleValues`, a pure helper; the regression test fails against the old logic and passes against the new. |
| Reset compared only `defaults` keys | Changing a prop with no spec default (`loading`, `width`, any slot) left Reset disabled with no way to undo. Button's `width` also had no `Auto` option, so a width once set could never be cleared. |
| A Gallery visit discarded your work | `Playground` and `Gallery` were ternary alternates, so the tab switch unmounted the props you had configured — contradicting what this PR and the README both promise. Hidden with `display: none` now, which Yoga drops from layout entirely. |
| Tag's group branch returned first | Grouped tags got the raw no-op handler, so all three announced as buttons and did nothing. Both branches now share an `InteractiveTag` that owns its own pressed state. The group also gained `stacked` — without it the radius collapsing the mode exists to show never happened. |
| A Gallery tab could resurrect itself | Selecting Gallery, moving to a spec without one, then back landed you on Gallery unasked. The fallback is written into state now. |
| Group snippets printed one child | The stage rendered three. A one-member group is precisely where the radius collapsing does not happen, so the snippet contradicted its own preview. |
| Three snippets did not compile | Card omitted the `onPress` its `selected` chrome needs (now a real control), BottomSheet omitted required `open`/`onClose`/children, TextInput omitted `value`/`onChangeText`. |
| `isLiquidGlassAvailable()` could take the app down | It throws when the native module is unlinked rather than returning `false`, and ran at module scope — a red screen during import rather than one degraded bar. |

Also fixed: `humanize` flattened PascalCase, so the component pickers read
"Taggroup" and "Iconbutton"; and `expo prebuild` had silently rewritten the
`ios`/`android` scripts to `expo run:*`, which is reverted.

The pure suite grew from 16 tests to 25.

## Verified on device after the fixes

- A slot toggled on then off leaves no `leftSlot={false}` in the block.
- Reset enables with only `loading` changed.
- Gallery → Preview round-trip keeps the loading spinner and the props.
- A stacked TagGroup collapses its interior corners, and its snippet prints
  all three members with `<TagGroup stacked>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWUKeTncWa9TefasUTyenh

