### PR TITLE
fix(code-editor): wire bundled Monaco language workers

### DIFF
--- a/packages/blend/__tests__/components/CodeEditor/monacoEnvironment.test.ts
+++ b/packages/blend/__tests__/components/CodeEditor/monacoEnvironment.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { configureMonacoEnvironment } from '../../../lib/components/shared/monacoEnvironment'
+
+type GlobalWithMonaco = typeof globalThis & {
+    MonacoEnvironment?: { getWorker?: unknown }
+}
+
+const globalScope = globalThis as GlobalWithMonaco
+
+describe('configureMonacoEnvironment (#1734)', () => {
+    let previous: GlobalWithMonaco['MonacoEnvironment']
+
+    beforeEach(() => {
+        previous = globalScope.MonacoEnvironment
+        delete globalScope.MonacoEnvironment
+    })
+
+    afterEach(() => {
+        globalScope.MonacoEnvironment = previous
+    })
+
+    it('defines MonacoEnvironment.getWorker so a self-hosted Monaco can spawn workers', () => {
+        expect(globalScope.MonacoEnvironment).toBeUndefined()
+        configureMonacoEnvironment()
+        expect(typeof globalScope.MonacoEnvironment?.getWorker).toBe('function')
+    })
+
+    it('does not override a consumer that already configured MonacoEnvironment', () => {
+        const consumerGetWorker = () => ({}) as unknown as Worker
+        globalScope.MonacoEnvironment = { getWorker: consumerGetWorker }
+        configureMonacoEnvironment()
+        expect(globalScope.MonacoEnvironment?.getWorker).toBe(consumerGetWorker)
+    })
+})

--- a/packages/blend/__tests__/components/CodeEditor/monacoEnvironment.test.ts
+++ b/packages/blend/__tests__/components/CodeEditor/monacoEnvironment.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { configureMonacoEnvironment } from '../../../lib/components/shared/monacoEnvironment'
 
 type GlobalWithMonaco = typeof globalThis & {
-    MonacoEnvironment?: { getWorker?: unknown }
+    MonacoEnvironment?: {
+        getWorker?: unknown
+        getWorkerUrl?: unknown
+        globalAPI?: boolean
+    }
 }
 
 const globalScope = globalThis as GlobalWithMonaco
@@ -25,10 +29,35 @@ describe('configureMonacoEnvironment (#1734)', () => {
         expect(typeof globalScope.MonacoEnvironment?.getWorker).toBe('function')
     })
 
-    it('does not override a consumer that already configured MonacoEnvironment', () => {
+    it('does not override a consumer that already wired getWorker', () => {
         const consumerGetWorker = () => ({}) as unknown as Worker
         globalScope.MonacoEnvironment = { getWorker: consumerGetWorker }
         configureMonacoEnvironment()
         expect(globalScope.MonacoEnvironment?.getWorker).toBe(consumerGetWorker)
+    })
+
+    it('defers to a consumer that wired getWorkerUrl instead of getWorker', () => {
+        const getWorkerUrl = () => 'worker.js'
+        globalScope.MonacoEnvironment = { getWorkerUrl }
+        configureMonacoEnvironment()
+        expect(globalScope.MonacoEnvironment?.getWorker).toBeUndefined()
+        expect(globalScope.MonacoEnvironment?.getWorkerUrl).toBe(getWorkerUrl)
+    })
+
+    it('installs getWorker on a partial config with no provider, keeping sibling keys', () => {
+        globalScope.MonacoEnvironment = {
+            globalAPI: true,
+        } as GlobalWithMonaco['MonacoEnvironment']
+        configureMonacoEnvironment()
+        expect(typeof globalScope.MonacoEnvironment?.getWorker).toBe('function')
+        expect(
+            (globalScope.MonacoEnvironment as { globalAPI?: boolean }).globalAPI
+        ).toBe(true)
+    })
+
+    it('installs getWorker on an empty MonacoEnvironment object', () => {
+        globalScope.MonacoEnvironment = {}
+        configureMonacoEnvironment()
+        expect(typeof globalScope.MonacoEnvironment?.getWorker).toBe('function')
     })
 })

--- a/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
@@ -360,14 +360,21 @@ export const MonacoEditorWrapper = ({
                 // @ts-expect-error Monaco does not publish types for this ESM entry.
                 'monaco-editor/esm/vs/editor/editor.main.js'
             ),
-        ]).then(([env, monaco]) => {
-            if (cancelled) return
-            // Wire the bundled language workers before configuring the loader,
-            // so a self-hosted Monaco can spawn them (#1734).
-            env.configureMonacoEnvironment()
-            loader.config({ monaco: monaco as typeof Monaco })
-            setIsMonacoLoaded(true)
-        })
+        ])
+            .then(([env, monaco]) => {
+                if (cancelled) return
+                // Wire the bundled language workers before configuring the
+                // loader, so a self-hosted Monaco can spawn them (#1734).
+                env.configureMonacoEnvironment()
+                loader.config({ monaco: monaco as typeof Monaco })
+                setIsMonacoLoaded(true)
+            })
+            .catch((error) => {
+                if (cancelled) return
+                // Surface the failure instead of an unhandled rejection; the
+                // wrapper stays in its loading state.
+                console.error('Failed to load the code editor (Monaco).', error)
+            })
 
         return () => {
             cancelled = true

--- a/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
@@ -354,12 +354,18 @@ export const MonacoEditorWrapper = ({
     useEffect(() => {
         let cancelled = false
 
-        import(
-            // @ts-expect-error Monaco does not publish types for this ESM entry.
-            'monaco-editor/esm/vs/editor/editor.main.js'
-        ).then((monaco: typeof Monaco) => {
+        Promise.all([
+            import('../shared/monacoEnvironment'),
+            import(
+                // @ts-expect-error Monaco does not publish types for this ESM entry.
+                'monaco-editor/esm/vs/editor/editor.main.js'
+            ),
+        ]).then(([env, monaco]) => {
             if (cancelled) return
-            loader.config({ monaco })
+            // Wire the bundled language workers before configuring the loader,
+            // so a self-hosted Monaco can spawn them (#1734).
+            env.configureMonacoEnvironment()
+            loader.config({ monaco: monaco as typeof Monaco })
             setIsMonacoLoaded(true)
         })
 

--- a/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
@@ -134,12 +134,18 @@ export function MonacoEditorWrapper({
     useEffect(() => {
         let cancelled = false
 
-        import(
-            // @ts-expect-error Monaco does not publish types for this ESM entry.
-            'monaco-editor/esm/vs/editor/editor.main.js'
-        ).then((monaco: typeof Monaco) => {
+        Promise.all([
+            import('../../shared/monacoEnvironment'),
+            import(
+                // @ts-expect-error Monaco does not publish types for this ESM entry.
+                'monaco-editor/esm/vs/editor/editor.main.js'
+            ),
+        ]).then(([env, monaco]) => {
             if (cancelled) return
-            loader.config({ monaco })
+            // Wire the bundled language workers before configuring the loader,
+            // so a self-hosted Monaco can spawn them (#1734).
+            env.configureMonacoEnvironment()
+            loader.config({ monaco: monaco as typeof Monaco })
             setIsMonacoLoaded(true)
         })
 

--- a/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
@@ -140,14 +140,21 @@ export function MonacoEditorWrapper({
                 // @ts-expect-error Monaco does not publish types for this ESM entry.
                 'monaco-editor/esm/vs/editor/editor.main.js'
             ),
-        ]).then(([env, monaco]) => {
-            if (cancelled) return
-            // Wire the bundled language workers before configuring the loader,
-            // so a self-hosted Monaco can spawn them (#1734).
-            env.configureMonacoEnvironment()
-            loader.config({ monaco: monaco as typeof Monaco })
-            setIsMonacoLoaded(true)
-        })
+        ])
+            .then(([env, monaco]) => {
+                if (cancelled) return
+                // Wire the bundled language workers before configuring the
+                // loader, so a self-hosted Monaco can spawn them (#1734).
+                env.configureMonacoEnvironment()
+                loader.config({ monaco: monaco as typeof Monaco })
+                setIsMonacoLoaded(true)
+            })
+            .catch((error) => {
+                if (cancelled) return
+                // Surface the failure instead of an unhandled rejection; the
+                // wrapper stays in its loading state.
+                console.error('Failed to load the code editor (Monaco).', error)
+            })
 
         return () => {
             cancelled = true

--- a/packages/blend/lib/components/shared/monacoEnvironment.ts
+++ b/packages/blend/lib/components/shared/monacoEnvironment.ts
@@ -16,6 +16,7 @@
 
 type MonacoEnvironmentLike = {
     getWorker?: (workerId: string, label: string) => Worker
+    getWorkerUrl?: (workerId: string, label: string) => string
 }
 
 const createWorker = (label: string): Worker => {
@@ -78,8 +79,15 @@ export const configureMonacoEnvironment = (): void => {
     const globalScope = globalThis as typeof globalThis & {
         MonacoEnvironment?: MonacoEnvironmentLike
     }
-    if (globalScope.MonacoEnvironment) return
+    const existing = globalScope.MonacoEnvironment
+    // Defer only when a worker provider is already wired (e.g. by
+    // monaco-editor-webpack-plugin). A partial config with no provider — an
+    // empty `{}` or a `{ globalAPI: true }` / `{ baseUrl }` left by another
+    // library — would otherwise skip our getWorker and re-surface #1734, so we
+    // merge into it rather than replace, keeping any sibling keys.
+    if (existing && (existing.getWorker || existing.getWorkerUrl)) return
     globalScope.MonacoEnvironment = {
+        ...existing,
         getWorker: (_workerId: string, label: string): Worker =>
             createWorker(label),
     }

--- a/packages/blend/lib/components/shared/monacoEnvironment.ts
+++ b/packages/blend/lib/components/shared/monacoEnvironment.ts
@@ -1,0 +1,86 @@
+// Wires Monaco's language-service web workers to the copy of `monaco-editor`
+// bundled in this package. CodeEditor/CodeEditorV2 self-host Monaco (see #1668)
+// via `loader.config({ monaco })`; a self-hosted Monaco spawns a worker per
+// language and requires `globalThis.MonacoEnvironment.getWorker`, which the
+// package never set — so `json`/`css`/`html`/`typescript` modes threw
+// "MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker" (#1734).
+//
+// `new Worker(new URL('…', import.meta.url), { type: 'module' })` makes the
+// bundler compile each worker (with its deps) into this package's dist and
+// reference it *relative to the module*, so the URLs resolve wherever a
+// consumer serves the package's assets — no Monaco/worker setup, version-skew
+// or CDN dependency on the consumer side.
+//
+// This module is browser-only and is loaded lazily from the editor wrappers'
+// mount effect, so it never runs during SSR.
+
+type MonacoEnvironmentLike = {
+    getWorker?: (workerId: string, label: string) => Worker
+}
+
+const createWorker = (label: string): Worker => {
+    switch (label) {
+        case 'json':
+            return new Worker(
+                new URL(
+                    'monaco-editor/esm/vs/language/json/json.worker.js',
+                    import.meta.url
+                ),
+                { type: 'module' }
+            )
+        case 'css':
+        case 'scss':
+        case 'less':
+            return new Worker(
+                new URL(
+                    'monaco-editor/esm/vs/language/css/css.worker.js',
+                    import.meta.url
+                ),
+                { type: 'module' }
+            )
+        case 'html':
+        case 'handlebars':
+        case 'razor':
+            return new Worker(
+                new URL(
+                    'monaco-editor/esm/vs/language/html/html.worker.js',
+                    import.meta.url
+                ),
+                { type: 'module' }
+            )
+        case 'typescript':
+        case 'javascript':
+            return new Worker(
+                new URL(
+                    'monaco-editor/esm/vs/language/typescript/ts.worker.js',
+                    import.meta.url
+                ),
+                { type: 'module' }
+            )
+        default:
+            return new Worker(
+                new URL(
+                    'monaco-editor/esm/vs/editor/editor.worker.js',
+                    import.meta.url
+                ),
+                { type: 'module' }
+            )
+    }
+}
+
+/**
+ * Sets `globalThis.MonacoEnvironment.getWorker` to spawn the bundled workers,
+ * once, and only if a consumer hasn't already configured it (e.g. via
+ * `monaco-editor-webpack-plugin`) — in which case the consumer's setup wins.
+ */
+export const configureMonacoEnvironment = (): void => {
+    if (typeof globalThis === 'undefined') return
+    const globalScope = globalThis as typeof globalThis & {
+        MonacoEnvironment?: MonacoEnvironmentLike
+    }
+    if (globalScope.MonacoEnvironment) return
+    globalScope.MonacoEnvironment = {
+        getWorker: (_workerId: string, label: string): Worker =>
+            createWorker(label),
+    }
+}

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -24,7 +24,7 @@
 // inline types claim two independent components where there is one, so
 // type-driven tooling emits duplicates. Discovery is by runtime value, so
 // new compounds are covered automatically without registering them here.
-import { readdirSync, existsSync, statSync } from 'node:fs'
+import { readdirSync, existsSync, statSync, readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
@@ -259,6 +259,26 @@ if (moduleSymbol && compoundStatics.length > 0) {
                     'value identity instead of inlining the props.'
             )
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 4: JS-referenced asset URLs (the Monaco worker chunks, issue #1734)
+// must keep an explicit `./` — `new URL("assets/x", import.meta.url)` without
+// it is a bare specifier that webpack-5 consumers re-bundling this ESM (e.g.
+// Next.js transpilePackages) resolve as a node_modules module, breaking their
+// build. The Vite config forces the `./`; this locks it in.
+// ---------------------------------------------------------------------------
+const bareAssetUrl = /new URL\(\s*(?:\/\*[^*]*\*\/\s*)?["']assets\//
+for (const file of readdirSync(distDir).filter((f) => f.endsWith('.js'))) {
+    const source = readFileSync(resolve(distDir, file), 'utf8')
+    if (bareAssetUrl.test(source)) {
+        failed = true
+        console.error(
+            `✖ dist/${file} references an asset with \`new URL("assets/…", import.meta.url)\` ` +
+                'without a leading "./". A bare specifier breaks webpack-5 consumers — ' +
+                'ensure vite.config `experimental.renderBuiltUrl` prefixes "./" for hostType "js".'
+        )
     }
 }
 

--- a/packages/blend/vite.config.ts
+++ b/packages/blend/vite.config.ts
@@ -47,6 +47,18 @@ export default defineConfig({
     worker: {
         format: 'es',
     },
+    experimental: {
+        // Force an explicit `./` on JS-referenced asset URLs (only the Monaco
+        // worker chunks — the sole `new URL(..., import.meta.url)` refs in the
+        // library). Without it Vite emits `new URL("assets/x", import.meta.url)`;
+        // webpack-5 consumers that re-bundle this ESM (e.g. Next.js
+        // transpilePackages) treat a bare `assets/x` as a module request and
+        // fail to resolve it. CSS url() (hostType 'css') is left untouched.
+        renderBuiltUrl(filename, { hostType }) {
+            if (hostType === 'js') return './' + filename
+            return { relative: true }
+        },
+    },
     build: {
         copyPublicDir: false,
         lib: {

--- a/packages/blend/vite.config.ts
+++ b/packages/blend/vite.config.ts
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig({
+    // Relative asset base so URLs referenced from JS (e.g. the Monaco worker
+    // chunks in monacoEnvironment) resolve relative to the module via
+    // import.meta.url, and work wherever a consumer serves the package assets.
+    // Only affects asset URLs (workers, CSS url()), not ES import specifiers.
+    base: './',
     plugins: [
         react(),
         dts({
@@ -35,6 +40,12 @@ export default defineConfig({
                 replacement: resolve(__dirname, 'lib/main.ts'),
             },
         ],
+    },
+    // Emit Monaco's language workers (referenced via `new Worker(new URL(...,
+    // import.meta.url), { type: 'module' })` in monacoEnvironment) as ES-module
+    // worker chunks, so their URLs resolve relative to the module in consumers.
+    worker: {
+        format: 'es',
     },
     build: {
         copyPublicDir: false,


### PR DESCRIPTION
## Summary

Since Monaco is self-hosted from the installed package (#1668), a `CodeEditor` / `CodeEditorV2` mounted in `json`/`css`/`html`/`typescript` mode threw:

```
Error: You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker
```

The package configured the loader (`loader.config({ monaco })`) but never set `globalThis.MonacoEnvironment`, so a self-hosted Monaco couldn't spawn its language-service web workers.

Closes #1734.

## Fix

- **New `lib/components/shared/monacoEnvironment.ts`** — sets `MonacoEnvironment.getWorker` using the **bundled** workers:
  ```ts
  new Worker(new URL('monaco-editor/esm/vs/language/json/json.worker.js', import.meta.url), { type: 'module' })
  ```
  Guarded on `!globalThis.MonacoEnvironment`, so a consumer that already wired workers (e.g. `monaco-editor-webpack-plugin`) still wins.
- **Both editor wrappers** load it lazily in the mount effect and configure it **before** `loader.config`, so it never runs during SSR.
- **Build** (`vite.config.ts`): emit ES-module worker chunks (`worker.format: 'es'`) and use a **relative asset base** (`base: './'`) so the worker URLs resolve **relative to the module** (`import.meta.url`) — they work wherever a consumer serves the package assets, with no version-skew or CDN dependency.

## Why in blend-design-system
The package bundles the matching `monaco-editor@0.54.0` + language-mode workers in its own `dist`, so it's the only place that can wire them without version-skew. This also lets consumers drop `cdn.jsdelivr.net` from their CSP.

## Verification
- `pnpm build` succeeds; `dist/assets/{editor,json,css,html,ts}.worker-*.js` are emitted and referenced relative to the module via `import.meta.url`; `check:dist` green; `style.css` unaffected.
- `base: './'` only affects asset URLs (workers, CSS `url()`), not ES import specifiers, so the module graph is unchanged.
- Tests: new `monacoEnvironment` regression test (defines `getWorker`, respects a pre-set `MonacoEnvironment`); existing CodeEditor/CodeEditorV2 suites still pass (14 total). Lint + format green.

## Notes
- Recommend a smoke test in a real webpack-5 consumer (mount `CodeEditor language="json"`) to confirm the worker chunks resolve end-to-end before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)