### PR TITLE
fix(code-editor): self-host Monaco editor CSS via runtime injection

### DIFF
--- a/packages/blend/__tests__/components/CodeEditor/monacoStyles.test.ts
+++ b/packages/blend/__tests__/components/CodeEditor/monacoStyles.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Self-hosting Monaco's editor stylesheet (#1744): injectMonacoStyles() must
+// put the stylesheet into the DOM exactly once, so a CodeEditor renders styled
+// with no global Blend stylesheet import — and never duplicate ~260KB of CSS
+// across multiple editor mounts or a second copy of the package.
+const MARKER = 'style[data-blend-monaco]'
+
+describe('injectMonacoStyles (#1744)', () => {
+    beforeEach(() => {
+        vi.resetModules()
+        document.head.querySelectorAll(MARKER).forEach((el) => el.remove())
+    })
+
+    afterEach(() => {
+        document.head.querySelectorAll(MARKER).forEach((el) => el.remove())
+    })
+
+    it('injects the editor stylesheet into document.head with content', async () => {
+        const { injectMonacoStyles } =
+            await import('../../../lib/components/shared/monacoStyles')
+        expect(document.head.querySelector(MARKER)).toBeNull()
+
+        injectMonacoStyles()
+
+        const style = document.head.querySelector(MARKER)
+        expect(style).not.toBeNull()
+        expect(style?.tagName).toBe('STYLE')
+        // The `?inline` import must resolve to real CSS text, not an empty
+        // string — otherwise the editor ships unstyled.
+        expect((style?.textContent ?? '').length).toBeGreaterThan(0)
+        expect(style?.textContent).toContain('.monaco-editor')
+    })
+
+    it('is idempotent across repeated calls (one <style> only)', async () => {
+        const { injectMonacoStyles } =
+            await import('../../../lib/components/shared/monacoStyles')
+        injectMonacoStyles()
+        injectMonacoStyles()
+        injectMonacoStyles()
+        expect(document.head.querySelectorAll(MARKER)).toHaveLength(1)
+    })
+
+    it('does not duplicate when a marker style already exists (e.g. a second package copy)', async () => {
+        const existing = document.createElement('style')
+        existing.setAttribute('data-blend-monaco', '')
+        existing.textContent = '/* injected by another bundle */'
+        document.head.appendChild(existing)
+
+        const { injectMonacoStyles } =
+            await import('../../../lib/components/shared/monacoStyles')
+        injectMonacoStyles()
+
+        const styles = document.head.querySelectorAll(MARKER)
+        expect(styles).toHaveLength(1)
+        expect(styles[0]).toBe(existing)
+    })
+})

--- a/packages/blend/__tests__/components/CodeEditor/monacoStyles.test.ts
+++ b/packages/blend/__tests__/components/CodeEditor/monacoStyles.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { version as MONACO_VERSION } from 'monaco-editor/package.json'
 
 // Self-hosting Monaco's editor stylesheet (#1744): injectMonacoStyles() must
 // put the stylesheet into the DOM exactly once, so a CodeEditor renders styled
 // with no global Blend stylesheet import — and never duplicate ~260KB of CSS
-// across multiple editor mounts or a second copy of the package.
+// across multiple editor mounts or another copy of the package that bundles the
+// same Monaco version.
 const MARKER = 'style[data-blend-monaco]'
 
 describe('injectMonacoStyles (#1744)', () => {
@@ -41,9 +43,9 @@ describe('injectMonacoStyles (#1744)', () => {
         expect(document.head.querySelectorAll(MARKER)).toHaveLength(1)
     })
 
-    it('does not duplicate when a marker style already exists (e.g. a second package copy)', async () => {
+    it('does not duplicate when a same-version marker already exists (another package copy)', async () => {
         const existing = document.createElement('style')
-        existing.setAttribute('data-blend-monaco', '')
+        existing.setAttribute('data-blend-monaco', MONACO_VERSION)
         existing.textContent = '/* injected by another bundle */'
         document.head.appendChild(existing)
 
@@ -54,5 +56,25 @@ describe('injectMonacoStyles (#1744)', () => {
         const styles = document.head.querySelectorAll(MARKER)
         expect(styles).toHaveLength(1)
         expect(styles[0]).toBe(existing)
+    })
+
+    it('injects its own stylesheet alongside a different Monaco version', async () => {
+        const other = document.createElement('style')
+        other.setAttribute('data-blend-monaco', '0.0.0-different')
+        other.textContent = '/* a different bundled Monaco version */'
+        document.head.appendChild(other)
+
+        const { injectMonacoStyles } =
+            await import('../../../lib/components/shared/monacoStyles')
+        injectMonacoStyles()
+
+        // The mismatched version must not satisfy dedup — our version gets its
+        // own stylesheet so the editor is not left inheriting foreign CSS.
+        expect(document.head.querySelectorAll(MARKER)).toHaveLength(2)
+        expect(
+            document.head.querySelector(
+                `style[data-blend-monaco="${MONACO_VERSION}"]`
+            )?.textContent
+        ).toContain('.monaco-editor')
     })
 })

--- a/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditor/MonacoEditorWrapper.tsx
@@ -3,7 +3,6 @@ import Editor, { loader, OnMount } from '@monaco-editor/react'
 import type * as Monaco from 'monaco-editor'
 import Block from '../Primitives/Block/Block'
 import type { CodeBlockTokenType } from '../CodeBlock/codeBlock.token'
-import './monaco-editor.css'
 
 // Monaco registers only `javascript`/`typescript` (VS Code's
 // `javascriptreact`/`typescriptreact` IDs are not registered, so they would
@@ -356,16 +355,20 @@ export const MonacoEditorWrapper = ({
 
         Promise.all([
             import('../shared/monacoEnvironment'),
+            import('../shared/monacoStyles'),
             import(
                 // @ts-expect-error Monaco does not publish types for this ESM entry.
                 'monaco-editor/esm/vs/editor/editor.main.js'
             ),
         ])
-            .then(([env, monaco]) => {
+            .then(([env, styles, monaco]) => {
                 if (cancelled) return
                 // Wire the bundled language workers before configuring the
-                // loader, so a self-hosted Monaco can spawn them (#1734).
+                // loader, so a self-hosted Monaco can spawn them (#1734), and
+                // inject the editor stylesheet so it renders styled without a
+                // global Blend stylesheet import (#1744).
                 env.configureMonacoEnvironment()
+                styles.injectMonacoStyles()
                 loader.config({ monaco: monaco as typeof Monaco })
                 setIsMonacoLoaded(true)
             })

--- a/packages/blend/lib/components/CodeEditor/monaco-editor.css
+++ b/packages/blend/lib/components/CodeEditor/monaco-editor.css
@@ -1,1 +1,0 @@
-@import 'monaco-editor/min/vs/editor/editor.main.css';

--- a/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
+++ b/packages/blend/lib/components/CodeEditorV2/MonacoEditor/MonacoEditorWrapper.tsx
@@ -136,16 +136,20 @@ export function MonacoEditorWrapper({
 
         Promise.all([
             import('../../shared/monacoEnvironment'),
+            import('../../shared/monacoStyles'),
             import(
                 // @ts-expect-error Monaco does not publish types for this ESM entry.
                 'monaco-editor/esm/vs/editor/editor.main.js'
             ),
         ])
-            .then(([env, monaco]) => {
+            .then(([env, styles, monaco]) => {
                 if (cancelled) return
                 // Wire the bundled language workers before configuring the
-                // loader, so a self-hosted Monaco can spawn them (#1734).
+                // loader, so a self-hosted Monaco can spawn them (#1734), and
+                // inject the editor stylesheet so it renders styled without a
+                // global Blend stylesheet import (#1744).
                 env.configureMonacoEnvironment()
+                styles.injectMonacoStyles()
                 loader.config({ monaco: monaco as typeof Monaco })
                 setIsMonacoLoaded(true)
             })

--- a/packages/blend/lib/components/CodeEditorV2/MonacoEditor/monaco-editor.css
+++ b/packages/blend/lib/components/CodeEditorV2/MonacoEditor/monaco-editor.css
@@ -1,1 +1,0 @@
-@import 'monaco-editor/min/vs/editor/editor.main.css';

--- a/packages/blend/lib/components/shared/monacoStyles.ts
+++ b/packages/blend/lib/components/shared/monacoStyles.ts
@@ -20,7 +20,12 @@
 
 // @ts-expect-error resolved by the '*.css?inline' ambient module (lib/types/assets.d.ts)
 import editorStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline'
+import { version as MONACO_VERSION } from 'monaco-editor/package.json'
 
+// The marker carries the bundled Monaco version so dedup is version-aware: two
+// copies of Blend that bundle the SAME Monaco share one injected stylesheet,
+// but copies bundling DIFFERENT Monaco versions each inject their own matching
+// CSS instead of one silently inheriting the other's.
 const STYLE_MARKER = 'data-blend-monaco'
 
 let injected = false
@@ -29,19 +34,24 @@ let injected = false
  * Injects Monaco's editor stylesheet into `document.head` once, so a
  * self-hosted editor is styled without the consumer importing any Blend
  * stylesheet. Idempotent across every editor instance and safe to call when a
- * previous mount (or another bundle of this package) already injected it.
+ * previous mount (or another bundle of this package with the same Monaco
+ * version) already injected it.
+ *
+ * Assumes a light-DOM consumer: it appends to `document.head`, so the styles do
+ * not cross into a shadow root. A Shadow-DOM-scoped editor would need the CSS
+ * injected into its own root (not handled here today).
  */
 export const injectMonacoStyles = (): void => {
     if (injected || typeof document === 'undefined') return
-    // A style with our marker may already exist — from an earlier mount in this
-    // bundle, or from a second copy of the package on the page. Don't duplicate
-    // ~260KB of CSS.
-    if (document.querySelector(`style[${STYLE_MARKER}]`)) {
+    // A style for this Monaco version may already exist — from an earlier mount
+    // in this bundle, or from another copy of the package on the page. Don't
+    // duplicate ~260KB of CSS.
+    if (document.querySelector(`style[${STYLE_MARKER}="${MONACO_VERSION}"]`)) {
         injected = true
         return
     }
     const style = document.createElement('style')
-    style.setAttribute(STYLE_MARKER, '')
+    style.setAttribute(STYLE_MARKER, MONACO_VERSION)
     style.textContent = editorStyles as string
     document.head.appendChild(style)
     injected = true

--- a/packages/blend/lib/components/shared/monacoStyles.ts
+++ b/packages/blend/lib/components/shared/monacoStyles.ts
@@ -1,0 +1,48 @@
+// Self-hosts Monaco's editor stylesheet so CodeEditor/CodeEditorV2 render
+// styled with ZERO consumer setup — no `@juspay/blend-design-system/style.css`
+// import required (#1744).
+//
+// CodeEditor self-hosts Monaco via `loader.config({ monaco })` (#1668) and its
+// workers via monacoEnvironment (#1734), but its *styles* previously reached
+// consumers only through the library's global `style.css`. Apps that import
+// Blend components without that global stylesheet (e.g. juspay-portal) got an
+// unstyled editor and had to import Monaco's CSS by hand.
+//
+// `?inline` returns the stylesheet's compiled text as a string instead of
+// letting Vite extract it into `style.css`, so we inject it into a `<style>` on
+// mount. Monaco's `min` build embeds its font/images as `data:` URIs (no
+// external `url()`), so the injected text is fully self-contained — no asset
+// paths to resolve. The version is pinned to the bundled `monaco-editor`, in
+// lockstep with the workers and the editor module.
+//
+// This module is browser-only and is loaded lazily from the editor wrappers'
+// mount effect, so it never runs during SSR.
+
+// @ts-expect-error resolved by the '*.css?inline' ambient module (lib/types/assets.d.ts)
+import editorStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline'
+
+const STYLE_MARKER = 'data-blend-monaco'
+
+let injected = false
+
+/**
+ * Injects Monaco's editor stylesheet into `document.head` once, so a
+ * self-hosted editor is styled without the consumer importing any Blend
+ * stylesheet. Idempotent across every editor instance and safe to call when a
+ * previous mount (or another bundle of this package) already injected it.
+ */
+export const injectMonacoStyles = (): void => {
+    if (injected || typeof document === 'undefined') return
+    // A style with our marker may already exist — from an earlier mount in this
+    // bundle, or from a second copy of the package on the page. Don't duplicate
+    // ~260KB of CSS.
+    if (document.querySelector(`style[${STYLE_MARKER}]`)) {
+        injected = true
+        return
+    }
+    const style = document.createElement('style')
+    style.setAttribute(STYLE_MARKER, '')
+    style.textContent = editorStyles as string
+    document.head.appendChild(style)
+    injected = true
+}

--- a/packages/blend/lib/components/shared/monacoStyles.ts
+++ b/packages/blend/lib/components/shared/monacoStyles.ts
@@ -18,7 +18,7 @@
 // This module is browser-only and is loaded lazily from the editor wrappers'
 // mount effect, so it never runs during SSR.
 
-// @ts-expect-error resolved by the '*.css?inline' ambient module (lib/types/assets.d.ts)
+// Import resolved by the '*.css?inline' ambient module (lib/types/assets.d.ts).
 import editorStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline'
 import { version as MONACO_VERSION } from 'monaco-editor/package.json'
 

--- a/packages/blend/lib/types/assets.d.ts
+++ b/packages/blend/lib/types/assets.d.ts
@@ -22,3 +22,11 @@ declare module '*.gif' {
     const content: string
     export default content
 }
+
+// Vite's `?inline` query returns a CSS module's compiled text as a string
+// instead of injecting it — used to self-host Monaco's editor stylesheet
+// (see components/shared/monacoStyles.ts).
+declare module '*.css?inline' {
+    const content: string
+    export default content
+}

--- a/packages/blend/scripts/check-dist.mjs
+++ b/packages/blend/scripts/check-dist.mjs
@@ -282,13 +282,64 @@ for (const file of readdirSync(distDir).filter((f) => f.endsWith('.js'))) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Check 5: Monaco's editor stylesheet must ship self-contained in JS, not in
+// the global style.css (issue #1744). CodeEditor injects the stylesheet at
+// runtime (components/shared/monacoStyles.ts) so a self-hosted editor renders
+// styled with NO `@juspay/blend-design-system/style.css` import. That means
+// the editor CSS must (a) be present in a JS chunk — the inlined string — and
+// (b) NOT be extracted into style.css, or it would double-ship ~260KB and
+// re-introduce the global-stylesheet dependency the injection removes.
+// The full Monaco editor CSS carries 700+ `.monaco-editor` selectors, so a
+// generous threshold cleanly separates "the whole stylesheet is here" from the
+// handful of ad-hoc `.monaco-editor` overrides the wrappers inline.
+// ---------------------------------------------------------------------------
+const MONACO_BULK_THRESHOLD = 100
+const countMatches = (source, needle) => source.split(needle).length - 1
+
+const stylePath = resolve(distDir, 'style.css')
+if (existsSync(stylePath)) {
+    const styleMonaco = countMatches(
+        readFileSync(stylePath, 'utf8'),
+        '.monaco-editor'
+    )
+    if (styleMonaco >= MONACO_BULK_THRESHOLD) {
+        failed = true
+        console.error(
+            `✖ dist/style.css carries the full Monaco editor stylesheet ` +
+                `(${styleMonaco} \`.monaco-editor\` selectors). CodeEditor injects ` +
+                'it at runtime (monacoStyles.ts), so it must NOT also be extracted ' +
+                'into style.css — a static `import` of a Monaco CSS file crept back in.'
+        )
+    }
+}
+
+const jsHasMonacoBulk = readdirSync(distDir)
+    .filter((f) => f.endsWith('.js'))
+    .some(
+        (f) =>
+            countMatches(
+                readFileSync(resolve(distDir, f), 'utf8'),
+                '.monaco-editor'
+            ) >= MONACO_BULK_THRESHOLD
+    )
+if (!jsHasMonacoBulk) {
+    failed = true
+    console.error(
+        '✖ No dist JS chunk contains the Monaco editor stylesheet. CodeEditor ' +
+            'relies on monacoStyles.ts injecting it via `?inline`; the inline import ' +
+            'appears to have been dropped, so a self-hosted editor renders unstyled.'
+    )
+}
+
 if (failed) {
     process.exit(1)
 }
 
 console.log(
     `✔ dist/ has no file/directory collisions; key exports (${KEY_EXPORTS.join(', ')}) are typed; ` +
-        `${verifiedStatics} compound statics declared (flat-export aliases as \`typeof\`).`
+        `${verifiedStatics} compound statics declared (flat-export aliases as \`typeof\`); ` +
+        'Monaco editor CSS ships self-contained in JS, not style.css.'
 )
 // Importing dist/main.js leaves live handles behind (styled-components /
 // framer-motion timers under jsdom), so Node would hang without an explicit

--- a/packages/blend/vite.config.ts
+++ b/packages/blend/vite.config.ts
@@ -1,7 +1,40 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import { resolve } from 'path'
 import react from '@vitejs/plugin-react'
 import dts from 'vite-plugin-dts'
+
+// Monaco's ESM editor bundle (`editor.main.js`, dynamically imported by the
+// CodeEditor wrappers) side-effect-imports dozens of its own `.css` files. In a
+// Vite *library* build those are extracted into the shared `dist/style.css`,
+// which forces consumers to import the global Blend stylesheet just to get a
+// styled editor (#1744). We instead inject the editor stylesheet ourselves at
+// runtime — see `components/shared/monacoStyles.ts`, which imports the `min`
+// build's self-contained CSS via `?inline`. This plugin neutralizes Monaco's
+// own CSS side-effect imports so ~260KB of editor CSS is shipped ONCE (inlined
+// in JS, injected on mount) and never duplicated into `style.css`.
+//
+// It only touches `.css` requests whose importer lives inside `monaco-editor`
+// (Monaco's internal imports); our explicit `?inline` import — whose importer
+// is a Blend lib file — is left untouched, as is every other package's CSS.
+const EMPTY_MONACO_CSS = '\0blend-empty-monaco-css'
+const neutralizeMonacoCss = (): Plugin => ({
+    name: 'blend-neutralize-monaco-css',
+    enforce: 'pre',
+    resolveId(source, importer) {
+        if (
+            source.endsWith('.css') &&
+            !source.includes('?inline') &&
+            importer?.includes('monaco-editor')
+        ) {
+            return EMPTY_MONACO_CSS
+        }
+        return null
+    },
+    load(id) {
+        if (id === EMPTY_MONACO_CSS) return ''
+        return null
+    },
+})
 
 export default defineConfig({
     // Relative asset base so URLs referenced from JS (e.g. the Monaco worker
@@ -10,6 +43,7 @@ export default defineConfig({
     // Only affects asset URLs (workers, CSS url()), not ES import specifiers.
     base: './',
     plugins: [
+        neutralizeMonacoCss(),
         react(),
         dts({
             include: ['lib'],


### PR DESCRIPTION
## What & why

Closes #1744.

Self-hosted Monaco (#1668) shipped its **JS** and **workers** (#1734), but its **stylesheet** reached consumers only through the library's global `dist/style.css` — extracted from `editor.main.js`'s side-effect CSS imports. Apps that use Blend components **without** importing that global stylesheet (e.g. juspay-portal) got an **unstyled** `CodeEditor` and had to import Monaco's CSS by hand.

This makes the editor styles ship **with the component**, so it renders fully styled with **zero consumer setup** — no `@juspay/blend-design-system/style.css` import required.

## How

- **`lib/components/shared/monacoStyles.ts`** (new) — imports the `min` build's editor CSS via Vite `?inline` and injects it into a `<style data-blend-monaco>` on mount, **once**, guarded against duplicate injection (repeat mounts / a second copy of the package). Browser-only + lazy, so it's SSR-safe. Monaco's `min` CSS embeds its font/images as `data:` URIs, so the injected text is fully self-contained (no asset paths to resolve).
- **Both `MonacoEditorWrapper`s** — call `injectMonacoStyles()` in the existing lazy mount effect, alongside `configureMonacoEnvironment()`.
- **`vite.config.ts`** — a small `enforce: 'pre'` plugin neutralizes Monaco's **own** ESM CSS side-effect imports (only `.css` requests whose importer lives inside `monaco-editor`; our `?inline` import and every other package's CSS are untouched). This keeps the ~260KB of editor CSS from being extracted into `style.css`, so it ships **once** — inlined in JS.
- Removed the now-unused `monaco-editor.css` files (V1's was the only importer; V2's was already orphaned).
- **`scripts/check-dist.mjs`** — new gate: the editor CSS must ship in a JS chunk (injection works) and must **not** be re-extracted into `style.css` (no double-ship). Version stays pinned to the bundled `monaco-editor@0.54.0`.

## Verification

- `dist/style.css`: **384 KB → 537 bytes**, `.monaco-editor` rules **706 → 0**.
- `dist/monacoStyles-*.js`: carries the full editor CSS (**692 `.monaco-editor`** + the base64 codicon font), injected on mount.
- React-free `node.js` / `token-engine.js` entries stay CSS-free (0 `.monaco-editor`).
- `pnpm build` + `check:dist` ✔, `check:circular` ✔, eslint/prettier ✔.
- Tests: new `monacoStyles.test.ts` (inject-once / idempotent / no-duplicate) + existing `monacoEnvironment` and CodeEditor/CodeEditorV2 suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Trade-off

~260KB of editor CSS now rides in the **lazy editor JS chunk** (loaded only when a `CodeEditor` mounts) instead of the global `style.css`. Previously only consumers importing `style.css` paid that cost; now every editor consumer does — but lazily, with the editor, and never on pages without one. Conscious trade for zero-setup styling. Marker dedup is version-aware, so multiple Blend copies with the same Monaco version still share a single injected stylesheet.
